### PR TITLE
Update and improve 3.0 Release Notes

### DIFF
--- a/pages/en/lb3/3.0-Release-Notes.md
+++ b/pages/en/lb3/3.0-Release-Notes.md
@@ -12,211 +12,498 @@ summary:
 {% include note.html content="
 LoopBack 3.0 has not yet been released. These release notes reflect the current state of the project, and may change before release." %}
 
-* [LoopBack core](/doc/en/lb2/3.0-Release-Notes.html)
-* [loopback-datasource-juggler](/doc/en/lb2/3.0-Release-Notes.html)
-* [strong-remoting](/doc/en/lb2/3.0-Release-Notes.html)
+Refer to [3.0 Migration Guide](http://loopback.io/doc/en/lb3/Migrating-to-3.0.html)
+for instructions on upgrading existing LoopBack 2.x applications to the new
+version.
 
-All breaking changes must be described here. When adding a new entry,
-always describe the impact on users and instructions for upgrading
-applications from 2.x to 3.0.
+## loopback-datasource-juggler was moved from peerDependencies to dependencies
 
-## LoopBack core
+Originally, we (ab)used peer dependencies to ensure there is only one instance
+of loopback-datasource-juggler in the dependency tree, so that there is only
+one singleton instance of model registry. This was very fragile and might not
+have worked in certain edge cases.
 
-### loopback-datasource-juggler was moved from peerDependencies to dependencies
+We have reworked loopback-datasource-juggler and connectors to not rely on
+a single juggler instance anymore. As the last step, juggler became a regular
+dependency.
 
-Originally, we (ab)used peer dependencies to ensure there is only one instance of loopback-datasource-juggler in the dependency tree,
-so that there is only one singleton instance of model registry.
-This was very fragile and might not have worked in certain edge cases.
+See [loopback#275](https://github.com/strongloop/loopback/issues/275).
 
-We have reworked loopback-datasource-juggler and connectors to not rely on a single juggler instance anymore.
-As the last step, juggler became a regular dependency.
+## Use bluebird as *the* Promise library
 
-[https://github.com/strongloop/loopback/issues/275](https://github.com/strongloop/loopback/issues/275)
+In version 3.0, we always use bluebird as our promise library
+instead of `global.Promise`.
+We consider Bluebird API a part of LoopBack API from now on,
+you are welcome to use any Bluebird-specific methods in your applications.
 
-When upgrading application from previous loopback versions, simply remove loopback-datasource-juggler from your dependencies.
+See [loopback#1896](https://github.com/strongloop/loopback/pull/1896) and
+[loopback-datasource-juggler#790](https://github.com/strongloop/loopback-datasource-juggler/pull/790).
 
-### Always use bluebird as promise library
+## Cleanup in conversion and coercion of input arguments
 
-In version 3.0, we always use bluebird as our promise library instead of `global.Promise`.
-We consider Bluebird API a part of LoopBack API from now on, you are welcome to use any Bluebird-specific methods in your applications.
+We have significantly reworked conversion and coercion of input arguments
+when using the default REST adapter.  The general approach is to make both
+conversion and coercion more strict. When we are not sure how to treat
+an input value, we rather return HTTP error `400 Bad Request` than coerce
+the value incorrectly.
 
-If you are using LoopBack with a custom promise implementation provided via `global.Promise`,
-you will have to check all places where you are using non-standard promise API and update them to use Bluebird API instead.
+Most notable breaking changes:
 
-Please see [Related code change](https://github.com/strongloop/loopback/pull/1896) here.
+ - `null` value is accepted only for "object", "array" and "any"
+ - Empty string is coerced to undefined to support ES6 default arguments
+ - JSON requests providing scalar values for array-typed argument are
+   rejected
+ - Empty value is not converted to an empty array
+ - Array values containing items of wrong type are rejected. For
+   example, an array containing a string value is rejected when
+   the input argument expects an array of numbers.
+ - Array items from JSON requests are not coerced. For example,
+   `[true]` is no longer coerced to `[1]` for number arrays,
+   and the request is subsequently rejected.
+ - Deep members of object arguments are no longer coerced. For example,
+   a query like `?arg[count]=42` produces `{ count: '42' }` now.
+ - "any" coercion preserves too large numbers as a string, to prevent
+   losing precision.
+ - Boolean types accepts only four string values:
+    'true', 'false', '0' and '1'
+   Values are case-insensitive, i.e. 'TRUE' and 'FaLsE' work too.
+ - Date type detects "Invalid Date" and rejects such requests.
+ - When converting a value coming from a string source like querystring
+   to a date, and the value is a timestamp (i.e. an integer), we treat
+   the value as a number now. That way the value "0" always produces
+   "1970-01-01T00:00:00.000Z" instead of some date around 1999/2000/2001
+   depending on server timezone.
+ - Array values are not allowed for arguments of type object.
 
-### New method of defining remoting metadata
+Hopefully this change should leave most LoopBack applications (and clients)
+unaffected. If your start seeing unusual amount of 400 error responses after
+upgrading to LoopBack 3.x, then please check the client code and ensure it
+correctly encodes request parameters.
 
-In 2.0, remote methods were defined as:
+See the following pull requests for more details:
 
-```js
-methods: {
-  staticMethod: {
-    isStatic: true,
-    http: { path: '/static' }
-  },
-  instanceMethod: {
-    isStatic: false,
-    http: { path: '/instance' }
+ - [strong-remoting#343](https://github.com/strongloop/strong-remoting/pull/343)
+ - [strong-remoting#347](https://github.com/strongloop/strong-remoting/pull/347)
+ - [strong-remoting#349](https://github.com/strongloop/strong-remoting/pull/349)
+
+## New error-handler for rest-adapter
+
+The REST adapter (typically created via `loopback.rest()`) uses a new error
+handler implementation that provides more secure configuration out of the box.
+
+In production mode:
+
+ - Stack trace is never returned in HTTP responses.
+ - Bad Request errors (4xx) provide the following properties copied from the
+   error object: `name`, `message`, `statusCode` and `details`.
+ - All other errors (including non-Error values like strings or arrays) provide
+   only basic information: `statusCode` and `message` set to status name from
+   HTTP specification.
+
+In debug mode:
+
+ - When in debug mode, HTTP responses include all properties provided by the
+   error object.
+ - For errors that are not an object, their string value is returned in
+   `message` field.
+
+The environment setting `NODE_ENV='production'` is no longer supported,
+production vs. debug mode is controlled exclusively by configuration.
+Production environment is assumed by default, the insecure debug mode
+must be explicitely turned on.
+
+The `error.status` has been removed and will be replaced by `error.statusCode`,
+`statusCode` is more descriptive and avoids ambiguity, users relying on `status`
+will need to change implementation accordingly.
+
+You can learn more about the rationale behind the new handler in
+[this comment](https://github.com/strongloop/loopback/issues/1650#issuecomment-161920555)
+
+See [strong-remoting#302](https://github.com/strongloop/strong-remoting/pull/302)
+and [`strong-error-handler`](https://github.com/strongloop/strong-error-handler/).
+
+## Current context API and middleware were removed
+
+We have removed the following current-context-related APIs:
+
+ - `loopback.getCurrentContext`
+ - `loopback.createContext`
+ - `loopback.runInContext`
+
+Additionally, `loopback#context` middleware and `remoting.context` server
+config were removed too.
+
+Existing applications using current-context will print the following error
+on the first HTTP request received:
+
+```
+Unhandled error for request GET /api/Users:
+Error: remoting.context option was removed in version 3.0.
+See https://docs.strongloop.com/display/APIC/Using%20current%20context for more
+details.
+    at restApiHandler (.../node_modules/loopback/server/middleware/rest.js:44:15)
+    at Layer.handle [as handle_request] (.../node_modules/express/lib/router/layer.js:95:5)
+```
+
+See [loopback#2564](https://github.com/strongloop/loopback/pull/2564)
+and [documentation](https://docs.strongloop.com/display/APIC/Using+current+context)
+
+## CORS is no longer enabled
+
+There are two types of applications that are commonly built using LoopBack,
+and each type has different requirements when it comes to CORS.
+
+ 1. Public facing API servers serving a variety of clients.
+  CORS should be enabled to allow 3rd party sites to access the API server
+  living on a different domain.
+
+ 2. API+SPA sites where both API and the SPA client live on the same domain
+  and the API should be locked down to serve only its own browser clients,
+  i.e. CORS must be disabled.
+
+By enabling CORS by default, we were making API+SPA sites vulnerable by default.
+
+In strong-remoting 3.x, we removed the built-in CORS middleware and pushed
+the responsibility for enabling and configuring CORS back to application
+developers.
+
+Note that this does not affect LoopBack applications scaffolded by a recent
+version of `slc loopback` or `apic loopback`, as these applications don't rely
+on the built-in CORS middleware and configure CORS explicitly
+in `server/middleware.json`.
+
+See [pull request #352](https://github.com/strongloop/strong-remoting/pull/352) and
+[Security considerations](https://docs.strongloop.com/display/public/LB/Security+considerations).
+
+## Simpler metadata for remote methods
+
+In 2.x, remote methods were defined as:
+
+```json
+{
+  "methods": {
+    "staticMethod": {
+      "isStatic": true,
+      "http": { "path": "/static" }
+    },
+    "instanceMethod": {
+      "isStatic": false,
+      "http": { "path": "/instance" }
+    }
   }
 }
 ```
 
-For 3.0, the isStatic flag is no longer required and will be determined from the method name.
-Method name starting with "prototype." will be the same as having isStatic flag set to false.
+Starting from 3.0, the `isStatic` flag is no longer used and will be determined
+from the method name. Method names starting with `prototype.` indicate
+prototype methods (`isStatic: false`).
 
-```js
-methods: {
-  staticMethod: {
-    http: { path: '/static' }
-  },
-  'prototype.instanceMethod': { http: { path: '/instance' }
+```json
+{
+  "methods": {
+    "staticMethod": {
+      "http": { "path": "/static" }
+    },
+    "prototype.instanceMethod": {
+      "http": { "path": "/instance" }
+    }
+  }
 }
 ```
 
-Please see [related code change](https://github.com/strongloop/loopback/pull/2174) here.
+See [loopback#2174](https://github.com/strongloop/loopback/pull/2174).
 
-### Remove `Change.handleError`
-
-`Change.handleError` is now removed as it was used inconsistenly for a subset of possible errors only.
-All Change methods will report all errors to the caller via the callback.
-
-Use PersistedModel to report change-tracking errors via the existing method PersistedModel.handleChangeError.
-This method can be customized on a per-model basis to provide different error handling.
-
-Please see [related code change](https://github.com/strongloop/loopback/pull/2308) here.
-
-### Remove unused user properties
+## Unused user properties were removed
 
 The following properties are removed from the built-in User model in 3.0:
-- credentials
-- challenges
-- status
-- created
-- lastUpdated
 
-Developers that are relying on these properties, can redefine them in `user.json` or equivalent model.json as follow:
-`json { "name": "MyUser", "base": "User", "properties": { "credentials": { "type": "object" }, "challenges": { "type": "object" }, "status": "string", "created": "date", "lastUpdated": "date" } }`
+ - credentials
+ - challenges
+ - status
+ - created
+ - lastUpdated
 
-Please see [Related code change](https://github.com/strongloop/loopback/pull/2299) here.
+If your application is using this properties, then you can define them in your
+model json file as follows:
 
-### Remove getters for Express 3.x middleware
+```json
+{
+  "name": "MyUser",
+  "base": "User",
+  "properties": {
+    "credentials": { "type": "object" },
+    "challenges": { "type": "object" },
+    "status": "string",
+    "created": "date",
+    "lastUpdated": "date"
+  }
+}
+```
 
-Express 4.x stopped bundling commonly-used middleware.
-To simplify migration of LoopBack 1.x applications (powered by Express 3.x) to LoopBack 2.x (powered by Express 4.x),
-we created getter properties to allow developers to keep using the old convention.
+See [loopback#2299](https://github.com/strongloop/loopback/pull/2299).
 
-We have removed these getters in LoopBack 3.0, here is the full list of removed properties together with the middleware module name to use instead:
+## Getters for Express 3.x middleware were removed
 
-* `loopback.compress` - use `require('compression')` instead
-* `loopback.timeout` - use `require('connect-timeout')` instead
-* `loopback.cookieParser` - use `require('cookie-parser')` instead
-* `loopback.cookieSession` - use `require('cookie-session')` instead
-* `loopback.csrf` - use `require('csurf')` instead
-* `loopback.errorHandler` - use `require('errorhandler')` instead
-* `loopback.session` - use `require('express-session')` instead
-* `loopback.methodOverride` - use `require('method-override')` instead
-* `loopback.logger` - use `require('morgan')` instead
-* `loopback.responseTime` - use `require('response-time')` instead
-* `loopback.favicon` - use `require('serve-favicon')` instead
-* `loopback.directory` - use `require('serve-index')` instead
-* `loopback.vhost` - use `require('vhost')` instead
+Express 4.x stopped bundling commonly-used middleware. To simplify migration
+of LoopBack 1.x applications (powered by Express 3.x) to LoopBack 2.x (powered
+by Express 4.x), we created getter properties to allow developers to keep using
+the old convention.
+
+We have removed these getters in LoopBack 3.0, here is the full list of
+removed properties together with the middleware module name to use instead:
+
+ - `loopback.compress` - use `require('compression')` instead
+ - `loopback.timeout` - use `require('connect-timeout')` instead
+ - `loopback.cookieParser` - use `require('cookie-parser')` instead
+ - `loopback.cookieSession` - use `require('cookie-session')` instead
+ - `loopback.csrf` - use `require('csurf')` instead
+ - `loopback.errorHandler` - use `require('errorhandler')` instead
+ - `loopback.session` - use `require('express-session')` instead
+ - `loopback.methodOverride` - use `require('method-override')` instead
+ - `loopback.logger` - use `require('morgan')` instead
+ - `loopback.responseTime` - use `require('response-time')` instead
+ - `loopback.favicon` - use `require('serve-favicon')` instead
+ - `loopback.directory` - use `require('serve-index')` instead
+ - `loopback.vhost` - use `require('vhost')` instead
 
 We have also removed `loopback.mime`, which was always set to `undefined`.
 
 See [loopback#2349](https://github.com/strongloop/loopback/pull/2394).
 
-### Remove `loopback#errorhandler`
+## `loopback.errorhandler` was removed
 
-We have removed `loopback#errorhandler` middleware, users should use `strong-error-handler` directly.
+We have removed `loopback#errorhandler` middleware, users should
+use `strong-error-handler` instead.
 
-See also strong-error-handler's [options](https://github.com/strongloop/strong-error-handler#options) and the [related code change](https://github.com/strongloop/loopback/pull/2411).
+See [loopback#2411](https://github.com/strongloop/loopback/pull/2411).
 
-## loopback-datasource-juggler
+## Serialization of Date values in responses
 
-See also [https://github.com/strongloop/loopback/blob/master/3.0-DEVELOPING.md](https://github.com/strongloop/loopback/blob/master/3.0-DEVELOPING.md)
-for more details.
+The format of date values has been changed from the output of `.toString()`,
+which produces values in local timezone, to the output of `.toJSON()`, which
+produces values in GMT.
 
-### Always use bluebird as promise library
+For example, let's take `new Date(0)` returned for `dateArgument`.
 
-In version 3.0, we always use bluebird as our promise library instead of `global.Promise`.
-We consider Bluebird API a part of LoopBack API from now on, you are welcome to use any Bluebird-specific methods in your applications.
+In strong-remoting 2.x, this value is converted to the following response
+when running on a computer in the Central-European timezone:
 
-If you are using LoopBack with a custom promise implementation provided via `global.Promise`,
-you will have to check all places where you are using non-standard promise API and update them to use Bluebird API instead.
+```json
+{
+  "dateArgument": {
+    "$type": "date",
+    "$data": "Thu Jan 01 1970 01:00:00 GMT+0100 (CET)"
+  }
+}
+```
 
-See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/790)
-for more details.
+In strong-remoting 3.x, the same value is converted to the following response
+regardless of the server timezone settings:
 
-### DAO.find provides ctx.data in "loaded" hook
+```json
+{
+  "dateArgument": {
+    "$type": "date",
+    "$data": "1970-01-01T00:00:00.000Z"
+  }
+}
+```
 
-When implementing "loaded" hook for `DAO.find` method, we have mistakenly implemented a version that sets `ctx.instance` instead of `ctx.data`.
-This defeats the purpose of the "loaded" hook, which is to allow hooks to modify the raw data provided by the datasource before it's used to build a model instance.
+See [strong-remoting#344](https://github.com/strongloop/strong-remoting/pull/344).
 
-This has been fixed in 3.0 and the "loaded" hook now consistently provides `ctx.data` for all operations.
-If you have a "loaded" hook handler that checks `if (ctx.instance)` then you can remove this condition together with the branch that follows.
+## `PersistedModel.find` provides `ctx.data` in "loaded" hook now
 
-See [related code change](https://github.com/strongloop/loopback-datasource-juggler/commit/30283291?w=1)
-for more details.
+When implementing "loaded" hook for `DAO.find` method, we have mistakenly
+implemented a version that sets `ctx.instance` instead of `ctx.data`. This
+defeats the purpose of the "loaded" hook, which is to allow hooks to modify
+the raw data provided by the datasource before it's used to build a model
+instance.
 
-### DAO.create no longer returns the instance(s) created
+This has been fixed in 3.0 and the "loaded" hook now consistently provides
+`ctx.data` for all operations. If you have a "loaded" hook handler that
+checks `if (ctx.instance)` then you can remove this condition together with
+the branch that follows.
 
-While implementing support for promises in `DAO.create`, we found that this method returns the instance object synchronously.
-This is inconsistent with the usual convention of accessing the result via callback/promise and it may not work correctly
-in cases where some fields like the `id` property are generated by the database.
+See [loopback-datasource-juggler@30283291](https://github.com/strongloop/loopback-datasource-juggler/commit/30283291?w=1).
 
-We have changed the API to be consistent with other DAO methods: when invoked with a callback argument,
-the method does not return anything.
-When invoked without any callback, a promise is returned.
+## `PersistedModel.create` no longer returns the instance(s) created
 
-See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/918)
-for more details.
+While implementing support for promises in `PersistedModel.create`, we found
+that this method returns the instance object synchronously. This is
+inconsistent with the usual convention of accessing the result via
+callback/promise and it may not work correctly in cases where some fields like
+the `id` property are generated by the database.
 
-### Applying an undefined mixin to a LoopBack model throws an error
+We have changed the API to be consistent with other DAO methods: when invoked
+with a callback argument, the method does not return anything. When invoked
+without any callback, a promise is returned.
 
-When applying an undefined mixin to a LoopBack model, a warning message was logged regarding the invalid mixin,
-which needs to be addressed rather than silently ignored.
-This has been fixed in 3.0, therefore an undefined mixin applied to a LoopBack model will throw an error that needs to be handled.
+See [loopback-datasource-juggler#918](https://github.com/strongloop/loopback-datasource-juggler/pull/918).
 
-See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/944)
-for more details.
+## Applying an undefined mixin to a LoopBack model throws an error
 
-### Remove deprecated model hooks and model events
+When applying an undefined mixin to a LoopBack model, a warning message was
+logged regarding the invalid mixin, which needs to be addressed rather than
+silently ignored. This has been fixed in 3.0, therefore an undefined mixin
+applied to a LoopBack model will throw an error that needs to be handled.
 
-The following deprecated model events are now removed. Please upgrade your code by using operation hooks in its place.
+See [loopback-datasource-juggler#944](https://github.com/strongloop/loopback-datasource-juggler/pull/944).
+
+## Deprecated model events were removed
+
+The following deprecated model events are now removed. Please upgrade your code
+by using operation hooks in its place.
 
 Model events
-* changed
-* deletedAll
-* deleted
 
-See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/965)
-for more details.
+  * changed
+  * deletedAll
+  * deleted
 
-### Model property names with dot(s) generates an error
+See [loopback-datasource-juggler#965](https://github.com/strongloop/loopback-datasource-juggler/pull/965).
 
-Instead of showing a deprecation warning for model property names with dots, for example, `customer.name: 'string'`,
-an error is thrown in 3.0 for enforcing use of valid model property names.
+## Model property names with dot(s) generates an error
 
-See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/947) for more details.
+Instead of showing a deprecation warning for model property names with dots,
+for example, `customer.name: 'string'`, an error is thrown in 3.0 for
+enforcing use of valid model property names.
 
-### Remove wrapper `DataSource.registerType()`
+See [loopback-datasource-juggler#947](https://github.com/strongloop/loopback-datasource-juggler/pull/947).
 
-`DataSource.registerType()` method is removed as it was a wrapper for `ModelBuilder.registerType()` and was deprecated.
+## Array input for updateOrCreate function is no longer allowed
 
-See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/976)
-for more details.
+Allowing updateOrCreate to accept an array as input would only work when
+creating new model instances (not updating them), so this support has been
+removed. Please use `create` function instead (array inputs only worked to
+create new instances with this method before). If you would like to perform a
+bulk `updateOrCreate`, you could use `async.each` or `Promise.all` to
+repeatedly call `updateOfCreate` for each instance.
 
-## strong-remoting
+See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/889) here.
 
-See also [https://github.com/strongloop/loopback/blob/master/3.0-DEVELOPING.md](https://github.com/strongloop/loopback/blob/master/3.0-DEVELOPING.md)
+## Settings `strict: validate` and `strict: throw` were removed
 
-### Invocation for remote method has been changed.
+We have simplified the configuration of `strict` mode back to a simple boolean
+and dropped `validate` and `throw` options.
 
-We are deprecating the `SharedClass.prototype.find` and `SharedClass.prototype.disableMethod` for looking up and disabling remote methods in 3.0.
-They will be replaced by `SharedClass.prototype.findMethodByName` and `SharedClass.prototype.disableMethodByName`
-where you can pass in a static method or a prototype method name.
-These new methods will accept a string in the form of "name" for a static method and "prototype.name" for a prototype method.
+Given the following definition of a User model, when a new User instance is
+created with extra (unknown) properties:
+
+```js
+ds.define('User', {
+  name: String, required: false,
+  age: Number, required: false
+});
+
+var johndoe = new User({ name: 'John doe', age: 15, gender: 'm'});
+```
+
+ - `strict: false` - behavior remains unchanged and unknown properties are be saved along with other properties
+
+    ```js
+    // johndoe is created as
+    {
+      id: 1,
+      name: 'John doe',
+      age: 15,
+      gender: 'm'
+    }
+    ```
+
+- `strict: 'validate'` and `strict: 'throw'` - are no longer supported.
+  Because non-empty string is considered as *truthy*, they share the same
+  behavior as `strict: true`
+
+- `strict: true` - behaviour changes between 2.x and 3.x as follows:
+
+  **Previously in 2.x**
+
+  `strict:true` was silently removing unknown properties. As a result,
+  a User instance is created with unknown properties discarded:
+
+    ```js
+    johndoe.isValid(); //true
+
+    // johndoe is created as
+    {
+      id: 1,
+      name: 'John doe',
+      age: 15
+    }
+    ```
+
+  **New Behavior since 3.0**
+
+    ```js
+    johndoe.isValid(); //false
+
+    // johndoe is NOT created, create operation fails with the following error:
+    // ValidationError: The User instance is not valid.
+    //   Details: gender is not defined in the model (value: 'm').
+    ```
+
+See [loopback-datasource-juggler#1084](https://github.com/strongloop/loopback-datasource-juggler/pull/1084).
+
+## Models with auto-generated ids reject user-provided id values
+
+For security reasons, the default value of the config variable `forceId` is set
+to `true` whenever a model uses auto-generated id. It means creating/updating
+an instance with a client-provided id will return an error message like:
+
+```
+Unhandled rejection ValidationError: The `MyModel` instance is not valid.
+Details: `id` can't be set (value: 1).
+```
+
+You can change `forceId: false` in model JSON file to disable the check, e.g:
+
+```json
+{
+  "name": "Product",
+  "forceId": false
+}
+```
+
+## Sugar API `app.model(modelName, settings)` was removed
+
+`app.model(modelName, settings)`, a sugar for creating non-existing model, is
+now removed in favor of promoting use of:
+- `app.registry.createModel(modelName, properties, options)` to create new model
+- `app.model(modelCtor, config)` to update existing model and attach it to app
+
+See [loopback#2401](https://github.com/strongloop/loopback/pull/2401).
+
+## `Change.handleError` was removed
+
+`Change.handleError` was removed as it was used inconsistenly for a subset of possible
+errors only. All Change methods are reporting errors to the caller via the
+callback now.
+
+Use `PersistedModel` to report change-tracking errors via the existing method
+`PersistedModel.handleChangeError`. This method can be customized on a per-model
+basis to provide different error handling.
+
+See [loopback#2308](https://github.com/strongloop/loopback/pull/2308).
+
+## loopback-datasource-juggler API changes
+
+### Wrapper `DataSource.registerType()` was removed
+
+`DataSource.registerType()` method was removed as it was a deprecated wrapper
+for `ModelBuilder.registerType()`.
+
+See [loopback-datasource-juggler#976](https://github.com/strongloop/loopback-datasource-juggler/pull/976).
+
+## strong-remoting API changes
+
+### Clean-up of API for finding and disabling remote methods
+
+We are deprecating the `SharedClass.prototype.find` and
+`SharedClass.prototype.disableMethod` for looking up and disabling remote
+methods in 3.0. They are superseded by `SharedClass.prototype.findMethodByName`
+and `SharedClass.prototype.disableMethodByName` where you can pass in a static
+method or a prototype method name. These new methods will accept a string in the
+form of "name" for a static method and "prototype.name" for a prototype method.
 
 To find a static remote method:
 `findMethodByName('create')`
@@ -230,46 +517,28 @@ To disable a static remote method
 To disable a prototype remote method:
 `disableMethodByName('prototype.updateAttributes')`
 
-### New error-handler for rest-adapter
+### Type converters replace `Dynamic` API
 
-The REST adapter (typically created via `loopback.rest()`) uses a new error
-handler implementation that provides more secure configuration out of the box.
+The `Dynamic` component was removed in favour of type converters and a
+registry.
 
-The `error.status` has been removed and will be replaced by `error.statusCode`, `statusCode` is more descriptive and avoids ambiguity,
-users relying on `status` will need to change implementation accordingly.
+The following APIs were removed:
 
-To replicate old behavior user can specify `config.local.js` as follow:
-`js module.exports = { remoting : { errorHandler: { handler : function(err, req, res, defaultHandler) { err.status = err.statusCode; defaultHandler(); } } } }`
+```js
+RemoteObjects.convert(name, fn)
+remoteObjectsInstance.convert(name, fn)
+RemoteObjects.defineType(name, fn)
+remoteObjectsInstance.defineType(name, fn)
+```
 
-The environment setting `NODE_ENV='production'` is no longer supported, production vs. debug mode is controlled exclusively by configuration.
-Production environment is assumed by default, the insecure debug mode must be explicitly turned on.
+Two new APIs are added as a replacement:
 
-You can learn more about the rationale behind the new handler in
-[this comment](https://github.com/strongloop/loopback/issues/1650#issuecomment-161920555)
+```js
+remoteObjectsInstance.defineType(name, converter)
+remoteObjectsInstance.defineObjectType(name, factoryFn)
+```
 
-User can specific options in their applications in `config.json` as follow:
-`json { "restApiRoot": "/api", "host": "0.0.0.0", "port": 3000, "remoting": { "errorHandler": { "debug": false, "log": false } } }`
+See the API docs and
+[pull request #343](https://github.com/strongloop/strong-remoting/pull/343)
+for more details.
 
-#### Production mode
-
-Stack trace is never returned in HTTP responses.
-
-Bad Request errors (4xx) provide the following properties copied from the error object:
-`name`, `message`, `statusCode` and `details`.
-
-All other errors (including non-Error values like strings or arrays) provide only basic information:
-`statusCode` and `message` set to status name from HTTP specification.
-
-#### Debug mode
-
-When in debug mode, HTTP responses include all properties provided by the error.
-
-For errors that are not an object, their string value is returned in `message` field.
-
-When a method fails with an array of errors (e.g. bulk create),
-HTTP the response contains still a single wrapper error with `details` set to the original array of errors.
-
-An example of an error response when an array of errors was raised:
-
-Please see [Related code change](https://github.com/strongloop/strong-remoting/pull/302) here,
-and new [`strong-error-handler` here](https://github.com/strongloop/strong-error-handler/).


### PR DESCRIPTION
I have reviewed, updated and improved 3.0 Release Notes. I have identified few more missing items, I'll add them to both release notes and the migration guide in a new PR.

@crandmck please review.

I noticed the top-level blue note box is eats the whole page, because the closing `<div>` elements is quoted in HTML. I tried few tweaks in the source but could not fix the problem. Perhaps it's just my machine?

Connect to strongloop-internal/scrum-loopback#908
