### PR TITLE
LoopBack 3.0: describe replaceOnPUT and removed autoAttach

### DIFF
--- a/pages/en/lb3/3.0-Release-Notes.md
+++ b/pages/en/lb3/3.0-Release-Notes.md
@@ -123,6 +123,64 @@ You can learn more about the rationale behind the new handler in
 See [strong-remoting#302](https://github.com/strongloop/strong-remoting/pull/302)
 and [`strong-error-handler`](https://github.com/strongloop/strong-error-handler/).
 
+## Full replace vs. partial update
+
+There are two ways to update an existing record (model instance):
+
+ - Update (patch) a subset of model properties only, for example
+   update the address field while keeping other properties like email intact.
+
+ - Replace the whole instance with the data provided in the request.
+
+This distinction is important when working with NoSQL databases like MongoDB,
+where it's not possible to unset a property via a partial update.
+
+```js
+// in database
+{ "name": "ibm", "twitter": "@ibm" }
+
+// patch request (user deleted the twitter field)
+{ "name": "ibm", "twitter": undefined }
+
+// result
+{ "name": "ibm", "twitter": "@ibm" }
+```
+
+We have introduced three new data-access operations that perform a full replace:
+
+ - `PersistedModel.prototype.replaceAttributes(data, options, cb)`
+ - `PersistedModel.replaceById(id, data, options, cb)`
+ - `PersistedModel.replaceOrCreate(data, options, cb)`
+
+We also renamed `updateAttributes` to `patchAttributes` and `updateOrCreate`
+to `patchOrCreate` to make their behaviour more clear. The old names are
+preserved as aliases for backwards compatibility.
+
+The biggest change is in the REST API exposed by LoopBack. By default, `PUT`
+endpoints are mapped to replace methods in 3.0 and `PATCH` endpoints are
+introduced to expose the old update/patch methods.
+
+| HTTP endpoint | 3.x method | 2.x method |
+|-|-|-|
+| `PUT`&nbsp;`/MyModels` | `replaceOrCreate` | `updateOrCreate` |
+| `PUT`&nbsp;`/MyModels/:id` | `replaceById` | `prototype.updateAttributes` |
+| `PATCH`&nbsp;`/MyModels` | `updateOrCreate` | `updateOrCreate` |
+| `PATCH`&nbsp;`/MyModels/:id` | `prototype.updateAttributes` | `prototype.updateAttributes` |
+
+Because this change may be quite disruptive, we implemented several measures
+to simplify the upgrade path:
+
+ - A new model-level setting `replaceOnPUT` that can be used to opt into
+  the 2.x HTTP mapping.
+ - Both new methods and the model-level setting were back-ported to 2.x,
+  allowing applications to opt into the new 3.x behaviour while still
+  running on LoopBack 2.x
+
+See [loopback#2316](https://github.com/strongloop/loopback/pull/2316),
+[loopback-datasource-juggler#788](https://github.com/strongloop/loopback-datasource-juggler/pull/788),
+[replaceOnPUT flag](http://loopback.io/doc/en/lb2/Exposing-models-over-REST.html#replaceonput-flag)
+and related documentation.
+
 ## Current context API and middleware were removed
 
 We have removed the following current-context-related APIs:
@@ -485,6 +543,15 @@ Use `PersistedModel` to report change-tracking errors via the existing method
 basis to provide different error handling.
 
 See [loopback#2308](https://github.com/strongloop/loopback/pull/2308).
+
+## `loopback.autoAttach` is gone
+
+Back in LoopBack 2.0, we reworked the way how LoopBack applications are
+bootstrapped, moved the implementation to a new module called
+`loopback-boot` and stopped using `loopback.autoAttach` method and
+`defaultForType` datasource option.
+
+In LoopBack 3.0, we have removed these two APIs completely.
 
 ## loopback-datasource-juggler API changes
 

--- a/pages/en/lb3/Migrating-to-3.0.md
+++ b/pages/en/lb3/Migrating-to-3.0.md
@@ -96,6 +96,40 @@ Building on the error message shown above, you would have to change
 }
 ```
 
+## PUT methods perform full replace now
+
+In LoopBack 3.0, `PUT` endpoints no longer perform a partial update (a patch operation),
+but replace the model instance as whole. If your application is relying on
+partial updates, then you have two migration strategies available:
+
+For short-term, disable the model setting `replaceOnPUT` in your models
+affected by this change. For example, if you have a model `MyModel`, then you
+can change `common/models/my-model.json` as follows:
+
+```json
+{
+  "name": "MyModel",
+  "replaceOnPUT": false,
+  "properties": {
+    "etc."
+  }
+}
+```
+
+In longer term, please rework your clients to switch from `PUT` to
+`PATCH` endpoints, as the option `replaceOnPUT` is likely to be removed
+in a future major version of LoopBack.
+
+If you are writing client code that should work with both major versions
+of LoopBack, then you can use the following HTTP endpoints:
+
+Method | Endpoint
+-|-
+replaceOrCreate | `POST /customers/replaceOrCreate`
+replaceById | `POST /customers/:id/replace`
+updateOrCreate | `PATCH /customers`
+prototype.updateAttributes | `PATCH /customers/:id`
+
 ## Unused `User` properties were removed
 
 We have removed the following properties of the built-in `User` model that
@@ -334,6 +368,24 @@ deprecation warning.
 In this final section, we describe changes that affect only advanced usage
 of LoopBack an its internal components. Instructions described in this section
 are not applicable to typical LoopBack applications.
+
+### Use loopback-boot instead of `loopback.autoAttach`
+
+We have removed `loopback.autoAttach` method and `defaultForType` datasource
+option in LoopBack 3.0. We recommend application developers to use our
+convention-based bootstrapper module
+[loopback-boot](https://www.npmjs.com/package/loopback-boot).
+
+Alternatively, you can modify your code to explicitly attach all models to
+appropriate datasources. For example:
+
+```js
+var MyModel = app.registry.createModel(
+  'MyModel',
+  {/* properties */},
+  {/* options */});
+app.model(MyModel, { dataSource: 'db' });
+```
 
 ### Use `registerType` in `ModelBuilder` instead of `DataSource`
 


### PR DESCRIPTION
Add two missing entries to both release notes and the migration guide:
- The new model setting `replaceOnPUT` and the change in `PUT` endpoints
- Removal of `loopback.autoAttach`

@Amir-61 Could you please review the text for `replaceOnPUT`? Did I describe the changes correctly? Is there anything significant that should be added to help readers to asses the impact of changes and migrate their apps? I am intentionally keeping the description high-level so that we don't duplicate regular documentation.

@crandmck PTAL too.

Connect to strongloop-internal/scrum-loopback#908
