### PR TITLE
fix lb2 sidebar title

### DIFF
--- a/_data/sidebars/lb2_sidebar.yml
+++ b/_data/sidebars/lb2_sidebar.yml
@@ -1,6 +1,6 @@
 entries:
 - title: sidebar
-  product: asdfsadf
+  product: LoopBack
   version: 2.0
   folders:
 
@@ -12,12 +12,6 @@ entries:
     - title: LoopBack docs
       url: /doc/lb2/loopback_docs.html
       output: web, pdf
-
-entries:
-- title: sidebar
-  product: LoopBack
-  version: 3.0
-  folders:
 
   - title: Installation
     url: /doc/lb2/Installation.html


### PR DESCRIPTION
There were duplicate entries in the yaml file that had version 3.0 in it
