### PR TITLE
Conversion of additional content to MD + link cleanup

### DIFF
--- a/_data/sidebars/lb2_sidebar.yml
+++ b/_data/sidebars/lb2_sidebar.yml
@@ -241,6 +241,10 @@ entries:
         url: /doc/en/lb2/User-REST-API.html
         output: 'web, pdf'
 
+    - title: 'Adding remote methods to built-in models'
+      url: /doc/en/lb2/Adding-remote-methods-to-built-in-models.html
+      output: 'web, pdf'
+
   - title: 'Connecting models to data sources'
     url: /doc/en/lb2/Connecting-models-to-data-sources.html
     output: 'web, pdf'
@@ -564,6 +568,10 @@ entries:
         url: /doc/en/lb2/Preparing-for-deployment.html
         output: 'web, pdf'
 
+      - title: 'Using strong-error-handler'
+        url: /doc/en/lb2/Using-strong-error-handler.html
+        output: 'web, pdf'
+
   - title: 'LoopBack components'
     url: /doc/en/lb2/LoopBack-components.html
     output: 'web, pdf'
@@ -826,6 +834,10 @@ entries:
         - title: 'Model definition JSON file'
           url: /doc/en/lb2/Model-definition-JSON-file.html
           output: 'web, pdf'
+
+  - title: 'Command-line reference'
+    url: /doc/en/lb2/Command-line-reference.html
+    output: 'web, pdf'
 
   - title: 'Node reference'
     url: /doc/en/lb2/Node-reference.html

--- a/pages/en/lb2/ACL-generator.md
+++ b/pages/en/lb2/ACL-generator.md
@@ -10,45 +10,45 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
-Then you must run the command from the root directory of the application."
-%}
+Then you must run the command from the root directory of the application.
+" %}
 
