### PR TITLE
Update LoopBack Documentation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@ Enter an empty property name when done.
                     <div class="row">
                         <div class="col-md-6">
                              <ul>
-                                <li><a href="http://docs.strongloop.com/display/LB/LoopBack">LoopBack Documentation</a></li>
+                                <li><a href="http://docs.strongloop.com/display/LB/LoopBack+2.0">LoopBack Documentation</a></li>
                                  <li><a href="http://apidocs.strongloop.com/loopback/">API docs</a></li>
                                 <li><a href="http://strongloop.com/strongblog/category/loopback-2/">StrongLoop blog</a></li>
                                 <li><a href="http://strongloop.com/strongloop-suite/subscription-plans/">Professional support</a></li>


### PR DESCRIPTION
The previous link hit a 404 page. It now points to the 2.0 documentation.
