### PR TITLE
packaging readme updating into run script for cleanliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ _pdf
 node_modules
 dist
 .jekyll-metadata
+vendor
+.bundle

--- a/README.md
+++ b/README.md
@@ -46,17 +46,14 @@ Jekyll uses the [Liquid template engine](http://liquidmarkup.org/) for templatin
 
 The documentation incorporates README files from a number of LoopBack example repositories.
 We use the [get-readmes](https://github.com/strongloop/get-readmes) utility to fetch
-the README files directly from GitHub.  Here is how to update the READMEs and save the result in the `_includes/readmes` directory (assuming you've cloned this repo already):
+the README files directly from GitHub.  Here is how to update the READMEs
 
-```
-$ cd loopback.io
-$ git clone https://github.com/strongloop/get-readmes.git
-$ cd get-readmes
-$ npm i
-$ node get-readmes --repos=../_data --out=../_includes/readmes
-```
+1. `npm install` (*first time/setup only*)
+2. `npm run fetch-readmes`
+
 From there, the README markdown files are incorporated into documentation articles
 using the standard Jekyll "include" syntax as follows (for example):
+
 ```
 ---
 title: "Angular example app"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "loopback.io-workflow-scripts",
+  "version": "1.0.0",
+  "description": "This file: Node-dependant workflow scripts for the jekyll-based site",
+  "scripts": {
+    "fetch-readmes": "get-readmes --repos=./_data --out=./_includes/readmes"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Strongloop/loopback.io.git"
+  },
+  "devDependencies": {
+    "getreadmes": "github:strongloop/get-readmes"
+  }
+}


### PR DESCRIPTION
Related to https://github.com/strongloop/get-readmes/pull/1

Packaged deps & utility scripts per node.js convention (to remove "clone another package, change directory" etc. steps from setup).