-### SYNOPSIS
+### Synopsis
 
 Adds a new access control list (ACL) entry to a LoopBack application.
 
 ```shell
-[slc | apic] loopback:acl [options]
+$ [slc | apic] loopback:acl [options]
 ```
 
 {% include note.html content="
-You cannot modify [built-in models](Using-built-in-models.html) using the ACL generator, only custom models you have defined, for example, with the [Model generator](Model-generator.html).
+You cannot modify [built-in models](/doc/en/lb2/Using-built-in-models.html) using the ACL generator, only custom models you have defined, for example, with the [Model generator](/doc/en/lb2/Model-generator.html).
 " %}
 
-### OPTIONS
+### Options
 
 `-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
-The tool will prompt you for the necessary information and then modify the [Model definition JSON file](Model-definition-JSON-file.html) accordingly.
+The tool will prompt you for the necessary information and then modify the [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) accordingly.
 
 The generator prompts for:
 
-*   Name of the model to which you want to apply access control or all models.
-*   Scope of access control: All methods and properties or a specific method.
-*   If you choose a specific method, the method's name.
-*   Access type: read, write, execute, or all.
-*   Role: all users, any unauthenticated user, any authenticated user, the object owner.
-*   Permission to apply: explicitly grant access or explicitly deny access.
+* Name of the model to which you want to apply access control or all models.
+* Scope of access control: All methods and properties or a specific method.
+* If you choose a specific method, the method's name.
+* Access type: read, write, execute, or all.
+* Role: all users, any unauthenticated user, any authenticated user, the object owner.
+* Permission to apply: explicitly grant access or explicitly deny access.
 
-For general information about setting up ACLs, see [Controlling data access](Controlling-data-access.html).
+For general information about setting up ACLs, see [Controlling data access](/doc/en/lb2/Controlling-data-access.html).

--- a/pages/en/lb2/API-definition-generator.md
+++ b/pages/en/lb2/API-definition-generator.md
@@ -10,34 +10,34 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
-Then you must run the command from the root directory of the application."
-%}
+Then you must run the command from the root directory of the application.
+" %}
 
-### SYNOPSIS
+### Synopsis
 
 Exports a Swagger API definition for a LoopBack application.
 
 ```shell
-[slc | apic] loopback:export-api-def [options]
+$ [slc | apic] loopback:export-api-def [options]
 ```
 
-### OPTIONS
+### Options
 
 `-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
 ### ADDITIONAL OPTIONS
 
-`-o,   --output`  
+`-o,   --output`
 Name and full path to the output file. By default, the generator displays the API definition to the screen (stdout). Use this option to save the definition to a file instead.
 
-`--json`  
+`--json`
 By default, the generator exports the API definition in YAML format. Use this option to export in JSON format instead; or specify a file with a `.json` format.

--- a/pages/en/lb2/Adding-remote-methods-to-built-in-models.md
+++ b/pages/en/lb2/Adding-remote-methods-to-built-in-models.md
@@ -10,8 +10,8 @@ summary:
 ---
 
 To add a remote method to a 
-[built-in model](https://docs.strongloop.com/display/APIC/Using+built-in+models), you can either 
-[extend the model](https://docs.strongloop.com/display/APIC/Extending+built-in+models) and add the remote method to your new model,
+[built-in model](/doc/en/lb2/Using-built-in-models.html), you can either 
+[extend the model](/doc/en/lb2/Extending-built-in-models.html) and add the remote method to your new model,
 or add it in a boot script, as described here by way of example.
 
 This example adds a "greet" method the built-in User model.

--- a/pages/en/lb2/Adding-remote-methods-to-built-in-models.md
+++ b/pages/en/lb2/Adding-remote-methods-to-built-in-models.md
@@ -1,0 +1,84 @@
+---
+title: "Adding remote methods to built-in models"
+lang: en
+layout: page
+keywords: LoopBack
+tags:
+sidebar: lb2_sidebar
+permalink: /doc/en/lb2/Adding-remote-methods-to-built-in-models.html
+summary:
+---
+
+To add a remote method to a 
+[built-in model](https://docs.strongloop.com/display/APIC/Using+built-in+models), you can either 
+[extend the model](https://docs.strongloop.com/display/APIC/Extending+built-in+models) and add the remote method to your new model,
+or add it in a boot script, as described here by way of example.
+
+This example adds a "greet" method the built-in User model.
+
+## Boot script
+
+Normally, to add a remote method to the User model, you would add it in `/common/models/user.js`.
+However, for built-in models however, this file would override the built-in model definition,
+so instead you have to create and attach our remote method in a boot script; for example:
+
+**server/boot/userRemoteMethods.js**
+
+```javascript
+module.exports = function(app) {
+  const User = app.models.User;
+
+  User.greet = function(msg, cb) {
+    cb(null, 'Greetings... ' + msg);
+  };
+
+  User.remoteMethod(
+    'greet', {
+      accepts: {
+        arg: 'msg',
+        type: 'string'
+      },
+      returns: {
+        arg: 'greeting',
+        type: 'string'
+      }
+    }
+  );
+};
+```
+
+## ACLs
+
+By default, the User model ACLs deny all requests besides those explicitly whitelisted, so you have to add an ACL record for the remote method.
+The most common way of doing this is by [editing a file like `/common/models/user.json`](/doc/en/lb2/Controlling-data-access.html),
+but again this file would override the built-in version, so that's not possible.
+Instead you can define ACLs in [`model-config.json`](/doc/en/lb2/model-config.json.html).
+
+For example:
+
+**server/model-config.json**
+
+```javascript
+{
+  "User": {
+    "dataSource": "db",
+    "acls": [{
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "greet"
+    }]
+  },
+  ...
+}
+```
+
+Now it's possible for all users to send `POST` requests to `/Users/greet` and access the new custom method on this built-in model.
+
+## Additional Considerations
+
+* Adding remote methods in this way **does not add them to the Swagger JSON**.
+  This means you will not see a "Users/greet" method listed in the [API explorer](https://docs.strongloop.com/display/LB/API+Explorer).
+* By design, you can override settings in `model-config.json` by
+  [environment specific configurations](/doc/en/lb2/Environment-specific-configuration.html).
+  Bear this in mind when defining ACLs as shown above.

--- a/pages/en/lb2/Android-SDK.md
+++ b/pages/en/lb2/Android-SDK.md
@@ -218,7 +218,7 @@ For the complete API documentation, see [LoopBack Android API](http://apidocs.s
 3.  You can now start working with your model through the generic Model object.
     Continue below to learn how to extend the `Model` Java object to directly match, and thus provide the strongly-typed interface for interaction with, your own `Model`'s members.
     Check out the [LoopBack Android API docs](http://apidocs.strongloop.com/loopback-sdk-android/api/index.html) 
-    or create more Models with the [Model generator](https://docs.strongloop.com/display/APIC/Model+generator).
+    or create more Models with the [Model generator](/doc/en/lb2/Model-generator.html).
 
 ## Creating your own LoopBack model
 

--- a/pages/en/lb2/Application-generator.md
+++ b/pages/en/lb2/Application-generator.md
@@ -9,53 +9,55 @@ permalink: /doc/en/lb2/Application-generator.html
 summary:
 ---
 
-### SYNOPSIS
+### Synopsis
 
 Creates a new LoopBack application.
 
 ```shell
-[slc | apic] loopback:app [options] [<name>]
+$ [slc | apic] loopback:app [options] [<name>]
 ```
 
-### OPTIONS
+### Options
 
 `-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### ARGUMENTS
+### Arguments
 
 Provide the application name as an optional argument.  The tool will create a directory of that name to contain the application.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The generator will prompt you for:
 
-*   Name of the directory in which to create your application.  Press **Enter** to create the application in the current directory.
-*   Name of the application, that defaults to the directory name you previously entered.
+* Name of the directory in which to create your application.  Press **Enter** to create the application in the current directory.
+* Name of the application, that defaults to the directory name you previously entered.
 
-The tool creates the standard LoopBack application structure.  See [Project layout reference](https://docs.strongloop.com/display/APIC/Project+layout+reference) for details.
+The tool creates the standard LoopBack application structure.  See [Project layout reference](/doc/en/lb2/Project-layout-reference.html) for details.
 
 {% include note.html content="
-By default, a generated application exposes only the User model over REST. To expose other [built-in models](https://docs.strongloop.com/display/TRASH/Built-in+models+reference), edit `/server/model-config.json` and change the model's \"public\" property to \"true\". See [model-config.json](https://docs.strongloop.com/display/APIC/model-config.json) for more information.
+By default, a generated application exposes only the User model over REST.
+To expose other [built-in models](https://docs.strongloop.com/display/TRASH/Built-in+models+reference), edit `/server/model-config.json` and change the model's \"public\" property to \"true\".
+See [model-config.json](/doc/en/lb2/model-config.json.html) for more information.
 " %}
 
 After you create an application, you can run additional generators from the application root directory:
 
-*   [ACL generator](/doc/en/lb2/ACL-generator.html)
-*   [API definition generator](/doc/en/lb2/API-definition-generator.html)
-*   [Application generator](/doc/en/lb2/Application-generator.html)
-*   [Boot script generator](/doc/en/lb2/Boot-script-generator.html)
-*   [Data source generator](/doc/en/lb2/Data-source-generator.html)
-*   [Middleware generator](/doc/en/lb2/Middleware-generator.html)
-*   [Model generator](/doc/en/lb2/Model-generator.html)
-*   [Property generator](/doc/en/lb2/Property-generator.html)
-*   [Relation generator](/doc/en/lb2/Relation-generator.html)
-*   [Remote method generator](/doc/en/lb2/Remote-method-generator.html)
-*   [Swagger generator](/doc/en/lb2/Swagger-generator.html)
-*   [Refresh definitions command](/doc/en/lb2/Refresh-definitions-command.html)
+* [ACL generator](/doc/en/lb2/ACL-generator.html)
+* [API definition generator](/doc/en/lb2/API-definition-generator.html)
+* [Application generator](/doc/en/lb2/Application-generator.html)
+* [Boot script generator](/doc/en/lb2/Boot-script-generator.html)
+* [Data source generator](/doc/en/lb2/Data-source-generator.html)
+* [Middleware generator](/doc/en/lb2/Middleware-generator.html)
+* [Model generator](/doc/en/lb2/Model-generator.html)
+* [Property generator](/doc/en/lb2/Property-generator.html)
+* [Relation generator](/doc/en/lb2/Relation-generator.html)
+* [Remote method generator](/doc/en/lb2/Remote-method-generator.html)
+* [Swagger generator](/doc/en/lb2/Swagger-generator.html)
+* [Refresh definitions command](/doc/en/lb2/Refresh-definitions-command.html)

--- a/pages/en/lb2/Attaching-models-to-data-sources.md
+++ b/pages/en/lb2/Attaching-models-to-data-sources.md
@@ -20,14 +20,14 @@ Rather, the `DataSource` class provides an API to configure the underlying con
 
 The built-in [memory connector](/doc/en/lb2/Memory-connector.html) is suitable for development. To use a different data source:
 
-1.  Use the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) 
+1.  Use the [data source generator](/doc/en/lb2/Data-source-generator.html) 
     to create the new data source and add it to the application's `datasources.json`.
 2.  Edit [`datasources.json`](/doc/en/lb2/datasources.json.html) to add the appropriate credentials for the data source.
 3.  Create a model to connect to the data source or modify an existing model definition to use the connector.
 
 ## Add a data source
 
-To add a new data source, use the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator):
+To add a new data source, use the [data source generator](/doc/en/lb2/Data-source-generator.html):
 
 ```shell
 $ apic create --type datasource
@@ -78,9 +78,9 @@ For example:
 
 ## Make the model use the data source
 
-When you create a new model with the [model generator](https://docs.strongloop.com/display/APIC/Model+generator),
+When you create a new model with the [model generator](/doc/en/lb2/Model-generator.html),
 you can specify the data source you want it to use from among those you've added to the application using the
-[Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) and the default `db`
+[Data source generator](/doc/en/lb2/Data-source-generator.html) and the default `db`
 data source (that uses the [memory connector](/doc/en/lb2/Memory-connector.html)).
 
 To change the data source a model uses after you've created the model, edit the application's `server/model-config.json`

--- a/pages/en/lb2/Authentication-authorization-and-permissions.md
+++ b/pages/en/lb2/Authentication-authorization-and-permissions.md
@@ -14,7 +14,7 @@ summary:
 **Prerequisites**
 
 * Install **[API Connect](https://developer.ibm.com/apiconnect/)** or **[StrongLoop](https://docs.strongloop.com/display/SL/Installing+StrongLoop)**.
-* Read [LoopBack core concepts](https://docs.strongloop.com/display/APIC/LoopBack+core+concepts).
+* Read [LoopBack core concepts](/doc/en/lb2/LoopBack-core-concepts.html).
 
 " %}
 
@@ -225,7 +225,7 @@ To disable a REST endpoints for related model methods, use [disableRemoteMethod
 
 {% include note.html content="
 
-For more information, see [Accessing related models](https://docs.strongloop.com/display/APIC/Accessing+related+models).
+For more information, see [Accessing related models](/doc/en/lb2/Accessing-related-models.html).
 
 " %}
 

--- a/pages/en/lb2/BelongsTo-relations.md
+++ b/pages/en/lb2/BelongsTo-relations.md
@@ -51,7 +51,7 @@ The tool will prompt you to enter the name of the model, the name of related mod
 The tool will then modify the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) 
 (for example, `common/models/customer.json`) accordingly.
 
-For more information, see [Relation generator](https://docs.strongloop.com/display/APIC/Relation+generator).
+For more information, see [Relation generator](/doc/en/lb2/Relation-generator.html).
 
 For example, here is the model JSON file for the order model in
 [loopback-example-relations](https://github.com/strongloop/loopback-example-relations):

--- a/pages/en/lb2/Boot-script-generator.md
+++ b/pages/en/lb2/Boot-script-generator.md
@@ -10,48 +10,49 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
 Then you must run the command from the root directory of the application."
 %}
 
-### SYNOPSIS
+### Synopsis
 
-The LoopBack boot script generator adds a new [boot script](Defining-boot-scripts.html) to a LoopBack application.
+The LoopBack boot script generator adds a new [boot script](/doc/en/lb2/Defining-boot-scripts.html) to a LoopBack application.
 
 ```shell
-[slc | apic] loopback:boot-script [options] [<name>]
+$ [slc | apic] loopback:boot-script [options] [<name>]
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### ARGUMENTS
+### Arguments
 
 You can optionally provide the name of the boot script as an argument.  If you do, then the tool won't prompt you for the name.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for:
 
-*   The name of the boot script, if you didn't provide it on the command-line.
-*   Whether you want to created an asynchronous or synchronous boot script.
+* The name of the boot script, if you didn't provide it on the command-line.
+* Whether you want to created an asynchronous or synchronous boot script.
 
-### OUTPUT
+### Output
 
-The tool will create a JavaScript file with the specified name in the application's `server/boot` directory.  The code will look like this, depending on your response to the prompt:
+The tool will create a JavaScript file with the specified name in the application's `server/boot` directory.
+The code will look like this, depending on your response to the prompt:
 
 Asynchronous script:
 
-```js
+```javascript
 module.exports = function(app, cb) {
   process.nextTick(cb);
 };
@@ -59,6 +60,6 @@ module.exports = function(app, cb) {
 
 Synchronous script:
 
-```js
+```javascript
 module.exports = function(app) {};
 ```

--- a/pages/en/lb2/Client-SDKs.md
+++ b/pages/en/lb2/Client-SDKs.md
@@ -14,11 +14,11 @@ LoopBack provides the following software development kits (SDKs):
 * [iOS SDK](/doc/en/lb2/iOS-SDK.html). See also:
   * [LoopBack iOS API reference](http://apidocs.strongloop.com/loopback-clients/ios/api/annotated.html).
   * [Push notifications for iOS apps](/doc/en/lb2/Push-notifications-for-iOS-apps.html)
-  * [Tutorial: push notifications - iOS client](https://docs.strongloop.com/display/APIC/Tutorial%3A+push+notifications+-++iOS+client)
+  * [Tutorial: push notifications - iOS client](/doc/en/lb2/Push-notifications-for-iOS-apps.html)
 * [Android SDK](/doc/en/lb2/Android-SDK.html). See also:
   * [LoopBack Android API reference.](http://apidocs.strongloop.com/loopback-android/api/index.html)
   * [Push notifications for Android apps](/doc/en/lb2/Push-notifications-for-Android-apps.html)
-  * [Tutorial: push notifications - Android client](https://docs.strongloop.com/display/APIC/Tutorial%3A+push+notifications+-+Android+client)
+  * [Tutorial: push notifications - Android client](/doc/en/lb2/Push-notifications-for-Android-apps.html)
 * [AngularJS JavaScript SDK](/doc/en/lb2/AngularJS-JavaScript-SDK.html)
 * [LoopBack in the client](/doc/en/lb2/LoopBack-in-the-client.html), also known as _isomorphic LoopBack_.
 

--- a/pages/en/lb2/Command-line-reference.md
+++ b/pages/en/lb2/Command-line-reference.md
@@ -15,27 +15,27 @@ Use the `apic loopback` command to create and _scaffold_ applications.
 Scaffolding simply means generating the basic code for your application.
 You can then extend and modify the code as desired for your specific needs.
 
-The `apic loopback` command is an [application generator](https://docs.strongloop.com/display/APIC/Application+generator) that creates a new LoopBack application. 
+The `apic loopback` command is an [application generator](/doc/en/lb2/Application-generator.html) that creates a new LoopBack application. 
 There are a number of additional generators to scaffold an application, as described in the following table.
 The commands are listed roughly in the order that you would use them.
 
 ## Command summary
 
 
-| Command                         | See                                                                                           | Description |
-|---------------------------------|-----------------------------------------------------------------------------------------------|-------------|
-| `apic loopback`                 | [Application generator](https://docs.strongloop.com/display/APIC/Application+generator)       | Create a new LoopBack application.                                                                                                          |
-| `apic create --type datasource` | [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator)       | Add a new data source to a LoopBack application                                                                                             |
-| `apic create --type model`      | [Model generator](https://docs.strongloop.com/display/APIC/Model+generator)                   | Add a new model to a LoopBack application.                                                                                                  |
-| `apic loopback:property`        | [Property generator](https://docs.strongloop.com/display/APIC/Property+generator)             | Add a new property to an existing model.                                                                                                    |
-| `apic loopback:acl`             | [ACL generator](https://docs.strongloop.com/display/APIC/ACL+generator)                       | Add a new access control list (ACL) entry to the LoopBack application.                                                                      |
-| `apic loopback:relation`        | [Relation generator](https://docs.strongloop.com/display/APIC/Relation+generator)             | Add a new model relationship.                                                                                                               |
-| `apic loopback:remote-method`   | [Remote method generator](https://docs.strongloop.com/display/APIC/Remote+method+generator)   | Add a new [remote method.](/doc/en/lb2/Remote-methods.html)                                                                                 |
-| `apic loopback:middleware`      | [Middleware generator](https://docs.strongloop.com/display/APIC/Middleware+generator)         | Add a new [middleware](/doc/en/lb2/Defining-middleware.html) configuration.                                                                 |
-| `apic loopback:boot-script`     | [Boot script generator](https://docs.strongloop.com/display/APIC/Boot+script+generator)       | Add a new [boot scripts](/doc/en/lb2/Defining-boot-scripts.html).                                                                           |
-| `apic loopback:export-api-def`  | [API definition generator](https://docs.strongloop.com/display/APIC/API+definition+generator) | Export OpenAPI (Swagger) API definition.                                                                                                    |
-| `apic loopback:swagger`         | [Swagger generator](https://docs.strongloop.com/display/APIC/Swagger+generator)               | Generates a fully-functional application that provides the APIs conforming to the OpenAPI [Swagger](http://swagger.io/) 2.0 specification.  |
-| `apic loopback:refresh`         |                                                                                               | Generate a product and an OpenAPI (Swagger) definition                                                                                      |
+| Command                         | See                                                                   | Description |
+|---------------------------------|-----------------------------------------------------------------------|-------------|
+| `apic loopback`                 | [Application generator](/doc/en/lb2/Application-generator.html)       | Create a new LoopBack application.                                                                                                          |
+| `apic create --type datasource` | [Data source generator](/doc/en/lb2/Data-source-generator.html)       | Add a new data source to a LoopBack application                                                                                             |
+| `apic create --type model`      | [Model generator](/doc/en/lb2/Model-generator.html)                   | Add a new model to a LoopBack application.                                                                                                  |
+| `apic loopback:property`        | [Property generator](/doc/en/lb2/Property-generator.html)             | Add a new property to an existing model.                                                                                                    |
+| `apic loopback:acl`             | [ACL generator](/doc/en/lb2/ACL-generator.html)                       | Add a new access control list (ACL) entry to the LoopBack application.                                                                      |
+| `apic loopback:relation`        | [Relation generator](/doc/en/lb2/Relation-generator.html)             | Add a new model relationship.                                                                                                               |
+| `apic loopback:remote-method`   | [Remote method generator](/doc/en/lb2/Remote-method-generator.html)   | Add a new [remote method.](/doc/en/lb2/Remote-methods.html)                                                                                 |
+| `apic loopback:middleware`      | [Middleware generator](/doc/en/lb2/Middleware-generator.html)         | Add a new [middleware](/doc/en/lb2/Defining-middleware.html) configuration.                                                                 |
+| `apic loopback:boot-script`     | [Boot script generator](/doc/en/lb2/Boot-script-generator.html)       | Add a new [boot scripts](/doc/en/lb2/Defining-boot-scripts.html).                                                                           |
+| `apic loopback:export-api-def`  | [API definition generator](/doc/en/lb2/API-definition-generator.html) | Export OpenAPI (Swagger) API definition.                                                                                                    |
+| `apic loopback:swagger`         | [Swagger generator](/doc/en/lb2/Swagger-generator.html)               | Generates a fully-functional application that provides the APIs conforming to the OpenAPI [Swagger](http://swagger.io/) 2.0 specification.  |
+| `apic loopback:refresh`         |                                                                       | Generate a product and an OpenAPI (Swagger) definition                                                                                      |
 
 
 ## Correspondence between StrongLoop commands to API Connect commands

--- a/pages/en/lb2/Command-line-reference.md
+++ b/pages/en/lb2/Command-line-reference.md
@@ -1,0 +1,58 @@
+---
+title: "Command-line reference"
+lang: en
+layout: page
+keywords: LoopBack
+tags:
+sidebar: lb2_sidebar
+permalink: /doc/en/lb2/Command-line-reference.html
+summary:
+---
+
+## Overview
+
+Use the `apic loopback` command to create and _scaffold_ applications.
+Scaffolding simply means generating the basic code for your application.
+You can then extend and modify the code as desired for your specific needs.
+
+The `apic loopback` command is an [application generator](https://docs.strongloop.com/display/APIC/Application+generator) that creates a new LoopBack application. 
+There are a number of additional generators to scaffold an application, as described in the following table.
+The commands are listed roughly in the order that you would use them.
+
+## Command summary
+
+
+| Command                         | See                                                                                           | Description |
+|---------------------------------|-----------------------------------------------------------------------------------------------|-------------|
+| `apic loopback`                 | [Application generator](https://docs.strongloop.com/display/APIC/Application+generator)       | Create a new LoopBack application.                                                                                                          |
+| `apic create --type datasource` | [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator)       | Add a new data source to a LoopBack application                                                                                             |
+| `apic create --type model`      | [Model generator](https://docs.strongloop.com/display/APIC/Model+generator)                   | Add a new model to a LoopBack application.                                                                                                  |
+| `apic loopback:property`        | [Property generator](https://docs.strongloop.com/display/APIC/Property+generator)             | Add a new property to an existing model.                                                                                                    |
+| `apic loopback:acl`             | [ACL generator](https://docs.strongloop.com/display/APIC/ACL+generator)                       | Add a new access control list (ACL) entry to the LoopBack application.                                                                      |
+| `apic loopback:relation`        | [Relation generator](https://docs.strongloop.com/display/APIC/Relation+generator)             | Add a new model relationship.                                                                                                               |
+| `apic loopback:remote-method`   | [Remote method generator](https://docs.strongloop.com/display/APIC/Remote+method+generator)   | Add a new [remote method.](/doc/en/lb2/Remote-methods.html)                                                                                 |
+| `apic loopback:middleware`      | [Middleware generator](https://docs.strongloop.com/display/APIC/Middleware+generator)         | Add a new [middleware](/doc/en/lb2/Defining-middleware.html) configuration.                                                                 |
+| `apic loopback:boot-script`     | [Boot script generator](https://docs.strongloop.com/display/APIC/Boot+script+generator)       | Add a new [boot scripts](/doc/en/lb2/Defining-boot-scripts.html).                                                                           |
+| `apic loopback:export-api-def`  | [API definition generator](https://docs.strongloop.com/display/APIC/API+definition+generator) | Export OpenAPI (Swagger) API definition.                                                                                                    |
+| `apic loopback:swagger`         | [Swagger generator](https://docs.strongloop.com/display/APIC/Swagger+generator)               | Generates a fully-functional application that provides the APIs conforming to the OpenAPI [Swagger](http://swagger.io/) 2.0 specification.  |
+| `apic loopback:refresh`         |                                                                                               | Generate a product and an OpenAPI (Swagger) definition                                                                                      |
+
+
+## Correspondence between StrongLoop commands to API Connect commands
+
+Every StrongLoop `slc loopback` command has a corresponding API Connect `apic` command.
+The following table provides the `apic` command corresponding to each `slc loopback` command. 
+
+| StrongLoop&nbsp;Command       | API Connect Command             |
+|-------------------------------|---------------------------------|
+| `slc loopback`                | `apic loopback`                 |
+| `slc loopback:datasource`     | `apic create --type datasource` |
+| `slc loopback:model`          | `apic create --type model`      |
+| `slc loopback:property`       | `apic loopback:property`        |
+| `slc loopback:acl`            | `apic loopback:acl`             |
+| `slc loopback:relation`       | `apic loopback:relation`        |
+| `slc loopback:remote-method`  | `apic loopback:remote-method`   |
+| `slc loopback:middleware`     | `apic loopback:middleware`      |
+| `slc loopback:boot-script`    | `apic loopback:boot-script`     |
+| `slc loopback:export-api-def` | `apic loopback:export-api-def`  |
+| `slc loopback:swagger`        | `apic loopback:swagger`         |

--- a/pages/en/lb2/Command-line-tools.md
+++ b/pages/en/lb2/Command-line-tools.md
@@ -11,14 +11,17 @@ summary:
 {% include note.html content="There are two similar command-line tools available for Loopback: the StrongLoop `slc loopback` commands and the IBM API Connect `apic loopback` commands.
 " %}
 
-You use these tools to create and _scaffold_ applications.  Scaffolding simply means generating the basic code for your application.  You can then extend and modify the code as desired for your specific needs.
+You use these tools to create and _scaffold_ applications.  Scaffolding simply means generating the basic code for your application.
+You can then extend and modify the code as desired for your specific needs.
 
-The command-line tools provide an [Application generator](Application-generator.html) to create a new LoopBack application and a number of sub-generators to scaffold an application, as described in the following table. The commands are listed roughly in the order that you would use them.
+The command-line tools provide an [Application generator](/doc/en/lb2/Application-generator.html) to create a new LoopBack application
+and a number of sub-generators to scaffold an application, as described in the following table.
+The commands are listed roughly in the order that you would use them.
 
 Under the hood, the command-line tools use [Yeoman](http://yeoman.io/). If you are already using Yeoman and are comfortable with it, you can install the LoopBack generator directly with the command:
 
-```sh
-npm install -g generator-loopback.
+```shell
+$ npm install -g generator-loopback.
 ```
 
 Then instead of using `slc loopback <command>` use `yo loopback:<command>` instead. For example, to create a new model, use `yo loopback:model`.
@@ -77,5 +80,5 @@ Then instead of using `slc loopback <command>` use `yo loopback:<command>` inste
 <td markdown="1"> Generates a fully-functional application that provides APIs conforming to the [Swagger](http://swagger.io/) 2.0 specification.
 <tr>
 <td> <code>apic loopback:refresh</code></td>
-<td>&nbsp;</td>  
+<td>&nbsp;</td>
 <td> Generate a product and an OpenAPI (Swagger) definition</td></tr>

--- a/pages/en/lb2/Community-connectors.md
+++ b/pages/en/lb2/Community-connectors.md
@@ -42,7 +42,7 @@ See also [https://github.com/pasindud/awesome-loopback](https://github.com/pasin
     <tr>
       <td><a href="http://kafka.apache.org/" class="external-link" rel="nofollow">Apache Kafka</a></td>
       <td><a href="https://www.npmjs.org/package/loopback-connector-kafka" class="external-link" rel="nofollow">loopback-connector-kafka</a></td>
-      <td>Provided as option by <a href="https://docs.strongloop.com/display/APIC/Data+source+generator">data source generator</a>.</td>
+      <td>Provided as option by <a href="/doc/en/lb2/Data-source-generator.html">data source generator</a>.</td>
     </tr>
     <tr>
       <td><a href="https://www.arangodb.com/" class="external-link" rel="nofollow">ArangoDB</a></td>
@@ -68,7 +68,7 @@ See also [https://github.com/pasindud/awesome-loopback](https://github.com/pasin
       <td><a href="http://neo4j.com/" class="external-link" rel="nofollow">Neo4j</a></td>
       <td><a href="https://www.npmjs.org/package/loopback-connector-neo4j" class="external-link" rel="nofollow">loopback-connector-neo4j</a></td>
       <td>
-        <p><span>Provided as option by </span><span>&nbsp;</span><a href="https://docs.strongloop.com/display/APIC/Data+source+generator">data source generator</a><span>.</span></p>
+        <p><span>Provided as option by </span><span>&nbsp;</span><a href="/doc/en/lb2/Data-source-generator.html">data source generator</a><span>.</span></p>
         <p><span>NOTE: This connector has <a href="https://groups.google.com/forum/#!topic/loopbackjs/HONEM1S3CnU" class="external-link" rel="nofollow">known issues</a>.</span></p>
       </td>
     </tr>
@@ -85,7 +85,7 @@ See also [https://github.com/pasindud/awesome-loopback](https://github.com/pasin
     <tr>
       <td><a href="http://hana.sap.com/abouthana.html" class="external-link" rel="nofollow">SAP HANA</a></td>
       <td><a href="https://www.npmjs.org/package/loopback-connector-saphana" class="external-link" rel="nofollow">loopback-connector-saphana</a></td>
-      <td><span>Provided as option by </span><span>&nbsp;</span><a href="https://docs.strongloop.com/display/APIC/Data+source+generator">data source generator</a><span>.</span></td>
+      <td><span>Provided as option by </span><span>&nbsp;</span><a href="/doc/en/lb2/Data-source-generator.html">data source generator</a><span>.</span></td>
     </tr>
     <tr>
       <td><a href="http://www.sqlite.org/" class="external-link" rel="nofollow">SQLite</a></td>

--- a/pages/en/lb2/Connecting-models-to-data-sources.md
+++ b/pages/en/lb2/Connecting-models-to-data-sources.md
@@ -26,7 +26,7 @@ and 
 
 To connect a model to a data source, follow these steps:
 
-1.  Use the  [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator)  to create a new data source.
+1.  Use the  [data source generator](/doc/en/lb2/Data-source-generator.html)  to create a new data source.
 
     For example: 
 
@@ -269,7 +269,7 @@ This command adds the following entry to `package.json`: 
 
 ## Creating a data source
 
-Use the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to create a new data source:
+Use the [data source generator](/doc/en/lb2/Data-source-generator.html) to create a new data source:
 
 ```shell
 $ apic create --type datasource

--- a/pages/en/lb2/Connecting-to-MongoDB.md
+++ b/pages/en/lb2/Connecting-to-MongoDB.md
@@ -13,7 +13,7 @@ summary:
 
 This example application describes using the StrongLoop `slc loopback` tool. You can also recreate the application using API Connect `apic` tool.
 Simply substitute the API Connect command for the corresponding StrongLoop command. For more information, see
-[Converting StrongLoop commands to API Connect commands](https://docs.strongloop.com/display/APIC/Command-line+reference#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
+[Converting StrongLoop commands to API Connect commands](/doc/en/lb2/Command-line-reference.html#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
 
 " %}
 

--- a/pages/en/lb2/Connecting-to-MySQL.md
+++ b/pages/en/lb2/Connecting-to-MySQL.md
@@ -13,7 +13,7 @@ summary:
 
 This example application describes using the StrongLoop `slc loopback` tool. You can also recreate the application using API Connect `apic` tool.
 Simply substitute the API Connect command for the corresponding StrongLoop command. For more information, see
-[Converting StrongLoop commands to API Connect commands](https://docs.strongloop.com/display/APIC/Command-line+reference#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
+[Converting StrongLoop commands to API Connect commands](/doc/en/lb2/Command-line-reference.html#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
 
 " %}
 {% include note.html content="

--- a/pages/en/lb2/Controlling-data-access.md
+++ b/pages/en/lb2/Controlling-data-access.md
@@ -82,7 +82,7 @@ Once you've created this kind of specification, you can easily construct `apic l
 
 ## Using the ACL generator to define access control
 
-The easiest way to define access control for an app is with the [ACL generator](https://docs.strongloop.com/display/APIC/ACL+generator). 
+The easiest way to define access control for an app is with the [ACL generator](/doc/en/lb2/ACL-generator.html). 
 This enables you to create a static definition before runtime. The generator prompts you for all the necessary information:
 
 ```shell

--- a/pages/en/lb2/Creating-a-default-admin-user.md
+++ b/pages/en/lb2/Creating-a-default-admin-user.md
@@ -55,7 +55,7 @@ User.create([
 };
 ```
 
-The project model JSON (created by running `apic loopback:acl`, the [ACL generator](https://docs.strongloop.com/display/APIC/ACL+generator)) 
+The project model JSON (created by running `apic loopback:acl`, the [ACL generator](/doc/en/lb2/ACL-generator.html)) 
 file specifies that the admin role has unrestricted access to view projects (`GET /api/projects`):
 
 **/common/models/model.json**

--- a/pages/en/lb2/Creating-an-application.md
+++ b/pages/en/lb2/Creating-an-application.md
@@ -14,7 +14,7 @@ summary:
 **Prerequisites**
 
 * Install **[API Connect](https://developer.ibm.com/apiconnect/)** or **[StrongLoop](https://docs.strongloop.com/display/SL/Installing+StrongLoop)**.
-* Read [LoopBack core concepts](https://docs.strongloop.com/display/APIC/LoopBack+core+concepts).
+* Read [LoopBack core concepts](/doc/en/lb2/LoopBack-core-concepts.html).
 
 " %}
 
@@ -105,9 +105,9 @@ and
 Start the web server.
 
 **7**:
-Emit the 'started' [event](https://docs.strongloop.com/display/APIC/Events).
+Emit the 'started' [event](/doc/en/lb2/Events.html).
 
 **10 - 13**:
 Start [API Explorer](/pages/createpage.action?spaceKey=APIC&title=API+Explorer&linkCreation=true&fromPageId=9634284).
 
-**18**: [Initialize (boot) the application](https://docs.strongloop.com/display/APIC/Defining+boot+scripts).
+**18**: [Initialize (boot) the application](/doc/en/lb2/Events.html).

--- a/pages/en/lb2/Creating-model-relations.md
+++ b/pages/en/lb2/Creating-model-relations.md
@@ -55,8 +55,8 @@ Models backed by different data sources can have relations between them.
 ## Using the relation generator
 
 The easiest way to create a new relation between existing models is to use the 
-[`slc loopback:relation`](https://docs.strongloop.com/display/APIC/Relation+generator), or the
-[`apic loopback:relation`](https://docs.strongloop.com/display/APIC/Relation+generator), relation generator.
+[`slc loopback:relation`](/doc/en/lb2/Relation-generator.html), or the
+[`apic loopback:relation`](/doc/en/lb2/Relation-generator.html), relation generator.
 
 The tool will prompt you to enter the type of relation (belongsTo, hasMany, and so on) and the affected models.
 

--- a/pages/en/lb2/Creating-model-relations.md
+++ b/pages/en/lb2/Creating-model-relations.md
@@ -11,12 +11,12 @@ summary:
 
 **See also**:
 
-* [Creating models](https://docs.strongloop.com/display/APIC/Creating+models)
-* [Customizing models](https://docs.strongloop.com/display/APIC/Customizing+models)
-* [Creating model relations](https://docs.strongloop.com/display/APIC/Creating+model+relations)
-* [Querying data](https://docs.strongloop.com/display/APIC/Querying+data)
+* [Creating models](/doc/en/lb2/Creating-models.html)
+* [Customizing models](/doc/en/lb2/Customizing-models.html)
+* [Creating model relations](/doc/en/lb2/Creating-model-relations.html)
+* [Querying data](/doc/en/lb2/Querying-data.html)
 * [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html)
-* [PersistedModel REST API](https://docs.strongloop.com/display/APIC/PersistedModel+REST+API)
+* [PersistedModel REST API](/doc/en/lb2/PersistedModel-REST-API.html)
 
 ## Overview of model relations
 

--- a/pages/en/lb2/Creating-updating-and-deleting-data.md
+++ b/pages/en/lb2/Creating-updating-and-deleting-data.md
@@ -11,7 +11,7 @@ summary:
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/Customizing-models.md
+++ b/pages/en/lb2/Customizing-models.md
@@ -9,23 +9,23 @@ permalink: /doc/en/lb2/Customizing-models.html
 summary:
 ---
 
-Once you've created a model with the [model generator](https://docs.strongloop.com/display/APIC/Model+generator), you can start customizing it.
+Once you've created a model with the [model generator](/doc/en/lb2/Model-generator.html), you can start customizing it.
 You can customize it using the command-line tool, by editing the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html), and by adding JavaScript code.
 
 ## Customizing a model with the command-line tool
 
 {% include note.html content="
 
-Once you've created a model with the  [model generator](https://docs.strongloop.com/display/APIC/Model+generator), you can't modify the model with the model generator.
+Once you've created a model with the  [model generator](/doc/en/lb2/Model-generator.html), you can't modify the model with the model generator.
 However, you can customize the model to some degree with the command-line tool; see below.
 
 " %}
 
 You can use the command-line tool to customize a model after you initially create it; specifically, you can:
 
-* Use the [property generator](https://docs.strongloop.com/display/APIC/Property+generator) to add a property to the model.
-* Use the [relation generator](https://docs.strongloop.com/display/APIC/Relation+generator) to add [add relations between models](/doc/en/lb2/Creating-model-relations.html).
-* Use [ACL generator](https://docs.strongloop.com/display/APIC/ACL+generator) to add [access control](/doc/en/lb2/Controlling-data-access.html) to the model.
+* Use the [property generator](/doc/en/lb2/Property-generator.html) to add a property to the model.
+* Use the [relation generator](/doc/en/lb2/Relation-generator.html) to add [add relations between models](/doc/en/lb2/Creating-model-relations.html).
+* Use [ACL generator](/doc/en/lb2/ACL-generator.html) to add [access control](/doc/en/lb2/Controlling-data-access.html) to the model.
 
 ## Customizing a model using JSON
 
@@ -55,7 +55,7 @@ For more information, see [ACL rule precedence](/doc/en/lb2/Controlling-data-ac
 ### Extending another model
 
 You can make a model extend or "inherit from" an existing model, either one of the built-in models such as User, or a custom model you've defined in your application.
-To do this with the [model generator](https://docs.strongloop.com/display/APIC/Model+generator), simply choose the desired model when you're prompted to "Select model's base class".
+To do this with the [model generator](/doc/en/lb2/Model-generator.html), simply choose the desired model when you're prompted to "Select model's base class".
 Alternatively,  you can edit the [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) and set the "base" property to the name of the model you want to extend.
 
 {% include note.html content="
@@ -87,7 +87,7 @@ Currently you cannot modify a built-in model's required properties. If you need 
 
 You can create custom models that extend from a single base custom model.
 For example, to define a model called `MyModel` that extends from a custom model you defined called `mMyBaseModel`,
-create MyModel using [model generator](https://docs.strongloop.com/display/APIC/Model+generator) 
+create MyModel using [model generator](/doc/en/lb2/Model-generator.html) 
 then edit the JSON file `common/models/MyModel.json` as follows:
 
 **/common/models/model.json**
@@ -133,7 +133,7 @@ See [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html#Mo
 
 The basic way to extend a model programmatically is to edit the model's JavaScript file in the `common/models/` directory.
 For example, a "customer" model will have a `common/models/customer.js` file (if you create the model using the 
-[model generator](https://docs.strongloop.com/display/APIC/Model+generator)).
+[model generator](/doc/en/lb2/Model-generator.html)).
 The script is executed immediately after the model is defined.
 Treat the script as part of the model definition; use it for model configuration and registration.
 You could also add model relationships, complex validations, or default functions for certain properties: Basically, anything you cannot do in JSON.

--- a/pages/en/lb2/Data-source-generator.md
+++ b/pages/en/lb2/Data-source-generator.md
@@ -10,52 +10,52 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
 Then you must run the command from the root directory of the application."
 %}
 
-### SYNOPSIS
+### Synopsis
 
 Adds a new data source definition to a LoopBack application.
 
 ```shell
-apic create --type datasource [options] [<name>]
+$ apic create --type datasource [options] [<name>]
 ```
 
 Or
 
 ```shell
-slc loopback:datasource [options] [<name>]
+$ slc loopback:datasource [options] [<name>]
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### ARGUMENTS
+### Arguments
 
 You can optionally provide the name of the data source to create as an argument.  If you do, the tool will use that as the default when it prompts for the name.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for:
 
-*   Name of the new data source.  If you supplied a name on the command-line, just hit Enter to use it.
-*   Connector to use for the data source.
+* Name of the new data source.  If you supplied a name on the command-line, just hit Enter to use it.
+* Connector to use for the data source.
 
 {% include important.html content="
 
-You must install the [connector](Connecting-models-to-data+sources.html) for the new data source; for example: `npm install --save loopback-connector-mysql`
+You must install the [connector](/doc/en/lb2/Connecting-models-to-data-sources.html) for the new data source; for example: `npm install --save loopback-connector-mysql`
 " %}
 
-### OUTPUT
+### Output
 
-This adds an entry to [`datasources.json`](datasources.json.html) with the specified settings.
+This adds an entry to [`datasources.json`](/doc/en/lb2/datasources.json.html) with the specified settings.

--- a/pages/en/lb2/Defining-boot-scripts.md
+++ b/pages/en/lb2/Defining-boot-scripts.md
@@ -47,7 +47,7 @@ See [loopback-boot API docs](http://apidocs.strongloop.com/loopback-boot/) for
 
 {% include note.html content="
 
-If you create your application with the [application generator](https://docs.strongloop.com/display/APIC/Application+generator) ,
+If you create your application with the [application generator](/doc/en/lb2/Application-generator.html) ,
 then you don't need to do anything to bootstrap your application--the above code is automatically scaffolded for you!
 
 " %}
@@ -63,7 +63,7 @@ See [Boot script loading order](/doc/en/lb2/Defining-boot-scripts.html) for de
 ## Predefined boot scripts
 
 The standard scaffolded LoopBack application created by the 
-[application generator](https://docs.strongloop.com/display/APIC/Application+generator) contains the following standard boot scripts (in `/server/boot`) that performs basic initialization:
+[application generator](/doc/en/lb2/Application-generator.html) contains the following standard boot scripts (in `/server/boot`) that performs basic initialization:
 
 * `root.js` - Binds [`loopback.status()`](http://apidocs.strongloop.com/loopback/#loopback-status) middleware at the root endpoint ("/") to provide basic status information.
 
@@ -84,7 +84,7 @@ To enable user model authentication you should add this script (or the equivalen
 
 In addition to the predefined boot scripts, you can define custom boot scripts to perform your own logic when an application starts.
 
-Use the [boot script generator](https://docs.strongloop.com/display/APIC/Boot+script+generator), to quickly generate boot script templates.
+Use the [boot script generator](/doc/en/lb2/Boot-script-generator.html), to quickly generate boot script templates.
 Depending on how you respond to the generator's prompts, it will generate a template for either a synchronous or asynchronous boot script:
 
 **Synchronous boot script template**

--- a/pages/en/lb2/Defining-middleware.md
+++ b/pages/en/lb2/Defining-middleware.md
@@ -324,7 +324,7 @@ For details about the `options` object, refer to [Middleware configuration prope
 The easiest way to register middleware is in `server/middleware.json`.
 This file specifies all an application's middleware functions and the phase in which they are called.
 
-When you create an application using the [Application generator](https://docs.strongloop.com/display/APIC/Application+generator) 
+When you create an application using the [Application generator](/doc/en/lb2/Application-generator.html) 
 it creates a default `middleware.json` file that looks as follows:
 
 **server/middleware.json**

--- a/pages/en/lb2/Defining-mixins.md
+++ b/pages/en/lb2/Defining-mixins.md
@@ -29,13 +29,13 @@ By default, the basic LoopBack [Model object](http://apidocs.strongloop.com/loop
 
 * [Inclusion object](http://apidocs.strongloop.com/loopback-datasource-juggler/#inclusion) - Enables you to load relations of several objects and optimize numbers of requests.
 * [Validateable object](http://apidocs.strongloop.com/loopback-datasource-juggler/#validatable) - provides validation methods.
-  See [Validating model data](https://docs.strongloop.com/display/APIC/Validating+model+data).
+  See [Validating model data](/doc/en/lb2/Validating-model-data.html).
 
 When you define relations between models, the [RelationMixin object](http://apidocs.strongloop.com/loopback-datasource-juggler/#relationmixin) object also gets mixed in to the model object.
 
 **Connected model**
 
-In addition to the methods of the [Basic model object](https://docs.strongloop.com/display/APIC/Basic+model+object),
+In addition to the methods of the [Basic model object](/doc/en/lb2/Basic-model-object.html),
 the following are mixed in when a model is connected to a data source:
 
 * [RelationMixin class](http://apidocs.strongloop.com/loopback-datasource-juggler/#relationmixin)
@@ -57,7 +57,7 @@ If it applies only to server models, put it in the `server/mixins` directory.
 
 The above locations are just recommendations.
 You are free to put mixin scripts in any project directory as long as you set the location with the `mixins` property in 
-[`model-config.js`](https://docs.strongloop.com/display/public/LB/Defining+mixins#Definingmixins-Referencemixinsinmodel-config.js).
+[`model-config.js`](/doc/en/lb2/Defining-mixins.html#Definingmixins-Referencemixinsinmodel-config.js).
 
 " %}
 

--- a/pages/en/lb2/Defining-mixins.md
+++ b/pages/en/lb2/Defining-mixins.md
@@ -65,6 +65,17 @@ You can use mixins to perform different common actions on models such as observi
 
 For example:
 
+{% include warning.html content="
+
+**Different `defineProperty`!**
+
+The `defineProperty` method below is from
+[loopback-datasource-juggler's `ModelBaseClass`](http://apidocs.strongloop.com/loopback-datasource-juggler/#modelbaseclass-defineproperty),
+which is _not the same_ as JavaScript's
+[`Object.defineProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty).
+
+" %}
+
 **common/mixins/timestamp.js**
 
 ```javascript

--- a/pages/en/lb2/Defining-models.md
+++ b/pages/en/lb2/Defining-models.md
@@ -23,7 +23,7 @@ You can [extend built-in models](/doc/en/lb2/Extending-built-in-models.html) to
 
 Additionally, you can [define your own custom models](/doc/en/lb2/Creating-models.html) specific to your application: 
 
-* Use the [model generator](https://docs.strongloop.com/display/APIC/Model+generator) to create custom models from scratch. 
+* Use the [model generator](/doc/en/lb2/Model-generator.html) to create custom models from scratch. 
   This creates a [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) that defines your model in LoopBack.
 * Use [`Datasource.buildModelFromInstance()`](http://apidocs.strongloop.com/loopback-datasource-juggler/#datasource-prototype-buildmodelfrominstance)
   to create _dynamic_ schema-less models for data sources such as SOAP and REST services.

--- a/pages/en/lb2/Email-connector.md
+++ b/pages/en/lb2/Email-connector.md
@@ -13,7 +13,7 @@ The email connector is built in to LoopBack, so you don't need to install it.
 
 ## Creating an email data source
 
-Create a new email data source with the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator):
+Create a new email data source with the [data source generator](/doc/en/lb2/Data-source-generator.html):
 
 ```shell
 $ apic create --type datasource

--- a/pages/en/lb2/Events.md
+++ b/pages/en/lb2/Events.md
@@ -28,7 +28,7 @@ By default, the basic LoopBack [Model object](http://apidocs.strongloop.com/loop
 
 * [Inclusion object](http://apidocs.strongloop.com/loopback-datasource-juggler/#inclusion) - Enables you to load relations of several objects and optimize numbers of requests.
 * [Validateable object](http://apidocs.strongloop.com/loopback-datasource-juggler/#validatable) - provides validation methods.
-  See [Validating model data](https://docs.strongloop.com/display/APIC/Validating+model+data).
+  See [Validating model data](/doc/en/lb2/Validating-model-data.html).
 
 When you define relations between models, the [RelationMixin object](http://apidocs.strongloop.com/loopback-datasource-juggler/#relationmixin) object also gets mixed in to the model object.
 

--- a/pages/en/lb2/Events.md
+++ b/pages/en/lb2/Events.md
@@ -9,6 +9,11 @@ permalink: /doc/en/lb2/Events.html
 summary:
 ---
 
+The [LoopBack app object](http://apidocs.strongloop.com/loopback/#var-app-loopback) is a Node
+[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter), and thus has
+[`app.emit()`](https://nodejs.org/api/events.html#events_emitter_emit_eventname_arg1_arg2) and
+[`app.on()`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) methods.
+
 In addition to the [standard Node events](http://nodejs.org/api/events.html), LoopBack applications and models emit other events.
 
 ## Application events

--- a/pages/en/lb2/Exposing-models-over-REST.md
+++ b/pages/en/lb2/Exposing-models-over-REST.md
@@ -1,5 +1,5 @@
 ---
-title: "Exposing models over RESTRelation REST APIAdding remote methods to built-in modelsCreating, updating, and deleting dataFields filterWhere filterDefining mixinsUsing current contextEventsPreparing for deploymentUsing strong-error-handlermiddleware.jsonModel definition JSON fileCommand-line reference"
+title: "Exposing models over REST"
 lang: en
 layout: page
 keywords: LoopBack
@@ -11,11 +11,13 @@ summary:
 
 ## Overview
 
-LoopBack models automatically have a [standard set of HTTP endpoints](http://apidocs.strongloop.com/loopback/#persistedmodel) that provide REST APIs for create, read, update, and delete (CRUD) operations on model data.  The `public` property in [model-config.json](https://docs.strongloop.com/display/APIC/model-config.json) specifies whether to expose the model's REST APIs, for example:
+LoopBack models automatically have a [standard set of HTTP endpoints](http://apidocs.strongloop.com/loopback/#persistedmodel)
+that provide REST APIs for create, read, update, and delete (CRUD) operations on model data.
+The `public` property in [model-config.json](/doc/en/lb2/model-config.json.html) specifies whether to expose the model's REST APIs, for example:
 
 **/server/model-config.json**
 
-```js
+```javascript
 ...
 "MyModel": {
   "public": true,
@@ -24,15 +26,15 @@ LoopBack models automatically have a [standard set of HTTP endpoints](http://ap
 ...
 ```
 
-To "hide" the model's REST API, simply change `public` to `false`.
+To "hide" the model's REST API, simply change `public` to `false`.
 
 ### REST paths
 
 By default, the REST APIs are mounted to the plural of the model name; specifically:
 
-*   `Model.settings.http.path`
-*   `plural`, if defined in the [Model definition JSON file](Model-definition-JSON-file_9634289.html).
-*   Automatically-pluralized model name (the default). For example, if you have a location model, by default it is mounted to `/locations`. 
+* `Model.settings.http.path`
+* `plural`, if defined in the [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html).
+* Automatically-pluralized model name (the default). For example, if you have a location model, by default it is mounted to `/locations`. 
 
 ### Using the REST Router
 
@@ -40,7 +42,8 @@ By default, scaffolded applications expose models over REST using the `loopback
 
 {% include important.html content="
 
-If your application is scaffolded using `apic loopback`, LoopBack will automatically set up REST middleware and register public models. You don't need to do anything additional.
+If your application is scaffolded using `apic loopback`, LoopBack will automatically set up REST middleware and register public models.
+You don't need to do anything additional.
 
 " %}
 
@@ -48,26 +51,33 @@ To manually expose a model over REST with the `loopback.rest` router, use the 
 
 **/server/server.js**
 
-```js
+```javascript
 var app = loopback();
-app.use(loopback.rest()); 
+app.use(loopback.rest());
+
 // Expose the `Product` model
 app.model(Product);
 ```
 
-After this, the `Product` model will have create, read, update, and delete functions working remotely from mobile. At this point, the model is schema-less and the data are not checked.
+After this, the `Product` model will have create, read, update, and delete functions working remotely from mobile.
+At this point, the model is schema-less and the data are not checked.
 
-You can then view generated REST documentation at [http://localhost:3000/explorer](http://localhost:3000/explorer)[.](http://localhost:3000/_docs)
+You can then view generated REST documentation at [http://localhost:3000/explorer](http://localhost:3000/explorer)
 
-LoopBack provides a number of [built-in models](https://docs.strongloop.com/display/APIC/Using+built-in+models) that have REST APIs.  See [Built-in models REST API](https://docs.strongloop.com/display/APIC/Built-in+models+REST+API) for more information.
+LoopBack provides a number of [built-in models](/doc/en/lb2/Using-built-in-models.html) that have REST APIs.
+See [Built-in models REST API](/doc/en/lb2/Built-in-models-REST-API.html) for more information.
 
 ### Request format
 
-For POST and PUT requests, the request body can be JSON, XML or urlencoded format, with the **Content-Type** header set to `application/json, application/xml, or application/x-www-form-urlencoded`. The **Accept** header indicates its preference for the response format.
+For POST and PUT requests, the request body can be JSON, XML or urlencoded format, with the **Content-Type** header set to 
+`application/json, application/xml, or application/x-www-form-urlencoded`.
+The **Accept** header indicates its preference for the response format.
 
 {% include tip.html content="
 
-Setting the request's **Accept** header to `application/vnd.api+json` will result in the response's **Content-Type** header being automatically set to `application/vnd.api+json` if `application/vnd.api+json` is in the array of supported types. Set the supported types with the `remoting.``rest.supportedTypes` property in [config.json](https://docs.strongloop.com/display/APIC/config.json).
+Setting the request's **Accept** header to `application/vnd.api+json` will result in the response's **Content-Type** header being automatically set
+to `application/vnd.api+json` if`application/vnd.api+json` is in the array of supported types.
+Set the supported types with the `remoting.``rest.supportedTypes` property in [config.json](/doc/en/lb2/config.json.html).
 
 " %}
 
@@ -75,14 +85,14 @@ Setting the request's **Accept** header to `application/vnd.api+json` will r
 
 Some REST APIs take a JSON object or array from the query string. LoopBack supports two styles to encode the object/array value as query parameters.
 
-*   Syntax from node-querystring (qs)
-*   Stringified JSON
+* Syntax from node-querystring (qs)
+* Stringified JSON
 
 For example,
 
-```js
-http: //localhost:3000/api/users?filter[where][username]=john&filter[where][email]=callback@strongloop.com
-  http: //localhost:3000/api/users?filter={"where":{"username":"john","email":"callback@strongloop.com"}}
+```
+http://localhost:3000/api/users?filter[where][username]=john&filter[where][email]=callback@strongloop.com
+http://localhost:3000/api/users?filter={"where":{"username":"john","email":"callback@strongloop.com"}}
 ```
 
 The table below illustrates how to encode the JSON object/array can be encoded in different styles:
@@ -95,58 +105,90 @@ The table below illustrates how to encode the JSON object/array can be encoded i
       <th>Stringified JSON</th>
     </tr>
     <tr>
-      <td><pre><code>{ where:&nbsp;<br></code>  { username: 'john',&nbsp;<br>    email: 'callback@strongloop.com' } }</pre></td>
-      <td><pre><code>?filter[where][username]=john<br>&amp;</code>filter[where][email]=callback@strongloop.com</pre></td>
-      <td><pre><code>?filter={"where":<br></code>  {"username":"john",<br>   "email":"callback@strongloop.com"}}</pre></td>
+      <td>
+        <pre><code>{
+where: {
+  username: 'john',
+  email: 'callback@strongloop.com'
+  }
+}</code></pre>
+      </td>
+      <td>
+        <pre><code>?filter[where][username]=john<br>&amp;</code>filter[where][email]=callback@strongloop.com</pre>
+      </td>
+      <td>
+        <pre><code>?filter={"where":
+{"username":"john",
+ "email":"callback@strongloop.com"}
+}</code></pre>
+      </td>
     </tr>
     <tr>
-      <td><pre><code>{ where: <br>  { username: {inq: ['john', 'mary']} } }</code></pre></td>
-      <td><pre>?filter[where][username][inq][0]=john<br>&amp;filter[where][username][inq][1]=mary</pre></td>
-      <td><pre><code>?filter=</code>{"where":<br>  {"username":{"inq":["john","mary"]}}}</pre></td>
+      <td>
+        <pre><code>{
+where: {
+    username: {inq: ['john', 'mary']}
+  }
+}</code></pre>
+      </td>
+      <td>
+        <pre>?filter[where][username][inq][0]=john<br>&amp;filter[where][username][inq][1]=mary</pre>
+      </td>
+      <td>
+        <pre><code>?filter={"where":
+  {"username":{"inq":["john","mary"]}}
+}</code></pre>
+      </td>
     </tr>
     <tr>
-      <td><pre><code>{ include: ['a', 'b'] }</code></pre></td>
-      <td><pre><code>?filter[include]=a&amp;filter[include]=b</code></pre></td>
-      <td><pre><code>?filter={"include":["a","b"]}</code></pre></td>
+      <td>
+        <pre><code>{
+  include: ['a', 'b']
+}</code></pre>
+      </td>
+      <td>
+        <pre><code>?filter[include]=a&amp;filter[include]=b</code></pre>
+      </td>
+      <td>
+        <pre><code>?filter={"include":["a","b"]}</code></pre>
+      </td>
     </tr>
   </tbody>
 </table>
 
 ### Response format
 
-The response format for all requests is typically a JSON object/array or XML in the body and a set of headers. Some responses have an empty body. For example,
+The response format for all requests is typically a JSON object/array or XML in the body and a set of headers.
+Some responses have an empty body. For example,
 
-```js
-HTTP / 1.1 200 OK
-Access - Control - Allow - Origin: http: //localhost:3000
-  Access - Control - Allow - Credentials: true
-Content - Type: application / json;
-charset = utf - 8
-Content - Length: 59
-Vary: Accept - Encoding
-Date: Fri, 24 Oct 2014 18: 02: 34 GMT
-Connection: keep - alive  {
-  "title": "MyNote",
-  "content": "This is my first note",
-  "id": 1
-}
+```
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: http://localhost:3000
+Access-Control-Allow-Credentials: true
+Content-Type: application/json; charset=utf-8
+Content-Length: 59
+Vary: Accept-Encoding
+Date: Fri, 24 Oct 2014 18:02:34 GMT
+Connection: keep-alive
+
+{"title":"MyNote","content":"This is my first note","id":1}
 ```
 
 The HTTP status code indicates whether a request succeeded:
 
-*   Status code 2xx indicates success
-*   Status code 4xx indicates request related issues.
-*   Status code 5xx indicates server-side problems
+* Status code 2xx indicates success
+* Status code 4xx indicates request related issues.
+* Status code 5xx indicates server-side problems
 
 The response for an error is in the following JSON format:
 
-*   message: String error message.
-*   stack: String stack trace.
-*   statusCode: Integer [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).
+* message: String error message.
+* stack: String stack trace.
+* statusCode: Integer [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).
 
 For example,
 
-```js
+```javascript
 {
   "error": {
     "message": "could not find a model with id 1",
@@ -158,16 +200,17 @@ For example,
 
 ### Disabling API Explorer
 
-LoopBack [API Explorer](https://docs.strongloop.com/display/LB/Use+API+Explorer) is great when you're developing your application, but for security reasons you may not want to expose it in production.  
+LoopBack [API Explorer](https://docs.strongloop.com/display/LB/Use+API+Explorer) is great when you're developing your application,
+but for security reasons you may not want to expose it in production.
 
 For an application using [loopback-component-explorer](https://github.com/strongloop/loopback-component-explorer), to disable explorer in production:
 
-*   Set the NODE_ENV environment variable to "production".
-*   Then in `server/component-config.production.json`:
+* Set the NODE_ENV environment variable to "production".
+* Then in `server/component-config.production.json`:
 
 **server/component-config.production.json**
 
-```js
+```javascript
 {
   "loopback-component-explorer": null
 }
@@ -181,183 +224,51 @@ For an application using the old `loopback-explorer` (prior to version 2.0), dis
 
 ## Predefined remote methods
 
-By default, for a model backed by a data source that supports it, LoopBack exposes a REST API that provides all the standard create, read, update, and delete (CRUD) operations.
+By default, for a model backed by a data source that supports it,
+LoopBack exposes a REST API that provides all the standard create, read, update, and delete (CRUD) operations.
 
-As an example, consider a simple model called `Location` (that provides business locations) to illustrate the REST API exposed by LoopBack.  LoopBack automatically creates a number of Node methods with corresponding REST endpoints, including:
+As an example, consider a simple model called `Location` (that provides business locations) to illustrate the REST API exposed by LoopBack.
+LoopBack automatically creates a number of Node methods with corresponding REST endpoints, including:
 
-<table>
-  <tbody>
-    <tr>
-      <th>Model (Node) API</th>
-      <th>HTTP Method</th>
-      <th>Example Path</th>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-create" class="external-link" rel="nofollow">create()</a></td>
-      <td>POST</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-upsert" class="external-link" rel="nofollow">upsert()</a></td>
-      <td>PUT</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-upsert" class="external-link" rel="nofollow">upsert()</a></td>
-      <td>PATCH</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-exists" class="external-link" rel="nofollow">exists()</a></td>
-      <td>GET</td>
-      <td>/locations/:id/exists</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-findbyid" class="external-link" rel="nofollow">findById()</a></td>
-      <td>GET</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-find" class="external-link" rel="nofollow">find()</a></td>
-      <td>GET</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-findone" class="external-link" rel="nofollow">findOne()</a></td>
-      <td>GET</td>
-      <td>/locations/findOne</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-destroybyid" class="external-link" rel="nofollow">destroyById() or deleteById()</a></td>
-      <td>DELETE</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-count" class="external-link" rel="nofollow">count()</a></td>
-      <td>GET</td>
-      <td>/locations/count</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-prototype-updateattributes" class="external-link" rel="nofollow">prototype.updateAttributes()</a></td>
-      <td>PUT</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-prototype-updateattributes" class="external-link" rel="nofollow">prototype.updateAttributes()</a></td>
-      <td>PATCH</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-createchangestream" class="external-link" rel="nofollow">createChangeStream()</a></td>
-      <td>POST</td>
-      <td>/locations/change-stream</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-updateall" class="external-link" rel="nofollow">updateAll()</a></td>
-      <td>POST</td>
-      <td>/locations/update</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate" class="external-link" rel="nofollow">replaceOrCreate()</a>*</td>
-      <td>POST</td>
-      <td>/locations/replaceOrCreate</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid" class="external-link" rel="nofollow">replaceById()</a>*</td>
-      <td>POST</td>
-      <td>/locations/:id/replace</td>
-    </tr>
-  </tbody>
-</table>
+| Model (Node) API | HTTP Method | Example Path |
+|---|---|---|
+| [create()](https://apidocs.strongloop.com/loopback/#persistedmodel-create)                                         | POST   | /locations                 |
+| [upsert()](https://apidocs.strongloop.com/loopback/#persistedmodel-upsert)                                         | PUT    | /locations                 |
+| [upsert()](https://apidocs.strongloop.com/loopback/#persistedmodel-upsert)                                         | PATCH  | /locations                 |
+| [exists()](https://apidocs.strongloop.com/loopback/#persistedmodel-exists)                                         | GET    | /locations/:id/exists      |
+| [findById()](https://apidocs.strongloop.com/loopback/#persistedmodel-findbyid)                                     | GET    | /locations/:id             |
+| [find()](https://apidocs.strongloop.com/loopback/#persistedmodel-find)                                             | GET    | /locations                 |
+| [findOne()](https://apidocs.strongloop.com/loopback/#persistedmodel-findone)                                       | GET    | /locations/findOne         |
+| [destroyById() or deleteById()](https://apidocs.strongloop.com/loopback/#persistedmodel-destroybyid)               | DELETE | /locations/:id             |
+| [count()](https://apidocs.strongloop.com/loopback/#persistedmodel-count)                                           | GET    | /locations/count           |
+| [prototype.updateAttributes()](https://apidocs.strongloop.com/loopback/#persistedmodel-prototype-updateattributes) | PUT    | /locations/:id             |
+| [prototype.updateAttributes()](https://apidocs.strongloop.com/loopback/#persistedmodel-prototype-updateattributes) | PATCH  | /locations/:id             |
+| [createChangeStream()](https://apidocs.strongloop.com/loopback/#persistedmodel-createchangestream)                 | POST   | /locations/change-stream   |
+| [updateAll()](https://apidocs.strongloop.com/loopback/#persistedmodel-updateall)                                   | POST   | /locations/update          |
+| [replaceOrCreate()](https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate)*                      | POST   | /locations/replaceOrCreate |
+| [replaceById()](https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid)*                              | POST   | /locations/:id/replace     |
 
-*Added in loopback v. 2.30.0
+\* Added in loopback v. 2.30.0
 
 Please note the above table is the default exposed endpoints for LoopBack 2.x, while they are exposed differently in LoopBack 3.x; please see the following table for LoopBack 3.x:
 
-<table>
-  <tbody>
-    <tr>
-      <th>Model (Node) API</th>
-      <th>HTTP Method</th>
-      <th>Example Path</th>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-create" class="external-link" rel="nofollow">create()</a></td>
-      <td>POST</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate" class="external-link" rel="nofollow">replaceOrCreate()</a></td>
-      <td>PUT</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-upsert" class="external-link" rel="nofollow">patchOrCreate()</a></td>
-      <td>PATCH</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-exists" class="external-link" rel="nofollow">exists()</a></td>
-      <td>GET</td>
-      <td>/locations/:id/exists</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-findbyid" class="external-link" rel="nofollow">findById()</a></td>
-      <td>GET</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-find" class="external-link" rel="nofollow">find()</a></td>
-      <td>GET</td>
-      <td>/locations</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-findone" class="external-link" rel="nofollow">findOne()</a></td>
-      <td>GET</td>
-      <td>/locations/findOne</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-destroybyid" class="external-link" rel="nofollow">destroyById() or deleteById()</a></td>
-      <td>DELETE</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-count" class="external-link" rel="nofollow">count()</a></td>
-      <td>GET</td>
-      <td>/locations/count</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid" class="external-link" rel="nofollow">replaceById()</a></td>
-      <td>PUT</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-prototype-updateattributes" class="external-link" rel="nofollow">prototype.patchAttributes()</a></td>
-      <td>PATCH</td>
-      <td>/locations/:id</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-createchangestream" class="external-link" rel="nofollow">createChangeStream()</a></td>
-      <td>POST</td>
-      <td>/locations/change-stream</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-updateall" class="external-link" rel="nofollow">updateAll()</a></td>
-      <td>POST</td>
-      <td>/locations/update</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate" class="external-link" rel="nofollow">replaceOrCreate()</a></td>
-      <td>POST</td>
-      <td>/locations/replaceOrCreate</td>
-    </tr>
-    <tr>
-      <td><a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid" class="external-link" rel="nofollow">replaceById()</a></td>
-      <td>POST</td>
-      <td>/locations/:id/replace</td>
-    </tr>
-  </tbody>
-</table>
+| Model (Node) API | HTTP Method | Example Path |
+|---|---|---|
+| [create()](https://apidocs.strongloop.com/loopback/#persistedmodel-create)                                        | POST   | /locations                 |
+| [replaceOrCreate()](https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate)                      | PUT    | /locations                 |
+| [patchOrCreate()](https://apidocs.strongloop.com/loopback/#persistedmodel-upsert)                                 | PATCH  | /locations                 |
+| [exists()](https://apidocs.strongloop.com/loopback/#persistedmodel-exists)                                        | GET    | /locations/:id/exists      |
+| [findById()](https://apidocs.strongloop.com/loopback/#persistedmodel-findbyid)                                    | GET    | /locations/:id             |
+| [find()](https://apidocs.strongloop.com/loopback/#persistedmodel-find)                                            | GET    | /locations                 |
+| [findOne()](https://apidocs.strongloop.com/loopback/#persistedmodel-findone)                                      | GET    | /locations/findOne         |
+| [destroyById() or deleteById()](https://apidocs.strongloop.com/loopback/#persistedmodel-destroybyid)              | DELETE | /locations/:id             |
+| [count()](https://apidocs.strongloop.com/loopback/#persistedmodel-count)                                          | GET    | /locations/count           |
+| [replaceById()](https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid)                              | PUT    | /locations/:id             |
+| [prototype.patchAttributes()](https://apidocs.strongloop.com/loopback/#persistedmodel-prototype-updateattributes) | PATCH  | /locations/:id             |
+| [createChangeStream()](https://apidocs.strongloop.com/loopback/#persistedmodel-createchangestream)                | POST   | /locations/change-stream   |
+| [updateAll()](https://apidocs.strongloop.com/loopback/#persistedmodel-updateall)                                  | POST   | /locations/update          |
+| [replaceOrCreate()](https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate)                      | POST   | /locations/replaceOrCreate |
+| [replaceById()](https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid)                              | POST   | /locations/:id/replace     |
 
 As you see the only difference between LoopBack 2.x and 3.0 in default configuration is the behaviour of HTTP PUT endpoints (both `PUT /api/my-models` and `PUT /api/my-models/:id`). By default in LoopBack 2.x, these endpoints invoke patch methods and perform a partial update, while in LoopBack 3.0, these methods perform a full replace.
 
@@ -367,7 +278,7 @@ Use the replaceOnPUT property in `model.json` to change the behavior of mappi
 
 The following example illustrates how to set `replaceOnPUT` in `location.json`:
 
-```
+```javascript
 ...
 {
   name: "location",
@@ -381,7 +292,9 @@ The following example illustrates how to set `replaceOnPUT` in `location.json
 
 {% include tip.html content="
 
-The above tables provide a partial list of methods and REST endpoints. See the [API documentation](https://apidocs.strongloop.com/loopback/#persistedmodel) for a complete list of all the Node API methods. See [PersistedModel REST API](https://docs.strongloop.com/display/APIC/PersistedModel+REST+API) for details on the REST API.
+The above table provides a partial list of methods and REST endpoints.
+See the [API documentation](https://apidocs.strongloop.com/loopback/#persistedmodel) for a complete list of all the Node API methods.
+See [PersistedModel REST API](/doc/en/lb2/PersistedModel-REST-API.html) for details on the REST API.
 
 " %}
 
@@ -389,7 +302,7 @@ The above tables provide a partial list of methods and REST endpoints. See the [
 
 To expose a model over REST, set the `public` property to true in `/server/model-config.json`:
 
-```js
+```javascript
 ...
 "Role": {
   "dataSource": "db",
@@ -400,11 +313,14 @@ To expose a model over REST, set the `public` property to true in `/server/mode
 
 ### Hiding methods and REST endpoints
 
-If you don't want to expose certain create, retrieve, update, and delete operations, you can easily hide them by calling [`disableRemoteMethod()`](https://apidocs.strongloop.com/loopback/#model-disableremotemethod) on the model. For example, following the previous example, by convention custom model code would go in the file `common/models/location.js`.  You would add the following lines to "hide" one of the predefined remote methods:
+If you don't want to expose certain create, retrieve, update, and delete operations, you can easily hide them by calling 
+[`disableRemoteMethod()`](https://apidocs.strongloop.com/loopback/#model-disableremotemethod) on the model. 
+For example, following the previous example, by convention custom model code would go in the file `common/models/location.js`.
+You would add the following lines to "hide" one of the predefined remote methods:
 
 **common/models/location.js**
 
-```js
+```javascript
 var isStatic = true;
 MyModel.disableRemoteMethod('deleteById', isStatic);
 ```
@@ -415,20 +331,21 @@ For a method on the prototype object, such as `updateAttributes()`:
 
 **common/models/location.js**
 
-```js
+```javascript
 var isStatic = false;
 MyModel.disableRemoteMethod('updateAttributes', isStatic);
 ```
 
 {% include important.html content="
 
-Be sure to call `disableRemoteMethod()` on your own custom model, not one of the built-in models; in the example below, for instance, the calls are `MyUser.disableRemoteMethod()` _not_ `User.disableRemoteMethod()`.
+Be sure to call `disableRemoteMethod()` on your own custom model, not one of the built-in models; in the example below, for instance,
+the calls are `MyUser.disableRemoteMethod()` _not_ `User.disableRemoteMethod()`.
 
 " %}
 
 Here's an example of hiding all methods of the `MyUser` model, except for `login` and `logout`:
 
-```js
+```javascript
 MyUser.disableRemoteMethod("create", true);
 MyUser.disableRemoteMethod("upsert", true);
 MyUser.disableRemoteMethod("updateAll", true);
@@ -460,30 +377,31 @@ You may want to only expose read-only operations on your model hiding all POST, 
 
 **common/models/model.js**
 
-```js
-Product.disableRemoteMethod('create', true); // Removes (POST) /products
-Product.disableRemoteMethod('upsert', true); // Removes (PUT) /products
-Product.disableRemoteMethod('deleteById', true); // Removes (DELETE) /products/:id
-Product.disableRemoteMethod("updateAll", true); // Removes (POST) /products/update
-Product.disableRemoteMethod("updateAttributes", false); // Removes (PUT) /products/:id
-Product.disableRemoteMethod('createChangeStream', true); // removes (GET|POST) /products/change-stream
+```javascript
+Product.disableRemoteMethod('create', true);				// Removes (POST) /products
+Product.disableRemoteMethod('upsert', true);				// Removes (PUT) /products
+Product.disableRemoteMethod('deleteById', true);			// Removes (DELETE) /products/:id
+Product.disableRemoteMethod("updateAll", true);				// Removes (POST) /products/update
+Product.disableRemoteMethod("updateAttributes", false);		// Removes (PUT) /products/:id
+Product.disableRemoteMethod('createChangeStream', true);	// removes (GET|POST) /products/change-stream
 ```
 
 ### Hiding endpoints for related models
 
-To disable a REST endpoints for related model methods, use [disableRemoteMethod()](https://apidocs.strongloop.com/loopback/#model-disableremotemethod).  
+To disable a REST endpoints for related model methods, use [disableRemoteMethod()](https://apidocs.strongloop.com/loopback/#model-disableremotemethod).
 
 {% include note.html content="
 
-For more information, see [Accessing related models](https://docs.strongloop.com/display/APIC/Accessing+related+models).
+For more information, see [Accessing related models](/doc/en/lb2/Accessing-related-models.html).
 
 " %}
 
-For example, if there are post and tag models, where a post hasMany tags, add the following code to `/common/models/post.js` to disable the remote methods for the related model and the corresponding REST endpoints: 
+For example, if there are post and tag models, where a post hasMany tags, add the following code to `/common/models/post.js` 
+to disable the remote methods for the related model and the corresponding REST endpoints: 
 
 **common/models/model.js**
 
-```js
+```javascript
 module.exports = function(Post) {
   Post.disableRemoteMethod('__get__tags', false);
   Post.disableRemoteMethod('__create__tags', false);
@@ -494,4 +412,5 @@ module.exports = function(Post) {
 
 ### Hiding properties
 
-To hide a property of a model exposed over REST, define a hidden property.  See [Model definition JSON file (Hidden properties)](Model-definition-JSON-file_9634289.html#ModeldefinitionJSONfile-Hiddenproperties).
+To hide a property of a model exposed over REST, define a hidden property.
+See [Model definition JSON file (Hidden properties)](/doc/en/lb2/Model-definition-JSON-file.html#ModeldefinitionJSONfile-Hiddenproperties).

--- a/pages/en/lb2/Extending-built-in-models.md
+++ b/pages/en/lb2/Extending-built-in-models.md
@@ -11,7 +11,7 @@ summary:
 
 ## Extending models using JSON
 
-When you create a model with the [model generator](https://docs.strongloop.com/display/APIC/Model+generator),
+When you create a model with the [model generator](/doc/en/lb2/Model-generator.html),
 you choose a base model, that is, the model that your model will "extend" and from which it will inherit methods and properties.
 The tool will set the  base property in the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) accordingly.
 For example, for a model that extends [PersistedModel](http://apidocs.strongloop.com/loopback/#persistedmodel):

--- a/pages/en/lb2/Fields-filter.md
+++ b/pages/en/lb2/Fields-filter.md
@@ -23,7 +23,7 @@ You can also use [stringified JSON format](/doc/en/lb2/Querying-data.html#Queryi
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/Fields-filter.md
+++ b/pages/en/lb2/Fields-filter.md
@@ -36,7 +36,6 @@ Where:
 
 * _propertyName_ is the name of the property (field) to include or exclude.
 * <true|false> signifies either `true` or `false` Boolean literal. Use `true` to include the property or `false` to exclude it from results.
-    You can also use 1 for true and 0 for false.
 
 By default, queries return all model properties in results. However, if you specify at least one fields filter with a value of `true`,
 then by default the query will include **only** those you specifically include with filters.

--- a/pages/en/lb2/HasAndBelongsToMany-relations.md
+++ b/pages/en/lb2/HasAndBelongsToMany-relations.md
@@ -22,7 +22,7 @@ The tool will then modify the [model definition JSON file](/doc/en/lb2/Model-de
 Use `slc loopback:relation` to create a relation between two models. The tool will prompt you to enter the name of the model, the name of related model, and other required information.
 The tool will then modify the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) (for example, `common/models/customer.json`) accordingly.
 
-For more information, see [Relation generator](https://docs.strongloop.com/display/APIC/Relation+generator).
+For more information, see [Relation generator](/doc/en/lb2/Relation-generator.html).
 
 {% include image.html file="9830483.png" alt="" %}
 

--- a/pages/en/lb2/HasMany-relations.md
+++ b/pages/en/lb2/HasMany-relations.md
@@ -29,7 +29,7 @@ Use `slc loopback:relation` to create a relation between two models.
 The tool will prompt you to enter the name of the model, the name of related model, and other required information.
 The tool will then modify the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) (for example, `common/models/customer.json`) accordingly.
 
-For more information, see [Relation generator](https://docs.strongloop.com/display/APIC/Relation+generator).
+For more information, see [Relation generator](/doc/en/lb2/Relation-generator.html).
 
 For example, here is the model JSON file for the customer model in [loopback-example-relations](https://github.com/strongloop/loopback-example-relations):
 

--- a/pages/en/lb2/HasManyThrough-relations.md
+++ b/pages/en/lb2/HasManyThrough-relations.md
@@ -30,7 +30,7 @@ Use `slc loopback:relation` to create a relation between two models.
 The tool will prompt you to enter the name of the model, the name of related model, and other required information.
 The tool will then modify the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) (for example, `common/models/customer.json`) accordingly.
 
-For more information, see [Relation generator](https://docs.strongloop.com/display/APIC/Relation+generator).
+For more information, see [Relation generator](/doc/en/lb2/Relation-generator.html).
 
 To create a hasManyThrough relation, respond with **Yes** to the prompt for a "through" model, then specify the model:
 

--- a/pages/en/lb2/HasOne-relations.md
+++ b/pages/en/lb2/HasOne-relations.md
@@ -24,7 +24,7 @@ Use `slc loopback:relation` to create a relation between two models.
 The tool will prompt you to enter the name of the model, the name of related model, and other required information.
 The tool will then modify the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) (for example, `common/models/customer.json`) accordingly.
 
-For more information, see [Relation generator](https://docs.strongloop.com/display/APIC/Relation+generator).
+For more information, see [Relation generator](/doc/en/lb2/Relation-generator.html).
 
 For example, consider two models: supplier and account.
 

--- a/pages/en/lb2/Include-filter.md
+++ b/pages/en/lb2/Include-filter.md
@@ -31,7 +31,7 @@ You can also use [stringified JSON format](/doc/en/lb2/Querying-data.html#Query
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/Limit-filter.md
+++ b/pages/en/lb2/Limit-filter.md
@@ -13,7 +13,7 @@ A _limit_ filter limits the number of records returned to the specified number
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/Managing-users.md
+++ b/pages/en/lb2/Managing-users.md
@@ -14,7 +14,7 @@ summary:
 Prerequisites
 
 * Install **[API Connect](https://developer.ibm.com/apiconnect/)** or **[StrongLoop](https://docs.strongloop.com/display/SL/Installing+StrongLoop)**.
-* Read [LoopBack core concepts](https://docs.strongloop.com/display/APIC/LoopBack+core+concepts).
+* Read [LoopBack core concepts](/doc/en/lb2/LoopBack-core-concepts.html).
 
 " %}
 
@@ -41,7 +41,7 @@ LoopBack's built-in [User](http://apidocs.strongloop.com/loopback/#user-new-user
 **IMPORTANT**
 
 You must create your own custom model (named something other than \"User,\" for example \"Customer\" or \"Client\")
-that [extends the built-in User model](https://docs.strongloop.com/display/APIC/Extending+built-in+models) rather than use the built-in User model directly.
+that [extends the built-in User model](/doc/en/lb2/Extending-built-in-models.html) rather than use the built-in User model directly.
 The built-in User model provides a great deal of commonly-used functionality that you can use via your custom model.
 
 " %}

--- a/pages/en/lb2/Managing-users.md
+++ b/pages/en/lb2/Managing-users.md
@@ -161,7 +161,7 @@ The above ACL denies all operations to everyone, then selectively allows:
 You cannot directly modify built-in models such as the User model with the ACL generator `apic loopback:acl`.
 
 However, you can create a custom model that extends the built-in User model,
-then use the [ACL generator](https://docs.strongloop.com/display/APIC/ACL+generator) to define access controls that are added to those of the default User model.
+then use the [ACL generator](/doc/en/lb2/ACL-generator.html) to define access controls that are added to those of the default User model.
 For example, you could create a Customer or Client model that [extends the built-in User model](/doc/en/lb2/Extending-built-in-models.html),
 and then modify that model's ACL with `apic loopback:acl`.
 Note that since a model doesn't inherit ACLs from its base model, you must define ACLs for the new custom model.

--- a/pages/en/lb2/Memory-connector.md
+++ b/pages/en/lb2/Memory-connector.md
@@ -33,7 +33,7 @@ You can persist data between application restarts using the `file` property. See
 
 ## Creating a data source
 
-By default, an application created with the [Application generator](https://docs.strongloop.com/display/APIC/Application+generator) has a memory data source defined; for example:
+By default, an application created with the [Application generator](/doc/en/lb2/Application-generator.html) has a memory data source defined; for example:
 
 **/server/datasources.json**
 
@@ -44,7 +44,7 @@ By default, an application created with the [Application generator](https://docs
 }
 ```
 
-Use the [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to add a new memory data source to your application.
+Use the [Data source generator](/doc/en/lb2/Data-source-generator.html) to add a new memory data source to your application.
 
 ### Memory connector properties
 

--- a/pages/en/lb2/Middleware-generator.md
+++ b/pages/en/lb2/Middleware-generator.md
@@ -10,12 +10,12 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
-Then you must run the command from the root directory of the application."
-%}
+Then you must run the command from the root directory of the application.
+" %}
 
-### SYNOPSIS
+### Synopsis
 
 Adds a new middleware configuration to an existing LoopBack application.
 
@@ -26,83 +26,72 @@ If you're adding third-party middleware, you must install the middleware package
 " %}
 
 ```shell
-[slc | apic] loopback:middleware [options] [<name>]
+$ [slc | apic] loopback:middleware [options] [<name>]
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### ARGUMENTS
+### Arguments
 
-You can optionally provide the name of the middleware function to create as an argument.  If you do, the tool will use that as the default when it prompts for the name.
+You can optionally provide the name of the middleware function to create as an argument. 
+If you do, the tool will use that as the default when it prompts for the name.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for:
 
-*   Name of the new middleware function.  If you supplied a name on the command-line, just hit Enter to use it.
-*   Phase when the middleware function will be invoked.  You can select any of the predefined phases or a custom phase. For more information about middleware phases, see [Defining middleware](Defining-middleware.html).
-*   Sub-phase when the middleware function will be invoked (before, regular, or after).
-*   Paths (routes) that will invoke the middleware function.
-*   Configuration parameters in JSON format.
+* Name of the new middleware function.  If you supplied a name on the command-line, just hit Enter to use it.
+* Phase when the middleware function will be invoked.  You can select any of the predefined phases or a custom phase.
+  For more information about middleware phases, see [Defining middleware](/doc/en/lb2/Defining-middleware.html).
+* Sub-phase when the middleware function will be invoked (before, regular, or after).
+* Paths (routes) that will invoke the middleware function.
+* Configuration parameters in JSON format.
 
-### OUTPUT
+### Output
 
-The tools adds the specified middleware to the application's [`middleware.json`](middleware.json.html) file
+The tools adds the specified middleware to the application's [`middleware.json`](/doc/en/lb2/middleware.json.html) file
 
 ### EXAMPLES
 
 Here is an example to add a middleware to an existing phase.
 
-```js
-$ apic loopback: middleware
-
-  ?
-  Enter the middleware name : m1 ?
-  Select the phase
-for m1: 5\.routes ?
-  Select the sub phase
-for m1: 1\.before
-Specify paths
-for m1:
-  Enter an empty path name when done. ?
-  Path uri : /x
+```shell
+$ apic loopback:middleware
+? Enter the middleware name: m1
+? Select the phase for m1: 5. routes
+? Select the sub phase for m1: 1. before
+Specify paths for m1:
+Enter an empty path name when done.
+? Path uri: /x
 Let's add another path.
-Enter an empty path name when done. ?
-  Path uri :
-  ?
-  Configuration parameters in JSON format : {
-    "a": 1
-  }
+Enter an empty path name when done.
+? Path uri:
+? Configuration parameters in JSON format: {"a": 1}
 Middleware m1 is added to phase routes.
 ```
 
 The following is an example to add a middleware to a custom phase.
 
-```js
-$ apic loopback: middleware ?
-  Enter the middleware name : m2 ?
-  Select the phase
-for m2: (custom phase) ?
-  Enter the phase name : p1 ?
-  Select the phase before which the new one will be inserted : 4\.parse ?
-  Select the sub phase
-for m2: 2\.regular
-Specify paths
-for m2:
-  Enter an empty path name when done. ?
-  Path uri : /a
-Let 's add another path. ?
-  Configuration parameters in JSON format : {
-    "x": "2"
-  }
+```shell
+$ apic loopback:middleware
+? Enter the middleware name: m2
+? Select the phase for m2: (custom phase)
+? Enter the phase name: p1
+? Select the phase before which the new one will be inserted: 4. parse
+? Select the sub phase for m2: 2. regular
+Specify paths for m2:
+Enter an empty path name when done.
+? Path uri: /a
+Let's add another path.
+? Configuration parameters in JSON format: {"x": "2"}
 Middleware m2 is added to phase p1.
 ```

--- a/pages/en/lb2/Model-definition-JSON-file.md
+++ b/pages/en/lb2/Model-definition-JSON-file.md
@@ -20,14 +20,14 @@ summary:
 
 ## Overview
 
-The LoopBack [Model generator](https://docs.strongloop.com/display/APIC/Model+generator) creates a model JSON file for each model in either the `server/models`
+The LoopBack [Model generator](/doc/en/lb2/Model-generator.html) creates a model JSON file for each model in either the `server/models`
 or the `common/models` directory (depending on your response to the generator's prompts).
 The file is named `_model-name_.json`, where _`model-name`_ is the model name; for example, `customer.json`.
 The model JSON file defines models, relations between models, and access to models. 
 
 {% include important.html content="
 
-The LoopBack [model generator](https://docs.strongloop.com/display/APIC/Model+generator) automatically converts camel-case model names (for example MyModel)
+The LoopBack [model generator](/doc/en/lb2/Model-generator.html) automatically converts camel-case model names (for example MyModel)
 to lowercase dashed names (my-model). For example, if you create a model named \"FooBar\" with the model generator, it creates files `foo-bar.json` and `foo-bar.js` in `common/models`.
 However, the model name (\"FooBar\") will be preserved via the model's name property.
 

--- a/pages/en/lb2/Model-definition-JSON-file.md
+++ b/pages/en/lb2/Model-definition-JSON-file.md
@@ -258,7 +258,11 @@ The properties key defines one or more  properties, each of which is an object 
 
 Each model property can have the properties described in the following table. Only the `type` property is required; for properties with only a `type`, you can use the following shorthand:
 
-"_propertyName_": "_type_"
+
+```javascript
+"propertyName": "type"
+```
+
 For example:
 
 ```javascript
@@ -670,7 +674,9 @@ For example:
 ## Relations
 
 The `relations` key defines relationships between models through a JSON object.
-Each key in this object is the name of a related model, and the value is a JSON object as described in the table below. For example:
+Each key in this object is the name of a related model, and the value is a JSON object as described in the table below.
+
+For example:
 
 ```javascript
 ...

--- a/pages/en/lb2/Model-definition-JSON-file.md
+++ b/pages/en/lb2/Model-definition-JSON-file.md
@@ -11,12 +11,12 @@ summary:
 
 **See also**:
 
-* [Creating models](https://docs.strongloop.com/display/APIC/Creating+models)
-* [Customizing models](https://docs.strongloop.com/display/APIC/Customizing+models)
-* [Creating model relations](https://docs.strongloop.com/display/APIC/Creating+model+relations)
-* [Querying data](https://docs.strongloop.com/display/APIC/Querying+data)
+* [Creating models](/doc/en/lb2/Creating-models.html)
+* [Customizing models](/doc/en/lb2/Customizing-models.html)
+* [Creating model relations](/doc/en/lb2/Creating-model-relations.html)
+* [Querying data](/doc/en/lb2/Querying-data.html)
 * [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html)
-* [PersistedModel REST API](https://docs.strongloop.com/display/APIC/PersistedModel+REST+API)
+* [PersistedModel REST API](/doc/en/lb2/PersistedModel-REST-API.html)
 
 ## Overview
 

--- a/pages/en/lb2/Model-generator.md
+++ b/pages/en/lb2/Model-generator.md
@@ -10,12 +10,12 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
 Then you must run the command from the root directory of the application."
 %}
 
-### SYNOPSIS
+### Synopsis
 
 Adds a new model to a LoopBack application.
 
@@ -29,33 +29,44 @@ Or:
 slc loopback:model
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### ARGUMENTS
+### Arguments
 
-You can optionally provide the name of the model to create as an argument to the command.  If you do, the tool will use that as the default when it prompts for the name.
+You can optionally provide the name of the model to create as an argument to the command. 
+If you do, the tool will use that as the default when it prompts for the name.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for:
 
-*   Name of the model.  If you supplied a name on the command-line, just hit Enter to use it.
-*   Data source to which to attach the model.  The tool will list all data sources defined in the application's [`datasources.json`](datasources.json.html) file. By default, only the [Memory connector](Memory-connector.html) data source exists.  Add additional data sources using the [Data source generator](Data-source-generator.html).
-*   Whether you want to expose the model over a REST API.  If the model is exposed over REST, then all the standard create, read, update, and delete (CRUD) operations are available via REST endpoints; see [PersistedModel REST API](PersistedModel-REST-API.html) for more information.  You can also add your own custom remote methods that can be called via REST operations; see [Remote methods](Remote-methods.html).
-*   If you choose to expose the model over REST, the custom plural form of the model.  By default, the LoopBack uses the standard English plural of the word.  The plural form is used in the REST API; for example `http:``//localhost:3000/api/locations`.
-*   Whether you want to create the model on the server only or for both server and client LoopBack APIs (see [LoopBack in the client](LoopBack-in-the-client.html) for more information on the LoopBack client API).
+* Name of the model.  
+  If you supplied a name on the command-line, just hit Enter to use it.
+* Data source to which to attach the model. 
+  The tool will list all data sources defined in the application's [`datasources.json`](/doc/en/lb2/datasources.json.html) file.
+  By default, only the [Memory connector](/doc/en/lb2/Memory-connector.html) data source exists. 
+  Add additional data sources using the [Data source generator](/doc/en/lb2/Data-source-generator.html).
+* Whether you want to expose the model over a REST API.
+  If the model is exposed over REST, then all the standard create, read, update, and delete (CRUD) operations are available via REST endpoints.
+  See [PersistedModel REST API](/doc/en/lb2/PersistedModel-REST-API.html) for more information.
+  You can also add your own custom remote methods that can be called via REST operations; see [Remote methods](/doc/en/lb2/Remote-methods.html).
+* If you choose to expose the model over REST, the custom plural form of the model.  
+  By default, the LoopBack uses the standard English plural of the word.  
+  The plural form is used in the REST API; for example `http:``//localhost:3000/api/locations`.
+* Whether you want to create the model on the server only or for both server and client LoopBack APIs
+  (see [LoopBack in the client](/doc/en/lb2/LoopBack-in-the-client.html) for more information on the LoopBack client API).
 
-Then, the tool will invoke the [Property generator](Property-generator.html) and prompt you to enter model properties
+Then, the tool will invoke the [Property generator](/doc/en/lb2/Property-generator.html) and prompt you to enter model properties
 
-### OUTPUT
+### Output
 
-Depending your response to the last prompt, the tool will create a new file defining the model; either `/common/models/_model-name_.json` (for use by client and server) or `/server/models/_model-name_.json` (server only).  See [Model definition JSON file](Model-definition-JSON-file.html) for details.
+Depending your response to the last prompt, the tool will create a new file defining the model; either `/common/models/_model-name_.json` (for use by client and server) or `/server/models/_model-name_.json` (server only).  See [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) for details.

--- a/pages/en/lb2/MongoDB-connector.md
+++ b/pages/en/lb2/MongoDB-connector.md
@@ -40,7 +40,7 @@ This will install the module from npm and add it as a dependency to the applicat
 
 ## Creating a MongoDB data source 
 
-Use the [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to add a MongoDB data source to your application.
+Use the [Data source generator](/doc/en/lb2/Data-source-generator.html) to add a MongoDB data source to your application.
 The entry in the application's `/server/datasources.json` will look like this:
 
 **/server/datasources.json**

--- a/pages/en/lb2/MySQL-connector.md
+++ b/pages/en/lb2/MySQL-connector.md
@@ -34,7 +34,7 @@ This will install the module from npm and add it as a dependency to the applicat
 
 ## Creating a MySQL data source
 
-Use the [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to add a MySQL data source to your application.
+Use the [Data source generator](/doc/en/lb2/Data-source-generator.html) to add a MySQL data source to your application.
 The entry in the application's `/server/datasources.json` will look like this:
 
 **/server/datasources.json**

--- a/pages/en/lb2/Order-filter.md
+++ b/pages/en/lb2/Order-filter.md
@@ -33,7 +33,7 @@ Default ordering can be configured in [default scope](/doc/en/lb2/Model-definiti
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/PersistedModel-REST-API.md
+++ b/pages/en/lb2/PersistedModel-REST-API.md
@@ -19,12 +19,12 @@ to a LoopBack app running on the server. If a LoopBack app is running on `localh
 
 **See also**:
 
-* [Creating models](https://docs.strongloop.com/display/APIC/Creating+models)
-* [Customizing models](https://docs.strongloop.com/display/APIC/Customizing+models)
-* [Creating model relations](https://docs.strongloop.com/display/APIC/Creating+model+relations)
-* [Querying data](https://docs.strongloop.com/display/APIC/Querying+data)
+* [Creating models](/doc/en/lb2/Creating-models.html)
+* [Customizing models](/doc/en/lb2/Customizing-models.html)
+* [Creating model relations](/doc/en/lb2/Creating-model-relations.html)
+* [Querying data](/doc/en/lb2/Querying-data.html)
 * [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html)
-* [PersistedModel REST API](https://docs.strongloop.com/display/APIC/PersistedModel+REST+API)
+* [PersistedModel REST API](/doc/en/lb2/PersistedModel-REST-API.html)
 
 ## Overview
 

--- a/pages/en/lb2/PostgreSQL-connector.md
+++ b/pages/en/lb2/PostgreSQL-connector.md
@@ -33,7 +33,7 @@ This will install the module from npm and add it as a dependency to the applicat
 
 ## Creating a data source
 
-Use the [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to add a PostgreSQL data source to your application. 
+Use the [Data source generator](/doc/en/lb2/Data-source-generator.html) to add a PostgreSQL data source to your application. 
 
 The entry in the application's `server/datasources.json` will look like this:
 

--- a/pages/en/lb2/Preparing-for-deployment.md
+++ b/pages/en/lb2/Preparing-for-deployment.md
@@ -26,7 +26,7 @@ has two kinds of configuration files in the server directory that you use to con
 Set `NODE_ENV` to a string reflecting the host environment, for example "development" or "production".
 
 To get ready for production, create at least two copies of these files: 
-`config.production.json` and `config.development.json`;
+`config.production.json` and `config.development.json`; and
 `datasources.production.json` and `datasources.development.json`. 
 
 You can create additional files (for example, `config.staging.json`) if desired.
@@ -96,6 +96,20 @@ var path = require('path'),
 fs = require("fs");
 exports.privateKey = fs.readFileSync(path.join(__dirname, './private/privatekey.pem')).toString();
 exports.certificate = fs.readFileSync(path.join(__dirname, './private/certificate.pem')).toString();
+```
+
+### Configure the app 
+
+```javascript
+{
+  "restApiRoot": "/api",
+  "host": "0.0.0.0",
+  "port": 3000,
+  "url": "https://localhost:3000/",
+  "swagger": {
+    "protocol": "https"
+  }
+}
 ```
 
 ### Create the HTTPS server

--- a/pages/en/lb2/Preparing-for-deployment.md
+++ b/pages/en/lb2/Preparing-for-deployment.md
@@ -15,7 +15,7 @@ When you move from deployment to production or staging, you typically want to ch
 (or even the in-memory data store) to a production database where your live application data will reside.
 Additionally, you may want to change application properties such as host name and port number.
 
-By default, a LoopBack application created with the [application generator](https://docs.strongloop.com/display/APIC/Application+generator)
+By default, a LoopBack application created with the [application generator](/doc/en/lb2/Application-generator.html)
 has two kinds of configuration files in the server directory that you use to configure production settings:
 
 * [`config.json`](/doc/en/lb2/config.json.html) containing general application configuration.

--- a/pages/en/lb2/Project-layout-reference.md
+++ b/pages/en/lb2/Project-layout-reference.md
@@ -133,7 +133,7 @@ All your model JSON and JavaScript files go in the `/common/models` directory.
 
 {% include important.html content="
 
-The LoopBack [model generator](https://docs.strongloop.com/display/APIC/Model+generator) automatically converts camel-case model names (for example MyModel) to lowercase dashed names (my-model).
+The LoopBack [model generator](/doc/en/lb2/Model-generator.html) automatically converts camel-case model names (for example MyModel) to lowercase dashed names (my-model).
 For example, if you create a model named \"FooBar\" with the model generator, it creates files `foo-bar.json` and `foo-bar.js` in `common/models`. 
 However, the model name (\"FooBar\") will be preserved via the model's name property.
 

--- a/pages/en/lb2/Property-generator.md
+++ b/pages/en/lb2/Property-generator.md
@@ -10,31 +10,31 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
 Then you must run the command from the root directory of the application."
 %}
 
-### SYNOPSIS
+### Synopsis
 
 Adds a new property to an existing LoopBack model.
 
 ```shell
-[slc | apic] loopback:property [options]
+$ [slc | apic] loopback:property [options]
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for the:
 
@@ -43,6 +43,6 @@ The tool will prompt you for the:
 *   Data type of the property.
 *   Whether the property is required.
 
-### OUTPUT
+### Output
 
-The tool modifies the [Model definition JSON file](Model-definition-JSON-file.html) to add the specified property to the specified model.
+The tool modifies the [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) to add the specified property to the specified model.

--- a/pages/en/lb2/Push-connector.md
+++ b/pages/en/lb2/Push-connector.md
@@ -22,7 +22,7 @@ This will install the module from npm and add it as a dependency to the applicat
 
 ## Creating a push data source
 
-Create a new push data source with the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator):
+Create a new push data source with the [data source generator](/doc/en/lb2/Data-source-generator.html):
 
 ```shell
 $ apic create --type datasource

--- a/pages/en/lb2/Push-notifications-using-Android-SDK.md
+++ b/pages/en/lb2/Push-notifications-using-Android-SDK.md
@@ -17,7 +17,7 @@ summary:
 ## Overview
 
 This article provides information on creating Android apps that can get push notifications from a LoopBack application.
-See [Push notifications](https://docs.strongloop.com/display/APIC/Push+notifications) for information on creating the corresponding LoopBack server application.
+See [Push notifications](/doc/en/lb2/Push-notifications.html) for information on creating the corresponding LoopBack server application.
 
 To enable an Android app to receive LoopBack push notifications:
 
@@ -33,7 +33,7 @@ To enable an Android app to receive LoopBack push notifications:
 
 Before you start developing your application make sure you've performed all the prerequisite steps outlined in this section.
 
-* **Download the [LoopBack Android SDK](https://docs.strongloop.com/display/APIC/Android+SDK)**
+* **Download the [LoopBack Android SDK](/doc/en/lb2/Android-SDK.html)**
 * **Install [Eclipse development tools](http://developer.android.com/sdk/index.html) (ADT)**
 
 ### Configure Android Development Tools
@@ -155,7 +155,7 @@ Then follow these steps to run the app:
       </tbody>
     </table>
 
-7.  Run the [LoopBack server application](https://docs.strongloop.com/display/APIC/Push+notifications) you set up earlier.
+7.  Run the [LoopBack server application](/doc/en/lb2/Push-notifications.html) you set up earlier.
     If you didn't set the appName in the server application's `config.js` earlier, do it now.
     Set it to "**com.google.android.gcm.demo.app.DemoActivity**".
 8.  Click the green **Run** button in the toolbar to run the application. Run it as an Android application.
@@ -206,7 +206,7 @@ Replace `server-api-key` with the API key you obtained in [Get your Google Clo
 
 ## Prepare your own Android project
 
-Follow the instructions in [Android SDK documentation](https://docs.strongloop.com/display/APIC/Android+SDK) to add LoopBack Android SDK to your Android project.
+Follow the instructions in [Android SDK documentation](/doc/en/lb2/Android-SDK.html) to add LoopBack Android SDK to your Android project.
 
 Follow the instructions in Google's [Implementing GCM Client guide](http://developer.android.com/google/gcm/client.html) for setting up Google Play Services in your project.
 
@@ -261,7 +261,7 @@ Once you have ensured the device provides Google Play Services, the app can reg
 Rather than register with GCM every time the app starts, simply store and retrieve the registration ID (device token).
 The `LocalInstallation` class in the LoopBack SDK handles these details for you.
 
-For more information on LocallInstallation, see [Working with the LocalInstallation class](https://docs.strongloop.com/display/APIC/Working+with+the+LocalInstallation+class).
+For more information on LocallInstallation, see [Working with the LocalInstallation class](/doc/en/lb2/Working-with-the-LocalInstallation-class.html).
 
 The example `updateRegistration()` method does the following:
 

--- a/pages/en/lb2/Querying-data.md
+++ b/pages/en/lb2/Querying-data.md
@@ -11,7 +11,7 @@ summary:
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/Redis-connector.md
+++ b/pages/en/lb2/Redis-connector.md
@@ -38,7 +38,7 @@ This will install the module and add it as a dependency to the application's [`
 
 ## Creating a Redis data source
 
-Use the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to add a Redis data source to your application.
+Use the [data source generator](/doc/en/lb2/Data-source-generator.html) to add a Redis data source to your application.
 When prompted for the connector, choose **other,** then enter **redis** for the connector name.
 The entry in the application's `server/datasources.json` will look like this:
 

--- a/pages/en/lb2/Refresh-definitions-command.md
+++ b/pages/en/lb2/Refresh-definitions-command.md
@@ -10,7 +10,7 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
 Then you must run the command from the root directory of the application."
 %}
@@ -18,11 +18,11 @@ Then you must run the command from the root directory of the application."
 Usage:
 
 ```shell
-apic loopback:refresh
+$ apic loopback:refresh
 ```
 
 Generate a product and an API definition from the LoopBack application models
 
-```
-  $ apic loopback:refresh
+```shell
+$ apic loopback:refresh
 ```

--- a/pages/en/lb2/Relation-REST-API.md
+++ b/pages/en/lb2/Relation-REST-API.md
@@ -370,7 +370,3 @@ The API returns the following JSON:
     ]
   }, ... ]
 ```
-
-### Errors
-
-None

--- a/pages/en/lb2/Relation-generator.md
+++ b/pages/en/lb2/Relation-generator.md
@@ -10,54 +10,54 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
 Then you must run the command from the root directory of the application."
 %}
 
 The models involved in the relation must also exist before running this generator.
 
-### SYNOPSIS
+### Synopsis
 
-Creates a new [model relation](Creating+model+relations.html) in a LoopBack application.
+Creates a new [model relation](/doc/en/lb2/Creating-model-relations.html) in a LoopBack application.
 
 ```shell
-[slc | apic] loopback:relation [options]
+$ [slc | apic] loopback:relation [options]
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for:
 
-*   Name of the model to create the relationship from.
-*   Relation type:
- - ([HasMany](HasMany+relations.html)
- - [BelongsTo](BelongsTo+relations.html)
- - [HasAndBelongsToMany](HasAndBelongsToMany+relations.html)
- - [HasOne](HasOne+relations.html).
-*   Name of the model to create a relationship with.
-*   Name for the relation (property name).
+* Name of the model to create the relationship from.
+* Relation type:
+  * [HasMany](/doc/en/lb2/HasMany-relations.html)
+  * [BelongsTo](/doc/en/lb2/BelongsTo-relations.html)
+  * [HasAndBelongsToMany](/doc/en/lb2/HasAndBelongsToMany-relations.html)
+  * [HasOne](/doc/en/lb2/HasOne-relations.html).
+* Name of the model to create a relationship with.
+* Name for the relation (property name).
 
 {% include important.html content="
 
 The name of the relation must be different than a property it references.
 " %}
 
-*   Custom foreign key (optional)
-*   Whether a "through" model is required.  Repy "Y" to create a [HasManyThrough relations](HasManyThrough+relations.html). 
-*   Name of the "through" model, if appropriate.
+* Custom foreign key (optional)
+* Whether a "through" model is required.  Repy "Y" to create a [HasManyThrough relations](/doc/en/lb2/HasManyThrough-relations.html). 
+* Name of the "through" model, if appropriate.
 
-### OUTPUT
+### Output
 
-Updates the [Model definition JSON files](Model-definition-JSON-file.html) for the models involved in the relation.
+Updates the [Model definition JSON files](/doc/en/lb2/Model-definition-JSON-file.html) for the models involved in the relation.

--- a/pages/en/lb2/Remote-connector.md
+++ b/pages/en/lb2/Remote-connector.md
@@ -29,7 +29,7 @@ This will install the module and add it as a dependency to the application's [`
 
 ## Creating an remote data source
 
-Create a new remote data source with the [datasource generator](https://docs.strongloop.com/display/APIC/Data+source+generator):
+Create a new remote data source with the [datasource generator](/doc/en/lb2/Data-source-generator.html):
 
 ```shell
 $ apic create --type datasource

--- a/pages/en/lb2/Remote-method-generator.md
+++ b/pages/en/lb2/Remote-method-generator.md
@@ -10,60 +10,45 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
 Then you must run the command from the root directory of the application."
 %}
 
-### SYNOPSIS
+### Synopsis
 
 Adds a new remote method to an existing application.
 
 ```shell
-[slc | apic] loopback:remote-method [options] [<modelName>] [<methodName>]
+$ [slc | apic] loopback:remote-method [options] [<modelName>] [<methodName>]
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### ARGUMENTS
+### Arguments
 
 All arguments are optional.
 
-<table>
-  <tbody>
-    <tr>
-      <th>Argument</th>
-      <th>Description</th>
-      <th>Type</th>
-    </tr>
-    <tr>
-      <td>modelName</td>
-      <td>Name of the model</td>
-      <td>String</td>
-    </tr>
-    <tr>
-      <td>methodName</td>
-      <td>Name of the remote method</td>
-      <td>String</td>
-    </tr>
-  </tbody>
-</table>
+| Argument      | Description               | Type   |
+|---------------|---------------------------|--------|
+| modelName     | Name of the model         | String |
+| methodName    | Name of the remote method | String |
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for:
 
-*   Name of the model to which to add the remote method.
-*   Name of the remote method.
-*   Whether the method is static (or an instance method).
-*   Description of the method.
-*   One or more HTTP endpoints, with corresponding accept and return arguments and their types.
+* Name of the model to which to add the remote method.
+* Name of the remote method.
+* Whether the method is static (or an instance method).
+* Description of the method.
+* One or more HTTP endpoints, with corresponding accept and return arguments and their types.

--- a/pages/en/lb2/Remote-methods.md
+++ b/pages/en/lb2/Remote-methods.md
@@ -24,7 +24,7 @@ Use a remote method to perform operations not provided by LoopBack's [standar
 
 {% include note.html content="
 
-The easiest way to define a remote method is by using the command-line [remote method generator](https://docs.strongloop.com/display/APIC/Remote+method+generator).
+The easiest way to define a remote method is by using the command-line [remote method generator](/doc/en/lb2/Remote-method-generator.html).
 
 For an introductory example of defining a remote method, see [Extend your API](https://docs.strongloop.com/display/LB/Extend+your+API) in Getting Started.
 
@@ -35,11 +35,11 @@ For an introductory example of defining a remote method, see [Extend your API](h
 To define a remote method:
 
 1.  Edit the [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) in `/common/models` directory; for example, to attach a remote method to the Person model, edit `/common/models/person.js`.
-    If you created the model with the [Model generator](https://docs.strongloop.com/display/APIC/Model+generator), then this file will already exist.
+    If you created the model with the [Model generator](/doc/en/lb2/Model-generator.html), then this file will already exist.
 
     {% include important.html content="
 
-    The LoopBack [model generator](https://docs.strongloop.com/display/APIC/Model+generator) automatically converts camel-case model names (for example MyModel) to lowercase dashed names (my-model).
+    The LoopBack [model generator](/doc/en/lb2/Model-generator.html) automatically converts camel-case model names (for example MyModel) to lowercase dashed names (my-model).
     For example, if you create a model named \"FooBar\" with the model generator, it creates files `foo-bar.json` and `foo-bar.js` in `common/models`. 
     However, the model name (\"FooBar\") will be preserved via the model's name property.
 
@@ -541,7 +541,7 @@ So a GET request to `http://localhost:3000/api/people/sayhi?msg=LoopBack%20deve
 
 ## Adding ACLs to remote methods
 
-To constrain access to custom remote methods, use the [ACL generator](https://docs.strongloop.com/display/APIC/ACL+generator) in the same way you control access to any model API.
+To constrain access to custom remote methods, use the [ACL generator](/doc/en/lb2/ACL-generator.html) in the same way you control access to any model API.
 The access type for custom remote methods is Execute.
 
 ### Basic use

--- a/pages/en/lb2/SOAP-connector.md
+++ b/pages/en/lb2/SOAP-connector.md
@@ -28,7 +28,7 @@ This will install the module from npm and add it as a dependency to the applicat
 
 ## Creating a data source
 
-Use the [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to add a SOAP data source to your application.
+Use the [Data source generator](/doc/en/lb2/Data-source-generator.html) to add a SOAP data source to your application.
 
 ```shell
 $ apic create --type datasource

--- a/pages/en/lb2/SQL-Server-connector.md
+++ b/pages/en/lb2/SQL-Server-connector.md
@@ -34,7 +34,7 @@ This will install the module from npm and add it as a dependency to the applicat
 
 ## Creating a SQL Server data source
 
-Use the [Data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to add a SQL Server data source to your application.
+Use the [Data source generator](/doc/en/lb2/Data-source-generator.html) to add a SQL Server data source to your application.
 The generator will add the following entry to the `/server/datasources.json` file:
 
 **/server/datasources.json**

--- a/pages/en/lb2/Skip-filter.md
+++ b/pages/en/lb2/Skip-filter.md
@@ -15,7 +15,7 @@ Use `offset` as an alias for `skip`.
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/Standard-project-structure.md
+++ b/pages/en/lb2/Standard-project-structure.md
@@ -41,11 +41,11 @@ All your model JSON and JavaScript files go in the `/common/models` directory.
     <tr>
       <td>
         <div style="width: 200px;">
-          <p><code><a href="https://docs.strongloop.com/display/APIC/package.json">package.json</a></code></p>
+          <p><code><a href="/doc/en/lb2/package.json.html">package.json</a></code></p>
         </div>
       </td>
       <td>
-        <p>Standard npm package specification. See <a href="https://docs.strongloop.com/display/APIC/package.json">package.json</a>.</p>
+        <p>Standard npm package specification. See <a href="/doc/en/lb2/package.json.html">package.json</a>.</p>
       </td>
       <td>N/A</td>
     </tr>
@@ -59,41 +59,42 @@ All your model JSON and JavaScript files go in the `/common/models` directory.
     </tr>
     <tr>
       <td><code>/boot</code> directory</td>
-      <td>Add scripts to perform initialization and setup. See <a href="https://docs.strongloop.com/display/APIC/Defining+boot+scripts">boot scripts</a>.</td>
+      <td>Add scripts to perform initialization and setup. See <a href="/doc/en/lb2/Events.html">boot scripts</a>.</td>
       <td>Scripts are automatically executed in alphabetical order.</td>
     </tr>
     <tr>
       <td><code><a href="https://docs.strongloop.com/display/LB/component-config.json">component-config.json</a></code></td>
-      <td>Specifies <a href="https://docs.strongloop.com/display/APIC/LoopBack+components">LoopBack components</a> to load.</td>
+      <td>Specifies <a href="/doc/en/lb2/LoopBack-components.html">LoopBack components</a> to load.</td>
       <td>Created by Strongloop tools only. Not used in API Connect.</td>
     </tr>
     <tr>
-      <td><code><a href="https://docs.strongloop.com/display/APIC/config.json">config.json</a></code></td>
-      <td>Application settings. See <a href="https://docs.strongloop.com/display/APIC/config.json">config.json</a>.</td>
+      <td><code><a href="/doc/en/lb2/config.json.html">config.json</a></code></td>
+      <td>Application settings. See <a href="/doc/en/lb2/config.json.html">config.json</a>.</td>
       <td><code>app.get('setting-name')</code></td>
     </tr>
     <tr>
-      <td><code><a href="https://docs.strongloop.com/display/APIC/datasources.json">datasources.json</a></code>&nbsp;</td>
-      <td>Data source configuration file. See <a href="https://docs.strongloop.com/display/APIC/datasources.json">datasources.json</a>. <span>For an example, see <a href="https://docs.strongloop.com/display/TRASH/Create+new+data+source">Create new data source</a></span><span>.</span></td>
+      <td><code><a href="/doc/en/lb2/datasources.json.html">datasources.json</a></code>&nbsp;</td>
+      <td>Data source configuration file. See <a href="/doc/en/lb2/datasources.json.html">datasources.json</a>. <span>For an example, see <a href="https://docs.strongloop.com/display/TRASH/Create+new+data+source">Create new data source</a></span><span>.</span></td>
       <td><code>app.datasources['datasource-name']</code></td>
     </tr>
     <tr>
-      <td><code><a href="https://docs.strongloop.com/display/APIC/middleware.json">middleware.json</a></code></td>
-      <td>Middleware definition file. For more information, see <a href="https://docs.strongloop.com/display/APIC/Defining+middleware">Defining middleware</a>.</td>
+      <td><code><a href="/doc/en/lb2/middleware.json.html">middleware.json</a></code></td>
+      <td>Middleware definition file. For more information, see <a href="/doc/en/lb2/Defining-middleware.html">Defining middleware</a>.</td>
       <td>N/A</td>
     </tr>
     <tr>
       <td><code>middleware.production.json</code></td>
-      <td>Middleware definition file with production configuration.&nbsp; See <a href="https://docs.strongloop.com/display/APIC/Preparing+for+deployment">Preparing for deployment</a>.</td>
+      <td>Middleware definition file with production configuration.&nbsp; See <a href="/doc/en/lb2/Preparing-for-deployment.html">Preparing for deployment</a>.</td>
       <td>&nbsp;</td>
     </tr>
     <tr>
       <td><code><a href="/doc/en/lb2/model-config.json.html">model-config.json</a></code></td>
-      <td>Model configuration file. See <a href="/doc/en/lb2/model-config.json.html">model-config.json</a>. <span>For more information, see </span><span>&nbsp;</span><a href="https://docs.strongloop.com/display/APIC/Connecting+models+to+data+sources">Connecting models to data sources</a><span>.</span></td>
+      <td>Model configuration file. See <a href="/doc/en/lb2/model-config.json.html">model-config.json</a>. <span>For more information,
+          see </span><span>&nbsp;</span><a href="/doc/en/lb2/Connecting-models-to-data-sources.html">Connecting models to data sources</a><span>.</span></td>
       <td>N/A</td>
     </tr>
     <tr>
-      <td><code><a href="https://docs.strongloop.com/display/APIC/server.js">server.js</a></code></td>
+      <td><code><a href="/doc/en/lb2/server.js.html">server.js</a></code></td>
       <td>Main application program file.</td>
       <td>&nbsp;N/A</td>
     </tr>
@@ -122,7 +123,7 @@ All your model JSON and JavaScript files go in the `/common/models` directory.
           <li><a href="/doc/en/lb2/Model-definition-JSON-file.html">Model definition JSON files</a>, by convention named <code><em>model-name</em>.json</code>; for example <code>customer.json</code>.</li>
           <li>Custom model scripts by convention named <code><em>model-name</em>.js</code>; for example, <code>customer.js</code>.</li>
         </ul>
-        <p>For more information, see <a href="/doc/en/lb2/Model-definition-JSON-file.html">Model definition JSON file</a> and<span> <a href="https://docs.strongloop.com/display/APIC/Customizing+models">Customizing models</a>.&nbsp; See note below.<br></span></p>
+        <p>For more information, see <a href="/doc/en/lb2/Model-definition-JSON-file.html">Model definition JSON file</a> and<span> <a href="/doc/en/lb2/Customizing-models.html">Customizing models</a>.&nbsp; See note below.<br></span></p>
       </td>
       <td>
         <p>Node:<br><code>myModel = app.models.myModelName</code></p>

--- a/pages/en/lb2/Standard-project-structure.md
+++ b/pages/en/lb2/Standard-project-structure.md
@@ -134,7 +134,7 @@ All your model JSON and JavaScript files go in the `/common/models` directory.
 
 {% include important.html content="
 
-The LoopBack [model generator](https://docs.strongloop.com/display/APIC/Model+generator)
+The LoopBack [model generator](/doc/en/lb2/Model-generator.html)
 automatically converts camel-case model names (for example MyModel) to lowercase dashed names (my-model).
 For example, if you create a model named \"FooBar\" with the model generator, it creates files `foo-bar.json` and `foo-bar.js` in `common/models`.
 However, the model name (\"FooBar\") will be preserved via the model's name property.

--- a/pages/en/lb2/Storage-connector.md
+++ b/pages/en/lb2/Storage-connector.md
@@ -21,7 +21,7 @@ This will install the module from npm and add it as a dependency to the applicat
 
 ## Creating a storage data source
 
-Create a new push data source with the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator):
+Create a new push data source with the [data source generator](/doc/en/lb2/Data-source-generator.html):
 
 ```shell
 $ apic create --type datasource
@@ -68,7 +68,7 @@ for example as shown in the [storage service example](https://github.com/strong
 
 ## Creating a storage model
 
-Use the [model generator](https://docs.strongloop.com/display/APIC/Model+generator) to create a new model, then edit the model.json file, 
+Use the [model generator](/doc/en/lb2/Model-generator.html) to create a new model, then edit the model.json file, 
 as shown in the [storage service example](https://github.com/strongloop/loopback-component-storage/blob/master/example-2.0/):
 
 **/server/models/container.json**

--- a/pages/en/lb2/Swagger-generator.md
+++ b/pages/en/lb2/Swagger-generator.md
@@ -10,41 +10,44 @@ summary:
 ---
 
 {% include important.html content="
-Before running this generator, you must create an application using the [Application generator](Application-generator.html).
+Before running this generator, you must create an application using the [Application generator](/doc/en/lb2/Application-generator.html).
 
-Then you must run the command from the root directory of the application."
-%}
+Then you must run the command from the root directory of the application.
+" %}
 
-### SYNOPSIS
+### Synopsis
 
-Creates a fully-functional application with an API defined using the [Swagger](http://swagger.io/) 2.0 specification.  For more information on Swagger, see [Swagger RESTful API Documentation Specification (version 2.0)](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).
+Creates a fully-functional application with an API defined using the [Swagger](http://swagger.io/) 2.0 specification.
+For more information on Swagger, see [Swagger RESTful API Documentation Specification (version 2.0)](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md).
 
 ```shell
-[slc | apic] loopback:swagger [options] [<_name_>]
+$ [slc | apic] loopback:swagger [options] [<_name_>]
 ```
 
-### OPTIONS
+### Options
 
-`-h, --help`  
+`-h, --help`
 Print the generator's options and usage.
 
-`--skip-cache`  
+`--skip-cache`
 Do not remember prompt answers. Default is false.
 
-`--skip-install`  
+`--skip-install`
 Do not automatically install dependencies. Default is false.
 
-### ARGUMENTS
+### Arguments
 
 You can optionally provide the URL of the Swagger specification file to use.  If you do, then the tool will use that as the default in the interactive prompts.
 
-### INTERACTIVE PROMPTS
+### Interactive Prompts
 
 The tool will prompt you for:
 
-*   Location of the Swagger JSON specification file.  Enter a URL or relative file path.
-*   Models to generate, based on the REST API defined in the Swagger file.  Move the cursor with the arrow keys, and press the space bar to de-select the model next to the cursor.  Then press Return to generate all the selected models.
-*   Data source to use.
+* Location of the Swagger JSON specification file.  Enter a URL or relative file path.
+* Models to generate, based on the REST API defined in the Swagger file. 
+  Move the cursor with the arrow keys, and press the space bar to de-select the model next to the cursor.  
+  Then press Return to generate all the selected models.
+* Data source to use.
 
 ### EXAMPLE
 
@@ -54,7 +57,7 @@ For example, if you enter the Swagger simple pet store example URL:
 
 The tool will display:
 
-```
+```shell
 [?] Select models to be generated:
 ❯⬢ swagger_api
  ⬢ pet
@@ -62,11 +65,12 @@ The tool will display:
  ⬢ errorModel
 ```
 
-Move the cursor with the arrow keys, and press the space bar to de-select the model next to the cursor.  Then press Return to generate all the selected models.
+Move the cursor with the arrow keys, and press the space bar to de-select the model next to the cursor.
+Then press Return to generate all the selected models.
 
-The tool will prompt you for the isplay information on what it's doing; for example:
+The tool will prompt you for the display information on what it's doing; for example:
 
-```
+```shell
 [?] Select the data-source to attach models to: db (memory)
 Creating model definition for swagger_api...
 Creating model definition for pet...
@@ -75,6 +79,7 @@ Creating model definition for errorModel...
 ...
 ```
 
-### OUTPUT
+### Output
 
-The tool generates all the files for the application based on the specified Swagger file, including all the [Model definition JSON files](Model-definition-JSON-file.html) and associated JavaScript files.
+The tool generates all the files for the application based on the specified Swagger file,
+including all the [Model definition JSON files](/doc/en/lb2/Model-definition-JSON-file.html) and associated JavaScript files.

--- a/pages/en/lb2/Tutorial-Adding-application-logic.md
+++ b/pages/en/lb2/Tutorial-Adding-application-logic.md
@@ -14,7 +14,7 @@ summary:
 This example application describes using the StrongLoop `slc loopback` tool. You can also recreate the application using API Connect `apic` tool.
 Simply substitute the API Connect command for the corresponding StrongLoop command.
 For more information, see
-[Converting StrongLoop commands to API Connect commands](https://docs.strongloop.com/display/APIC/Command-line+reference#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
+[Converting StrongLoop commands to API Connect commands](/doc/en/lb2/Command-line-reference.html#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
 
 " %}
 

--- a/pages/en/lb2/Tutorial-model-relations.md
+++ b/pages/en/lb2/Tutorial-model-relations.md
@@ -14,7 +14,7 @@ summary:
 This example application describes using the StrongLoop `slc loopback` tool. You can also recreate the application using API Connect `apic` tool.
 Simply substitute the API Connect command for the corresponding StrongLoop command.
 For more information, see
-[Converting StrongLoop commands to API Connect commands](https://docs.strongloop.com/display/APIC/Command-line+reference#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
+[Converting StrongLoop commands to API Connect commands](/doc/en/lb2/Command-line-reference.html#Command-linereference-CorrespondencebetweenStrongLoopcommandstoAPIConnectcommands).
 
 " %}
 

--- a/pages/en/lb2/Using-built-in-models.md
+++ b/pages/en/lb2/Using-built-in-models.md
@@ -44,7 +44,7 @@ The default model definition file is [common/models/user.json](https://github.c
 **IMPORTANT**
 
 You must create your own custom model (named something other than \"User,\" for example \"Customer\" or \"Client\")
-that [extends the built-in User model](https://docs.strongloop.com/display/APIC/Extending+built-in+models) rather than use the built-in User model directly.
+that [extends the built-in User model](/doc/en/lb2/Extending-built-in-models.html) rather than use the built-in User model directly.
 The built-in User model provides a great deal of commonly-used functionality that you can use via your custom model.
 
 " %}

--- a/pages/en/lb2/Using-current-context.md
+++ b/pages/en/lb2/Using-current-context.md
@@ -19,16 +19,61 @@ LoopBack applications sometimes need to access context information to implement 
 A typical request to invoke a LoopBack model method travels through multiple layers with chains of asynchronous callbacks.
 It's not always possible to pass all the information through method parameters. 
 
-## Configure context propagation
+{% include warning.html content="
 
-LoopBack context is now enabled by default for REST APIs via `loopback.rest()` middleware.
-Configure it in `server/config.json` as follows:
+Warning: Using the current context feature is not recommended!
+
+The current implementation of loopback-context is based on the module [continuation-local-storage](https://www.npmjs.com/package/continuation-local-storage) 
+which is known to have many problems, (for example, see [issue #59](https://github.com/othiym23/node-continuation-local-storage/issues/59)).
+As a result, loopback-context does not work in many situations, as can be seen from issues reported in LoopBack's
+[issue tracker](https://github.com/strongloop/loopback/issues?utf8=%E2%9C%93&q=is%3Aissue%20getCurrentContext).
+
+Refer to loopback [issue #1495](https://github.com/strongloop/loopback/issues/1495) updates and an alternative solution.
+
+" %}
+
+## Fixing deprecation warnings
+
+All context-related LoopBack APIs are deprecated starting with version 2.30.0.
+After upgrading an existing application to a recent LoopBack version, you will see the following deprecation warning:
+
+```
+loopback deprecated loopback#context middleware is deprecated.
+See https://docs.strongloop.com/display/APIC/Using%20current%20context for more details.
+node_modules/loopback/server/middleware/rest.js:60:32
+```
+
+To remove this warning, disable the context middleware added by the built-in REST handler. Set the `remoting.context` property in `server/config.json` to **false**; for example:
+
+**server/config.json**
 
 ```javascript
-"remoting": {
-  "context": {
-    "enableHttpContext": false
+{
+  "remoting": {
+    "context": false,
+    // etc.
   },
+  // etc.
+}
+```
+
+If your application relies on `loopback.getCurrentContext`, then you should rework your code to use `loopback-context` directly, per the following instructions.
+
+## Install loopback-context
+
+Add `loopback-context` to your project dependencies
+
+`$ npm install --save loopback-context`
+
+## Configure context propagation
+
+To setup your LoopBack application to create a new context for each incoming HTTP request, configure `per-context` middleware in your `server/middleware.json` as follows:
+
+```javascript
+{
+  "initial": {
+    "loopback-context#per-request": {},
+  }
   ...
 }
 ```
@@ -42,14 +87,16 @@ You need to set `enableHttpContext` to true to enable automatic population of re
 
 ## Use the current context
 
-Once you've enabled context propagation, you can access the current context object using `loopback.getCurrentContext()`.
-The context should be available in middleware (those come after the context middleware), remoting hooks, model hooks, and custom methods.
+Once you've enabled context propagation, you can access the current context object using `LoopBackContext.getCurrentContext()`.
+The context will be available in middleware (if it is loaded after the context middleware), remoting hooks, model hooks, and custom methods.
 
 ```javascript
+var LoopBackContext = require('loopback-context');
+
 MyModel.myMethod = function(cb) {
-  var ctx = loopback.getCurrentContext();
+  var ctx = LoopBackContext.getCurrentContext();
   // Get the current access token
-  var accessToken = ctx.get('accessToken');
+  var accessToken = ctx && ctx.get('accessToken');
   ...
   // Set more information on current context
   ctx.set('foo', { bar: 'val' } );
@@ -60,13 +107,12 @@ MyModel.myMethod = function(cb) {
 
 ## Use current authenticated user in remote methods
 
-The `loopback.context()` has been added to `loopback.rest()` to ensure that all REST applications have the context available, even if they don't add the middleware explicitly.
-In advanced use cases, for example when you want to add custom middleware, you have to add the context middleware at
-the right position in the middleware chain (before the middleware that depends on `loopback.getCurrentContext`).
+In advanced use cases, for example when you want to add custom middleware, you have to add the context middleware
+at the right position in the middleware chain (before the middleware that depends on `LoopBackContext.getCurrentContext`).
 
 {% include important.html content="
 
-`loopback.context()` detects the situation when it is invoked multiple times on the same request and returns immediately in subsequent runs.
+`LoopBackContext.perRequest()` detects the situation when it is invoked multiple times on the same request and returns immediately in subsequent runs.
 
 " %}
 
@@ -77,7 +123,7 @@ Here's sample code which uses a middleware function to place the currently authe
 ```javascript
 ...
 // -- Add your pre-processing middleware here --
-app.use(loopback.context());
+app.use(LoopBackContext.perRequest());
 app.use(loopback.token());
 app.use(function setCurrentUser(req, res, next) {
   if (!req.accessToken) {
@@ -90,7 +136,7 @@ app.use(function setCurrentUser(req, res, next) {
     if (!user) {
       return next(new Error('No user with this access token was found.'));
     }
-    var loopbackContext = loopback.getCurrentContext();
+    var loopbackContext = LoopBackContext.getCurrentContext();
     if (loopbackContext) {
       loopbackContext.set('currentUser', user);
     }
@@ -106,11 +152,12 @@ app.use(function setCurrentUser(req, res, next) {
 
 ```javascript
 var loopback = require('loopback');
+var LoopBackContext = require('loopback-context');
 module.exports = function(YourModel) {
   ...
   //remote method
   YourModel.someRemoteMethod = function(arg1, arg2, cb) {
-    var ctx = loopback.getCurrentContext();
+    var ctx = LoopBackContext.getCurrentContext();
     var currentUser = ctx && ctx.get('currentUser');
     console.log('currentUser.username: ', currentUser.username); // voila!
     ...

--- a/pages/en/lb2/Using-strong-error-handler.md
+++ b/pages/en/lb2/Using-strong-error-handler.md
@@ -1,0 +1,107 @@
+---
+title: "Using strong-error-handler"
+lang: en
+layout: page
+keywords: LoopBack
+tags:
+sidebar: lb2_sidebar
+permalink: /doc/en/lb2/Using-strong-error-handler.html
+summary:
+---
+
+# strong-error-handler
+
+Error handler for use in development (debug) and production environments.
+
+## Production mode
+
+* error responses are purposely left without detail in order to prevent leaking sensitive information.
+* For 5xx errors, the output contains only the status code and the status name from the HTTP specification.
+* For 4xx errors, the output contains the full error message (`error.message`) and the contents of the `details` property (`error.details`).
+  The latter is typically used by `ValidationError` to provide machine-readable details about the validation problems.
+
+## Debug Mode
+
+* Full error stack traces and internal details of any object passed passed as the error will be sent back to the client in the HTTP responses when an error occurs.
+
+## Response Format
+
+* `strong-error-handler` currently supports HTML and JSON responses.
+* When the object is a standard Error object, the string provided by the stack property will be returned in HTML/text responses.
+* When the object is a non-Error object, the result of `util.inspect` will be returned in HTML/text responses.
+* For JSON responses, the result will be an object with all enumerable properties from the object in the response.
+
+## Install
+
+## Usage
+
+In an express-based application:
+
+In LoopBack applications, add the following entry to your `server/middleware.json` file.
+
+## Content Type
+
+Depending on the request header’s `Accepts`, response will be returned in the corresponding content-type, current supported types include:
+
+* JSON (`json`/`application/json`)
+* HTML (`html`/`text/html`)
+
+_There are plans to support other formats such as Text and XML._
+
+## Options
+
+### debug
+
+`boolean`, defaults to `false`.
+
+If you need to set the environment to development mode, you will need to change the value to `true`.
+
+When enabled, HTTP responses include all error properties, including sensitive data such as file paths, URLs and stack traces. _See Examples below_
+
+### log
+
+`boolean`, defaults to `true`.
+
+When enabled, all errors are printed via `console.error`.
+That includes an array of fields (custom error properties) that are safe to include in response messages (both 4xx and 5xx).
+
+When not enabled, it only sends the error back in the response.
+
+Customization of the log format is intentionally not allowed.
+If you would like to use a different format/logger, disable this option and add your own custom error-handling middleware.
+
+## Migration to strong-error-handler for existing LoopBack applications
+
+1. In package.json dependencies, remove `"errorhandler": "^x.x.x”,`
+
+2. Run `npm install --save strong-error-handler`
+
+3. In `./server/config.json`:
+   remove `"errorHandler": { "disableStackTrace": false }` and replace it with `"handleErrors": false`.
+
+4. In `server/middleware.json`:
+   remove `"final:after": { "loopback#errorHandler": {} }` and replace it with `"final:after": { "strong-error-handler": {} }`
+
+5. In the `./server`, delete `middleware.production.json`.
+
+6. In the `./server`, create `middleware.development.json` containing:
+   `{ "final:after": { "strong-error-handler": { "params": { "debug": true, "log": true } } } }`
+
+## Examples:
+
+Error generated when `debug: false`:
+
+`{ error: { statusCode: 500, message: 'Internal Server Error' } }`
+
+Error generated when `debug: true`:
+
+```javascript
+{
+  error: {
+    statusCode: 500,
+    name: 'Error',
+    message: 'a test error message',
+    stack: 'Error: a test error message\n    at Context.<anonymous> (User/strong-error-handler/test/handler.test.js:220:21)\n    at callFnAsync (User/strong-error-handler/node_modules/mocha/lib/runnable.js:349:8)\n    at Test.Runnable.run (User/strong-error-handler/node_modules/mocha/lib/runnable.js:301:7)\n    at Runner.runTest (User/strong-error-handler/node_modules/mocha/lib/runner.js:422:10)\n    at User/strong-error-handler/node_modules/mocha/lib/runner.js:528:12\n    at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:342:14)\n    at User/strong-error-handler/node_modules/mocha/lib/runner.js:352:7\n    at next (User/strong-error-handler/node_modules/mocha/lib/runner.js:284:14)\n    at Immediate._onImmediate (User/strong-error-handler/node_modules/mocha/lib/runner.js:320:5)\n    at tryOnImmediate (timers.js:543:15)\n    at processImmediate [as _immediateCallback] (timers.js:523:5)'
+  }
+ }
+```

--- a/pages/en/lb2/Using-the-model-generator.md
+++ b/pages/en/lb2/Using-the-model-generator.md
@@ -18,14 +18,14 @@ See [Discovering models from relational databases](/doc/en/lb2/Discovering-model
 
 ## Overview
 
-The easiest way to create a new model is with the [model generator](https://docs.strongloop.com/display/APIC/Model+generator):
+The easiest way to create a new model is with the [model generator](/doc/en/lb2/Model-generator.html):
 
 ```shell
 $ apic create --type model
 ```
 
 When creating a new model, the generator will prompt you for the properties in the model.
-Subsequently, you can add more properties to it using the [property generator](https://docs.strongloop.com/display/APIC/Property+generator).
+Subsequently, you can add more properties to it using the [property generator](/doc/en/lb2/Property-generator.html).
 
 When you create a model (for example, called "myModel"), the tool:
 
@@ -43,7 +43,7 @@ Once you've created your model, you may want to read:
 
 ## Basic use
 
-Use the LoopBack [model generator](https://docs.strongloop.com/display/APIC/Model+generator) to create a new model.
+Use the LoopBack [model generator](/doc/en/lb2/Model-generator.html) to create a new model.
 In your application root directory, enter the command (for example, to create a "books" model):
 
 ```shell
@@ -54,7 +54,7 @@ Then the tool will prompt you to:
 
 * Choose the data source to which the model will connect. By default, there will be only the in-memory data source (named "db").
   When you create additional data sources with apic create --type datasource,
-  the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator), they will be listed as options.
+  the [data source generator](/doc/en/lb2/Data-source-generator.html), they will be listed as options.
 
 * Choose the model's base class, from a list of [built-in models](/doc/en/lb2/Using-built-in-models.html) classes and existing custom models in the application.
 
@@ -75,7 +75,7 @@ Then the tool will prompt you to:
 
 Adding properties
 
-After you create a model, you can add more properties with the [property generator](https://docs.strongloop.com/display/APIC/Property+generator).
+After you create a model, you can add more properties with the [property generator](/doc/en/lb2/Property-generator.html).
 
 ```shell
 $ apic create --type property

--- a/pages/en/lb2/Validating-model-data.md
+++ b/pages/en/lb2/Validating-model-data.md
@@ -116,7 +116,7 @@ method on a model instance, and automatically each time model instance is create
 
 To enforce validation constraints when calling [`upsert()`](http://apidocs.strongloop.com/loopback/#persistedmodel-upsert), ensure that `validateUpsert`
 option is set to `true` in the [model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html). 
-By default, the [model generator](https://docs.strongloop.com/display/APIC/Model+generator) sets this property to true.
+By default, the [model generator](/doc/en/lb2/Model-generator.html) sets this property to true.
 
 " %}
 

--- a/pages/en/lb2/Where-filter.md
+++ b/pages/en/lb2/Where-filter.md
@@ -34,7 +34,7 @@ You can also use [stringified JSON format](/doc/en/lb2/Querying-data.html#Query
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/Where-filter.md
+++ b/pages/en/lb2/Where-filter.md
@@ -125,7 +125,7 @@ productModel.destroyAll({cost: {gt: 100}}, function(err, obj) { ... });
 
 ### Default scopes with where filters
 
-Adding a `scope` to a model definition (in the [model.json file](/doc/en/lb2/Model-definition-JSON-file.html))
+Adding a `scope` to a model definition (in the [`model.json` file](/doc/en/lb2/Model-definition-JSON-file.html))
 automatically adds a method to model called `defaultScope()`. LoopBack will call this method whenever a model is created, updated, or queried.
 
 {% include tip.html content="
@@ -426,9 +426,82 @@ Shirts.find({where: {size: {between: [0,7]}}}, function (err, posts) { ... } )
 
 ### near
 
-Example using the **near** operator that returns the three closest locations to a given geo point:
+The `where.<field>.near` filter is different from other where filters: most where filters **limit**the number of records returned,
+whereas `near` **orders** them, making it more like a SQL `order by` clause.
+By combining it with [`limit`](/doc/en/lb2/Limit-filter.html), you can create a query to get, for example, the **three records nearest to a given location**.
+
+For example:
 
 `/locations?filter[where][geo][near]=153.536,-28.1&filter[limit]=3`
+
+GeoPoints can be expressed in any of the following ways:
+
+```javascript
+location = new GeoPoint({lat: 42.266271, lng: -72.6700016}); // GeoPoint
+location = '42.266271,-72.6700016';                          // String
+location = [42.266271, -72.6700016];                         // Array
+location = {lat: 42.266271, lng: -72.6700016};               // Object Literal
+
+Restaurants.find({where: {geo: {near: location }}}, function callback(...
+```
+
+### near (ordering _and limiting by distance_)
+
+The near filter can take two additional properties:
+
+*   `maxDistance`
+*   `unit`
+
+When `maxDistance` is included in the filter, near behaves more like a typical where filter, limiting results to those within a given distance to a location.
+By default, `maxDistance` measures distance in **miles**.
+
+Example of finding the all restaurants within two miles of a given GeoPoint:
+
+```javascript
+var userLocation = new GeoPoint({
+  lat: 42.266271,
+  lng: -72.6700016
+});
+var resultsPromise = Restaurants.find({
+  where: {
+    location: {
+      near: userLocation,
+      maxDistance: 2
+    }
+  }
+});
+```
+
+To change the units of measurement, specify `unit` property to one of the following:
+
+* `kilometers`
+* `meters`
+* `miles`
+* `feet`
+* `radians`
+* `degrees`
+
+For example, to change the query above to use kilometers instead of miles:
+
+```javascript
+var resultsPromise = Restaurants.find({
+  where: {
+    location: {
+      near: userLocation,
+      maxDistance: 2,
+      unit: 'kilometers'
+    }
+  }
+});
+```
+
+{% include warning.html content="
+
+Spell Carefully!
+
+If `unit` value is mistyped, for example `'mile'` instead of `'miles'`, LoopBack will **silently ignore the filter!**
+
+" %}
 
 ### like and nlike
 

--- a/pages/en/lb2/Working-with-LoopBack-objects.md
+++ b/pages/en/lb2/Working-with-LoopBack-objects.md
@@ -93,7 +93,7 @@ You simply require `/server/server.js` as you would any Node module.
 
 ### From a model script
 
-To get a handle on the `app` object in a model scaffolded by the [Model generator](https://docs.strongloop.com/display/APIC/Model+generator),
+To get a handle on the `app` object in a model scaffolded by the [Model generator](/doc/en/lb2/Model-generator.html),
 "require" it as you would any Node module:
 
 **Model - /common/models/book.js**

--- a/pages/en/lb2/Working-with-data.md
+++ b/pages/en/lb2/Working-with-data.md
@@ -24,30 +24,30 @@ All LoopBack models that are connected to persistent data stores (such as a data
     <tr>
       <td>Create</td>
       <td>
-        <p><a href="https://docs.strongloop.com/display/APIC/PersistedModel+REST+API#PersistedModelRESTAPI-Createmodelinstance">PUT /<em>modelName</em></a></p>
-        <p><a href="https://docs.strongloop.com/display/APIC/PersistedModel+REST+API#PersistedModelRESTAPI-Update/insertinstance">POST /<em>modelName</em></a></p>
+        <p><a href="/doc/en/lb2/PersistedModel-REST-API.html#PersistedModelRESTAPI-Createmodelinstance">PUT /<em>modelName</em></a></p>
+        <p><a href="/doc/en/lb2/PersistedModel-REST-API.html#PersistedModelRESTAPI-Update/insertinstance">POST /<em>modelName</em></a></p>
       </td>
       <td><code><a href="http://apidocs.strongloop.com/loopback/#persistedmodel-create" class="external-link" rel="nofollow">create()</a><sup>*</sup></code></td>
       <td>INSERT</td>
     </tr>
     <tr>
       <td>Read (Retrieve)</td>
-      <td><a href="https://docs.strongloop.com/display/APIC/PersistedModel+REST+API#PersistedModelRESTAPI-Findmatchinginstances">GET /modelName?filter=...</a></td>
+      <td><a href="/doc/en/lb2/PersistedModel-REST-API.html#PersistedModelRESTAPI-Findmatchinginstances">GET /modelName?filter=...</a></td>
       <td><code><a href="http://apidocs.strongloop.com/loopback/#persistedmodel-find" class="external-link" rel="nofollow">find()</a><sup>*</sup></code></td>
       <td>SELECT</td>
     </tr>
     <tr>
       <td>Update (Modify)</td>
       <td>
-        <p><a href="https://docs.strongloop.com/display/APIC/PersistedModel+REST+API#PersistedModelRESTAPI-Update/insertinstance">POST /<em>modelName</em></a>&nbsp;</p>
-        <p><a href="https://docs.strongloop.com/display/APIC/PersistedModel+REST+API#PersistedModelRESTAPI-Updatemodelinstanceattributes">PUT /modelName</a></p>
+        <p><a href="/doc/en/lb2/PersistedModel-REST-API.html#PersistedModelRESTAPI-Update/insertinstance">POST /<em>modelName</em></a>&nbsp;</p>
+        <p><a href="/doc/en/lb2/PersistedModel-REST-API.html#PersistedModelRESTAPI-Updatemodelinstanceattributes">PUT /modelName</a></p>
       </td>
       <td><code><a href="http://apidocs.strongloop.com/loopback/#persistedmodel-updateall" class="external-link" rel="nofollow">updateAll()</a><sup>*</sup></code></td>
       <td>UPDATE</td>
     </tr>
     <tr>
       <td>Delete (Destroy)</td>
-      <td><a href="https://docs.strongloop.com/display/APIC/PersistedModel+REST+API#PersistedModelRESTAPI-Deletemodelinstance">DELETE /<em>modelName</em>/<em>modelID</em></a></td>
+      <td><a href="/doc/en/lb2/PersistedModel-REST-API.html#PersistedModelRESTAPI-Deletemodelinstance">DELETE /<em>modelName</em>/<em>modelID</em></a></td>
       <td><code><a href="http://apidocs.strongloop.com/loopback/#persistedmodel-destroybyid" class="external-link" rel="nofollow">destroyById()</a><sup>*</sup></code></td>
       <td>DELETE</td>
     </tr>
@@ -72,7 +72,7 @@ See the following articles for more information:
 
 {% include warning.html content="
 
-Methods of models in the [AngularJS client](https://docs.strongloop.com/display/APIC/AngularJS+JavaScript+SDK) have a different signature than those of the Node API.
+Methods of models in the [AngularJS client](/doc/en/lb2/AngularJS-JavaScript-SDK.html) have a different signature than those of the Node API.
 For more information, see [AngularJS SDK API](http://apidocs.strongloop.com/loopback-sdk-angular/).
 
 " %}

--- a/pages/en/lb2/client-directory.md
+++ b/pages/en/lb2/client-directory.md
@@ -11,7 +11,7 @@ summary:
 
 The `/client` directory is where you put client JavaScript, HTML, and CSS files.
 
-Currently, the [application generator](https://docs.strongloop.com/display/APIC/Application+generator) 
+Currently, the [application generator](/doc/en/lb2/Application-generator.html) 
 does not generate any files in this directory, except for a stub `README.md`. 
 
 For information on creating a client LoopBack application, see [LoopBack in the client](/doc/en/lb2/LoopBack-in-the-client.html).

--- a/pages/en/lb2/common-directory.md
+++ b/pages/en/lb2/common-directory.md
@@ -11,7 +11,7 @@ summary:
 
 The /common directory contains files shared by the server and client parts of the application.
 When you create models that are shared by client and server, the
-[Application generator](https://docs.strongloop.com/display/APIC/Application+generator) 
+[Application generator](/doc/en/lb2/Application-generator.html) 
 creates a `/models` sub-directory with one JSON file per model in the application.
 See [Model definition JSON file](/doc/en/lb2/Model-definition-JSON-file.html) for a description of the format of this file. 
 

--- a/pages/en/lb2/datasources.json.md
+++ b/pages/en/lb2/datasources.json.md
@@ -90,7 +90,7 @@ To connect a model to a data source, follow these steps:
     ```
 
     Follow the prompts to name the datasource and select the connector to use.
-    This adds the new data source to [`datasources.json`](https://docs.strongloop.com/display/APIC/datasources.json).
+    This adds the new data source to `datasources.json`
 
 2.  Edit `server/datasources.json` to add the necessary authentication credentials: typically hostname, username, password, and database name.
 
@@ -111,19 +111,19 @@ To connect a model to a data source, follow these steps:
 
     For information on the specific properties that each connector supports, see:
 
-    * [Cloudant connector](https://docs.strongloop.com/display/APIC/Cloudant+connector)
-    * [DashDB](https://docs.strongloop.com/display/APIC/DashDB)
-    * [DB2 connector](https://docs.strongloop.com/display/APIC/DB2+connector)
-    * [DB2 for z/OS](https://docs.strongloop.com/pages/viewpage.action?pageId=10354945)
-    * [Informix](https://docs.strongloop.com/display/APIC/Informix)
-    * [Memory connector](https://docs.strongloop.com/display/APIC/Memory+connector)
-    * [MongoDB connector](https://docs.strongloop.com/display/APIC/MongoDB+connector)
-    * [MySQL connector](https://docs.strongloop.com/display/APIC/MySQL+connector)
-    * [Oracle connector](https://docs.strongloop.com/display/APIC/Oracle+connector)
-    * [PostgreSQL connector](https://docs.strongloop.com/display/APIC/PostgreSQL+connector)
-    * [Redis connector](https://docs.strongloop.com/display/APIC/Redis+connector)
-    * [SQL Server connector](https://docs.strongloop.com/display/APIC/SQL+Server+connector)
-    * [SQLite3](https://docs.strongloop.com/display/APIC/SQLite3)
+    * [Cloudant connector](/doc/en/lb2/Cloudant-connector.html)
+    * [DashDB](/doc/en/lb2/DashDB.html)
+    * [DB2 connector](/doc/en/lb2/DB2-connector.html)
+    * [DB2 for z/OS](/doc/en/lb2/DB2-for-z-OS.html)
+    * [Informix](/doc/en/lb2/Informix.html)
+    * [Memory connector](/doc/en/lb2/Memory-connector.html)
+    * [MongoDB connector](/doc/en/lb2/MongoDB-connector.html)
+    * [MySQL connector](/doc/en/lb2/MySQL-connector.html)
+    * [Oracle connector](/doc/en/lb2/Oracle-connector.html)
+    * [PostgreSQL connector](/doc/en/lb2/PostgreSQL-connector.html)
+    * [Redis connector](/doc/en/lb2/Redis-connector.html)
+    * [SQL Server connector](/doc/en/lb2/SQL-Server-connector.html)
+    * [SQLite3](/doc/en/lb2/SQLite3.html)
      
 3.  Install the corresponding connector as a dependency of your app with `npm`, for example: 
 
@@ -162,14 +162,14 @@ To connect a model to a data source, follow these steps:
 
     {% include note.html content="
 
-    The model generator lists the [memory connector](https://docs.strongloop.com/display/APIC/Memory+connector), \"no data source,\"
-    and data sources listed in [`datasources.json`](https://docs.strongloop.com/display/APIC/datasources.json).
+    The model generator lists the [memory connector](/doc/en/lb2/Memory-connector.html), \"no data source,\"
+    and data sources listed in `datasources.json`.
     That's why you created the data source first in step 1.
 
     " %}
 
     You can also create models from an existing database.
-    See [Creating models](https://docs.strongloop.com/display/APIC/Creating+models) for more information.
+    See [Creating models](/doc/en/lb2/Creating-models.html) for more information.
 
 ## Environment-specific configuration
 

--- a/pages/en/lb2/datasources.json.md
+++ b/pages/en/lb2/datasources.json.md
@@ -75,7 +75,7 @@ All data sources support a few standard properties. Beyond that, specific proper
 
 To connect a model to a data source, follow these steps:
 
-1.  Use the [data source generator](https://docs.strongloop.com/display/APIC/Data+source+generator) to create a new data source. For example: 
+1.  Use the [data source generator](/doc/en/lb2/Data-source-generator.html) to create a new data source. For example: 
 
     ```shell
     $ apic create --type datasource
@@ -134,7 +134,7 @@ To connect a model to a data source, follow these steps:
 
     See [Connectors](/doc/en/lb2/Connecting-models-to-data-sources.html) for the list of connectors.
 
-4.  Use the [model generator](https://docs.strongloop.com/display/APIC/Using+the+model+generator) to create a model.
+4.  Use the [model generator](/doc/en/lb2/Using-the-model-generator.html) to create a model.
 
     ```shell
     $ apic create --type model

--- a/pages/en/lb2/middleware.json.md
+++ b/pages/en/lb2/middleware.json.md
@@ -12,7 +12,7 @@ summary:
 ## Overview
 
 Set up [middleware](/doc/en/lb2/Defining-middleware.html) in `middleware.json`.
-Here is the default version created by the [Application generator](https://docs.strongloop.com/display/APIC/Application+generator): 
+Here is the default version created by the [Application generator](/doc/en/lb2/Application-generator.html): 
 
 ```javascript
 {


### PR DESCRIPTION
@crandmck 
Added the pages provided in the [Migrate Conflunce content to markdown #29 ](https://github.com/strongloop/loopback.io/issues/29#issuecomment-243193922)

I also did a tidy up of the internal navigation links. Found some missing pages or dead links:
- ACL generator
- API definition generator
- Application generator
- Boot script generator
- Data source generator
- Middleware generator
- Model generator
- Property generator
- Relation generator
- Remote method generator
- Swagger generator
- Database discovery API
- API Explorer
- Extend your API
