### PR TITLE
Add wiki info to contrib docs

### DIFF
--- a/_data/sidebars/contrib_sidebar.yml
+++ b/_data/sidebars/contrib_sidebar.yml
@@ -2,6 +2,10 @@ title: Contributing to LoopBack
 url: /doc/en/contrib/index.html
 children:
 
+- title: Governance
+  url: /doc/en/contrib/Governance.html
+  output: web, pdf
+
 - title: Contributing code
   url: /doc/en/contrib/code-contrib.html
   output: web, pdf
@@ -36,111 +40,104 @@ children:
   output: web, pdf
 
   children:
-  - title: Getting started with Jekyll
+  - title: Using Jekyll
     url: /doc/en/contrib/jekyll_getting_started.html
     output: web, pdf
+    children:
+      
+    - title: Including READMEs
+      url: /doc/en/contrib/Including-READMEs.html
+      output: web, pdf
 
-  - title: Including READMEs from other repos
-    url: /doc/en/contrib/Including-READMEs.html
+  - title: Authoring pages
+    url: /doc/en/contrib/pages.html
     output: web, pdf
 
-- title: Authoring pages
-  url: /doc/en/contrib/pages.html
-  output: web, pdf
+    children:
+    - title: Conditional logic
+      url: /doc/en/contrib/conditional_logic.html
+      output: web, pdf
 
-  children:
-  - title: Conditional logic
-    url: /doc/en/contrib/conditional_logic.html
+    - title: Content reuse
+      url: /doc/en/contrib/content_reuse.html
+      output: web, pdf
+
+  - title: Navigation
+    url: /doc/en/contrib/navigation.html
     output: web, pdf
 
-  - title: Content reuse
-    url: /doc/en/contrib/content_reuse.html
+    children:
+    - title: Sidebar navigation
+      url: /doc/en/contrib/sidebar_navigation.html
+      output: web, pdf
+
+    - title: Tags
+      url: /doc/en/contrib/tags.html
+      output: web, pdf
+
+  - title: Formatting
+    url: /doc/en/contrib/formatting.html
     output: web, pdf
 
-- title: Navigation
-  url: /doc/en/contrib/navigation.html
-  output: web, pdf
+    children:
+    - title: Alerts
+      url: /doc/en/contrib/alerts.html
+      output: web, pdf
 
-  children:
-  - title: Sidebar navigation
-    url: /doc/en/contrib/sidebar_navigation.html
+    - title: Images
+      url: /doc/en/contrib/images.html
+      output: web, pdf
+
+    - title: Code samples
+      url: /doc/en/contrib/code_samples.html
+      output: web, pdf
+
+    - title: Tooltips
+      url: /doc/en/contrib/adding_tooltips.html
+      output: web, pdf
+
+    - title: Icons
+      url: /doc/en/contrib/icons.html
+      output: web, pdf
+
+    - title: Links
+      url: /doc/en/contrib/hyperlinks.html
+      output: web, pdf
+
+    - title: Navtabs
+      url: /doc/en/contrib/navtabs.html
+      output: web, pdf
+
+    - title: Tables
+      url: /doc/en/contrib/tables.html
+      output: web, pdf
+
+    - title: Syntax highlighting
+      url: /doc/en/contrib/syntax_highlighting.html
+      output: web, pdf
+
+  - title: Special layouts
+    url: /doc/en/contrib/layouts.html
     output: web, pdf
 
-  - title: Tags
-    url: /doc/en/contrib/tags.html
+    children:
+    - title: Glossary layout
+      url: /doc/en/contrib/glossary.html
+      output: web, pdf
+
+    - title: FAQ layout
+      url: /doc/en/contrib/faq_layout.html
+      output: web, pdf
+
+  - title: Translation
+    url: /doc/en/contrib/translation.html
     output: web, pdf
 
-  - title: Series
-    url: /doc/en/contrib/series.html
-    output: web, pdf
+    children:
+    - title: Adding a new language
+      url: /doc/en/contrib/Adding_a_new_language.html
+      output: web, pdf
 
-- title: Formatting
-  url: /doc/en/contrib/formatting.html
-  output: web, pdf
-
-  children:
-  - title: Alerts
-    url: /doc/en/contrib/alerts.html
-    output: web, pdf
-
-  - title: Images
-    url: /doc/en/contrib/images.html
-    output: web, pdf
-
-  - title: Code samples
-    url: /doc/en/contrib/code_samples.html
-    output: web, pdf
-
-  - title: Tooltips
-    url: /doc/en/contrib/adding_tooltips.html
-    output: web, pdf
-
-  - title: Icons
-    url: /doc/en/contrib/icons.html
-    output: web, pdf
-
-  - title: Links
-    url: /doc/en/contrib/hyperlinks.html
-    output: web, pdf
-
-  - title: Navtabs
-    url: /doc/en/contrib/navtabs.html
-    output: web, pdf
-
-  - title: Tables
-    url: /doc/en/contrib/tables.html
-    output: web, pdf
-
-  - title: Syntax highlighting
-    url: /doc/en/contrib/syntax_highlighting.html
-    output: web, pdf
-
-- title: Review comments
-  url: /doc/en/contrib/commenting_on_files.html
-  output: web, pdf
-
-- title: Special layouts
-  url: /doc/en/contrib/layouts.html
-  output: web, pdf
-
-  children:
-  - title: Glossary layout
-    url: /doc/en/contrib/glossary.html
-    output: web, pdf
-
-  - title: FAQ layout
-    url: /doc/en/contrib/faq_layout.html
-    output: web, pdf
-
-- title: Translation
-  url: /doc/en/contrib/translation.html
-  output: web, pdf
-
-  children:
-  - title: Adding a new language
-    url: /doc/en/contrib/Adding_a_new_language.html
-    output: web, pdf
-
-  - title: Translating articles
-    url: /doc/en/contrib/Translating_articles.html
-    output: web, pdf
+    - title: Translating articles
+      url: /doc/en/contrib/Translating_articles.html
+      output: web, pdf

--- a/contributing/index.html
+++ b/contributing/index.html
@@ -3,30 +3,17 @@ layout: overview
 title: Contributing
 item: contributing
 ---
-      <main class="c-content">
-        <section class="c-section">
-          <div class="c-container -padded">
-            <h1 class="c-heading -h2">Contributing to LoopBack</h1>
-          </div>
-        </section>
-        <section class="c-section x-greylight">
-          <div class="c-container -padded">
-            <div class="c-grid">
-              <div class="_col -col-2-3">
-                <p>LoopBack has an active and growing open-source community.  All work on the project occurs in GitHub,
-                primarily in the following repositories:
-                <ul>
-                  <li><a href="https://github.com/strongloop/loopback">loopback</a></li>
-                  <li><a href="https://github.com/strongloop/loopback-datasource-juggler">loopback-datasource-juggler</a></li>
-                  <li><a href="https://github.com/strongloop/loopback-boot">loopback-boot</a></li>
-                  <li><a href="https://github.com/strongloop/loopback-phase">loopback-phase</a></li>
-                  <li><a href="https://github.com/strongloop/generator-loopback">generator-loopback</a></li>
-                </ul>
-                 <p>See <a href="http://loopback.io/doc/en/lb2/index.html#the-loopback-framework">LoopBack  documentation</a> for a complete list of repositories.</p>
-
-<h4 class="c-heading -h3">Feature roadmap</h4>
-
-<p>For a high-level view of the LoopBack roadmap, see <a href="https://github.com/strongloop/loopback/wiki/Roadmap">Roadmap</a>.</p>
+<main class="c-content">
+  <section class="c-section">
+    <div class="c-container -padded">
+      <h1 class="c-heading -h2">Contributing to LoopBack</h1>
+    </div>
+  </section>
+  <section class="c-section x-greylight">
+    <div class="c-container -padded">
+      <div class="c-grid">
+        <div class="_col -col-2-3">
+          <p>LoopBack has an active and growing open-source community.
 
 <h3 class="c-heading -h3">Governance</h3>
 
@@ -38,110 +25,11 @@ The LoopBack project governance model follows the spirit and tradition of open s
 <p>
 LoopBack is an open, inclusive, and tolerant community of people working together to build a world-class Node framework and tools. We value diversity of individuals and opinions, and seek to operate on consensus whenever possible. We strive to maintain a welcoming, inclusive, and harassment-free environment, regardless of the form of communication. When consensus is not achievable, we defer to the owners of each individual module; the powers of the individual owner are kept in check by the ability of the community to fork and replace dependencies on the individual module and maintainer.</p>
 
-<h4 class="c-heading -h4">Maintainers</h4>
-
-<p>Each repository has one or more lead maintainers responsible for:
-
-<ul>
-  <li>Daily operations: approving pull requests, responding to new issues, guiding discussions, and so on.</li>
-  <li>Seeking consensus on technical decisions.</li>
-  <li>Making the final decisions when consensus cannot be achieved.</li>
-</ul>
-
-<p>StrongLoop maintainers have npm publishing rights for modules and StrongLoop has the final say on releasing new versions.</p>
-
-<h4 class="c-heading -h4">Scrum board</h4>
-
+<h3 class="c-heading -h3">More information</h3>
 <p>
-The LoopBack project uses <a href="https://waffle.io/">Waffle</a>, an a agile development tool built on the GitHub API.
-Waffle  provides a easy way to track work and provide project transparency in real time.  We use it to groom and maintain
-our backlog and track what the team and community are working on in each sprint.
+  For all the details about how the LoopBack project is managed and how to contribute, see <a href="/doc/en/contrib/index.html">Contriburting to LoopBack</a>.
 </p>
 
-<p>
-See the <a href="https://waffle.io/strongloop/loopback">LoopBack Waffle Scrum Board</a> for a realtime view of the project.
-For details on how the LoopBack team uses Waffle, see the blog post <a href="https://strongloop.com/strongblog/an-update-on-the-loopback-roadmap-and-backlog/">An Update on the LoopBack Roadmap and Backlog</a>.
-</p>
-
-<h4 class="c-heading -h4">LoopBack lead maintainers</h4>
-
-<p>LoopBack lead maintainers include StrongLoop employees and other active community members:</p>
-
-<!--
-  <div class="c-container">
-    <div class="c-grid -center-v">
-      <div class="_col -col-1-3" style="padding: 10px;">
-        <div class="github-card" data-github="bajtos" data-theme="medium" data-width="250" data-height="150" ></div>
-        <script src="http://lab.lepture.com/github-cards/widget.js"></script>
-      </div>
-      <div class="_col -col-1-3" style="padding: 10px;">
-        <div class="github-card" data-github="raymondfeng" data-theme="medium" data-width="250" data-height="100" ></div>
-        <script src="http://lab.lepture.com/github-cards/widget.js"></script>
-      </div>
-      <div class="_col -col-1-3" style="padding: 10px;">
-        <div class="github-card" data-github="fabien" data-theme="medium" data-width="250" data-height="150" ></div>
-        <script src="http://lab.lepture.com/github-cards/widget.js"></script>
-      </div>
-    </div>
-  </div>
-
-    <div class="c-container">
-    <div class="c-grid -center-v">
-      <div class="_col -col-1-3" style="padding: 10px;">
-        <div class="github-card" data-github="ritch" data-width="250" data-height="100" data-theme="medium"></div>
-        <script src="../src/widget.js"></script>
-      </div>
-      <div class="_col -col-1-3" style="padding: 10px;">
-        <div class="github-card" data-github="STRML" data-width="250" data-height="100" data-theme="medium"></div>
-        <script src="../src/widget.js"></script>
-      </div>
-      <div class="_col -col-1-3" style="padding: 10px;">
-        <div class="github-card" data-github="clarkorz" data-width="250" data-height="100" data-theme="medium"></div>
-        <script src="../src/widget.js"></script>
-      </div>
-    </div>
-  </div>
--->
-
-<ul>
-  <li><a href="https://github.com/bajtos">Miroslav Bajtoš</a></li>
-  <li><a href="https://github.com/raymondfeng">Raymond Feng</a></li>
-  <li><a href="https://github.com/fabien">Fabien Franzen</a></li>
-  <li><a href="https://github.com/ritch">Ritchie Martori</a></li>
-  <li><a href="https://github.com/STRML">Samuel Reed</a></li>
-  <li><a href="https://github.com/clarkorz">Clark Wang</a></li>
-</ul>
-
-      <h3 class="c-heading -h3">Contributing</h3>
-      <p>There are many ways you can contribute to the LoopBack project.  All contributions are welcome!</p>
-
-      <h4 class="c-heading -h4">LoopBack discussion groups</h4>
-<p>The LoopBack community carries on lively discussions in several places:
-  <ul>
-    <li><a href="https://groups.google.com/forum/?fromgroups#!forum/loopbackjs">LoopBackJS Google Group</a></li>
-    <li><a href="http://stackoverflow.com/questions/tagged/strongloop">LoopBack on Stack Overflow</a></li>
-    <li><a href="https://gitter.im/strongloop/loopback">LoopBack on Gitter</a></li>
-  </ul>
-<p> Feel free to learn and participate by asking and answering questions.</p>
-
-      <h4 class="c-heading -h4">Blogs and other social media </h4>
-<p>Do you have a blog post or other content on LoopBack?  <a href="mailto:callback@strongloop.com">Send us a link</a> and we'll promote your work and send you some schwag!
-
-        <h4 class="c-heading -h4">Contributing code</h4>
-<p>If you're interested in contributing, be sure to read the <a href="https://github.com/strongloop/loopback/wiki/Contributing-code">code contribution guidelines</a> first.
-A good place to start is the <a href="https://github.com/strongloop/loopback/issues?q=is%3Aopen+is%3Aissue+label%3A%22Beginner+Friendly%22">list of open issues</a>.</p>
-
-<p>For code donated by community members and other community-led projects, check out the <a href="https://github.com/strongloop-community">GitHub StrongLoop Community Org</a>.
-
-                <h4 class="c-heading -h4">Contributing to documentation</h4>
-                <p>We welcome input and help with the documentation.  If you're interested in contributing to the documentation, see <a href="http://loopback.io/doc/en/contrib/index.html">Contributing to LoopBack documentation</a>.</p>
-
-                <h4 class="c-heading -h4">Reporting issues</h4>
-                <p>You can also contribute by reporting new issues; please see <a href="https://github.com/strongloop/loopback/wiki/Reporting-issues">Reporting issues</a> for general guidelines.
-New issues start in an un-labelled state. During triage, if the requirements and/or steps-to-reproduce are clear, the issue is labelled as "bug" or "enhancement".
-If the issue description is not good enough, leave a comment asking the reporter to provide the specific information needed, and label the issue as "triage".
-Issues that are questions will be redirected to the mailing list and closed straight away.
-</p>
               </div>
             </div>
           </div>

--- a/pages/en/contrib/Adding_a_new_language.md
+++ b/pages/en/contrib/Adding_a_new_language.md
@@ -35,7 +35,7 @@ Edit it as follows:
 ...    
 ```
 6. Add to `_data/topnav.yml` (under the `title: Translations` list)
-7. Ensure all pages have the proper front matter; for example:
+7. Ensure all translated pages have the proper front matter; for example:
 
 ```
 lang: xx
@@ -46,10 +46,13 @@ sidebar: xx_lb2_sidebar
 permalink: /doc/xx/lb2/Access-token-REST-API.html
 ```
 
-Note the `translated` layout.  This adds the translation disclaimer at the top of the page.
+Note the `translation` layout.  This adds the translation disclaimer at the top of the page.
 
 {% include note.html content="If you add any new \"stub\" pages (pages that are not fully translated), also add `trans_complete: false` in the front matter.
 " %}
+
+Best practices is _not_ to include untranslated pages, except for the `index.md` "front page"; even if you 
+haven't translated this page, you can include some text in the target language stating that translation into this language is underway.
 
 ## Importing existing translations
 

--- a/pages/en/contrib/Governance.md
+++ b/pages/en/contrib/Governance.md
@@ -1,0 +1,38 @@
+---
+title: Governance
+keywords: LoopBack community
+tags: [community]
+sidebar: contrib_sidebar
+permalink: /doc/en/contrib/Governance.html
+summary: The LoopBack project governance model follows the spirit and tradition of open source by embracing consensus, forking, and individual ownership.
+---
+
+## Principles
+
+LoopBack is an open, inclusive, and tolerant community of people working together to build a world-class Node framework and tools. We value diversity of individuals and opinions, and seek to operate on consensus whenever possible. We strive to maintain a welcoming, inclusive, and harassment-free environment, regardless of the form of communication. When consensus is not achievable, we defer to the owners of each individual module; the powers of the individual owner are kept in check by the ability of the community to fork and replace dependencies on the individual module and maintainer.
+
+## Maintainers
+
+Each repository has one or more lead maintainers responsible for:
+
+*   Daily operations: approving pull requests, responding to new issues, guiding discussions, and so on.
+*   Seeking consensus on technical decisions.
+*   Making the final decisions when consensus cannot be achieved.
+
+Maintainers have npm publishing rights for modules and the final say on releasing new versions.
+
+## Lead maintainers
+
+LoopBack lead maintainers include:
+
+*   [Miroslav Bajtoš](https://github.com/bajtos)
+*   [Raymond Feng](https://github.com/raymondfeng)
+*   [Ritchie Martori](https://github.com/ritch)
+
+For more details, see [Functional area owners](functional-area-owners.html).
+
+## Scrum board
+
+The LoopBack project uses [Waffle](https://waffle.io/), an agile development tool built on the GitHub API. Waffle provides a easy way to track work and provide project transparency in real time. We use it to groom and maintain our backlog and track what the team and community are working on in each sprint.
+
+See the [LoopBack Waffle Scrum Board](https://waffle.io/strongloop/loopback) for a realtime view of the project. For details on how the LoopBack team uses Waffle, see [the related blog post](https://strongloop.com/strongblog/an-update-on-the-loopback-roadmap-and-backlog/).

--- a/pages/en/contrib/Including-READMEs.md
+++ b/pages/en/contrib/Including-READMEs.md
@@ -1,7 +1,7 @@
 ---
-title: Including READMEs
+title: Including READMEs from other repositories
 keywords: LoopBack documentation
-tags:
+tags: [community, contributing]
 sidebar: contrib_sidebar
 permalink: /doc/en/contrib/Including-READMEs.html
 summary:

--- a/pages/en/contrib/Reporting-issues.md
+++ b/pages/en/contrib/Reporting-issues.md
@@ -1,30 +1,46 @@
 ---
 title: Reporting issues
 keywords: LoopBack community
-tags: [getting_started]
+tags: [community, contributing]
 sidebar: contrib_sidebar
 permalink: /doc/en/contrib/Reporting-issues.html
-summary: This is a guide on what to do when you run into issues while using LoopBack.
+summary: Follow the procedure outlined here when reporting issues with the LoopBack project.
 ---
 
-Follow the procedure outlined here when reporting issues with the LoopBack project.
+## Asking questions
 
-{% include important.html content="
-DO NOT post questions using GitHub issues
-
-Questions posted to GitHub issues will be closed IMMEDIATELY as we only accept feature requests and bug reports there.  Instead, ask your question on the [LoopBack Google Group](https://groups.google.com/forum/#!forum/loopbackjs),   [StackOverflow](http://stackoverflow.com/questions/tagged/loopbackjs+or+strongloop?sort=newest&pageSize=50), or [Gitter](https://gitter.im/strongloop/loopback)
-
-Posting to Google Group is preferred so others may benefit.
+{% include warning.html content="
+DO NOT post questions as GitHub issues, which are for feature requests and bug reports _only_.  Questions will be closed IMMEDIATELY.  
 " %}
 
-## 1. Determine the issue type
+If you have a question about how to do something in LoopBack, follow these steps:
+
+1. [Consult the documentation](doc/en/lb2/) and the [API documentation](http://apidocs.strongloop.com).  **NOTE**: The search box above searches _both_ of these sites.
+1. If you don't find an answer to your question, then do one of the following:
+  - Ask on the [developer forum / Google group](https://groups.google.com/forum/#!forum/loopbackjs).
+  - Search and then ask on  [StackOverflow](http://stackoverflow.com/questions/tagged/loopbackjs+or+strongloop?sort=newest&pageSize=50).
+  - Ask on [Gitter](https://gitter.im/strongloop/loopback).  
+
+Posting to Google Group or StackOverflow is preferred so others may benefit from the answer.
+
+## Procedure
+
+To report an issue, follow these basic steps:
+
+ 1. Search [existing issues](https://github.com/strongloop/loopback/issues).  It's possible someone has already reported the same problem.
+ 1. Make sure you have a [GitHub account](https://github.com/signup/free).
+ 1. Create a [new issue](https://github.com/strongloop/loopback/issues) for the bug, following the steps outlined below
+
+For more information, see [Reporting issues](Reporting-issues.html).
+
+### 1. Determine the issue type
 
 There are three types of issues:
 - Questions - Please post to the [developer forum (Google Group)](https://groups.google.com/forum/#!forum/loopbackjs) instead.
 - [Feature/enhancement request](#featureenhancement-request)
 - [Bug report](#bug-report)
 
-### Security issues
+#### Security issues
 
 Do not report security vulnerabilities using GitHub issues. Please send an email to `callback@ibm.com` with:
 
@@ -32,13 +48,13 @@ Do not report security vulnerabilities using GitHub issues. Please send an email
 - Steps to reproduce the issue.
 - Possible solutions.
 
-### Feature requests
+#### Feature requests
 
 Open a new GitHub issue at https://github.com/strongloop/loopback/issues.
 
 For feature/enhancement requests related to specific LoopBack dependencies (for example, `loopback-connector-mysql`), please create an issue in the repository itself (for example,  https://github.com/strongloop/loopback-connector-mysql/issues).
 
-### Bug report
+#### Bug report
 
 To report a bug:
 
@@ -46,24 +62,27 @@ To report a bug:
 2. Add the code required to reproduce your issue in the forked repository.
 3. Create an issue in the appropriate repository with STR (steps to reproduce) in the issue description **AND** a link to the forked repository.
 
-> From this point, we will clone the the forked repository and try to reproduce the issue on our own machines. Once verified, we will respond to you and prioritize the fix accordingly.
+From this point, we will clone the the forked repository and try to reproduce the issue on our own machines. Once verified, we will respond to you and prioritize the fix accordingly.
 
 We recommend forking with STR in order to leverage community support in reproducing issues. By doing this, we can focus on fixing and responding to the actual issues.
 
-> We give priority to issues that follow the above process, that is, those with a forked repository for us to clone and clear STR.
+{% include tip.html content="We give priority to issues that follow the above process, that is, those with a forked repository for us to clone and clear STR.
+" %}
 
-For  bug reports related to specific LoopBack dependencies (for example, `loopback-connector-mysql`), please create an issue in the repository itself (for example,  https://github.com/strongloop/loopback-connector-mysql/issues).
+For  bug reports related to specific LoopBack dependencies (for example, `loopback-connector-mysql`), please create an issue in the repository itself; for example,  [loopback-connector-mysql](https://github.com/strongloop/loopback-connector-mysql/issues).
 
-## 2. Report the issue using an appropriate channel
+### 2. Report the issue in appropriate channel
 
-We officially support multiple channels for specific purposes. Please choose the **SINGLE** most appropriate channel to report your issue to.
+We support multiple channels for specific purposes. Please choose the **SINGLE** most appropriate channel to report your issue to.
 
-> Please try to post issues to the correct repository (for example, boot-related issues to `loopback-boot`, REST and remoting-related issues to `strong-remoting`, and so on). If you cannot determine which project to report the issue to, post the issue in the LoopBack repository itself.
+{% include note.html content="Post issues to the correct repository (for example, boot-related issues to `loopback-boot`, REST and remoting-related issues to `strong-remoting`, and so on). If you cannot determine which project to report the issue to, post the issue in the `loopback` repository itself.
+" %}
 
-## 3. Wait for a response
+### 3. Wait for a response
 
 We actively monitor the officially supported channels and generally respond as soon as possible. If you haven't received a response from us within two days, please remind us on [Google Groups](https://groups.google.com/forum/#!forum/loopbackjs) or ping us on [Gitter](https://gitter.im/strongloop/loopback).
 
-> If your issue turns out to be a question, you will be asked to post on the Google Group mailing list instead. We will then tag the issue with the `question` label and close it immediately.
+{% include tip.html content=" If your issue turns out to be a question, you will be asked to post on the Google Group mailing list instead. We will then tag the issue with the `question` label and close it immediately.
+" %}
 
 We also encourage community participation with regards to resolving issues. If you know the answer to any issues you encounter, please chime in and help each other out. We will also try our best to help users who are actively helping other users.

--- a/pages/en/contrib/code-contrib.md
+++ b/pages/en/contrib/code-contrib.md
@@ -1,17 +1,109 @@
 ---
 title: Contributing code
-tags: [contributing]
+tags: [community, contributing]
 keywords: LoopBack, open-source
 last_updated: Sept 27, 2016
-summary: ""
+summary: "This article explains the process and guidelines for contributing code to the LoopBack project."
 sidebar: contrib_sidebar
 permalink: /doc/en/contrib/code-contrib.html
 ---
 
-The LoopBack project welcomes code contributions.  Here are some guidelines and other useful information for contributors:
+## How to contribute to the code
 
-- [Triaging pull requests](triaging-pull-requests.html)
-- [Coding style guide](style-guide.html)
-- [Git commit message guidelines](git-commit-messages.html)
-- [Using ESLint with LoopBack](eslint-guide.html)
-- [Functional area owners](functional-area-owners.html)
+You can contribute in a number of ways:
+
+* [Report an issue](#reporting-an-issue).   Reporting it first will ensure that it is
+  in fact an issue, and there is not already a fix in the works.
+* After reporting a bug, go one step further and fix it.
+* Ensure that your effort is aligned with the project's roadmap by
+  talking to the maintainers, especially if you are going to spend a
+  lot of time on it.
+* Adhere to code style outlined in the [Google C++ Style Guide][] and
+  [Google Javascript Style Guide][].
+* [Sign your patches](#signing-patches) to indicate that your are
+  making your contribution available under the terms of the
+  [Contributor License Agreement](#contributor-license-agreement).
+* [Submit a pull request](#submitting-a-pull-request) through Github.
+* Run tests; see [Running tests](#running-tests).
+
+## Where to start
+
+If you are looking to contribute, but aren't sure where to start, review open pull requests for the module.  For example: [LoopBack open pull requests](https://github.com/strongloop/loopback/pulls).
+
+Also, please read the source code before contributing. If something is confusing, poorly documented, poorly commented, or could otherwise be improved: open a GitHub issue and link to the file and line of code with a useful description of what you would like to see or think is missing.
+
+### Recommended Node.js version for code contributions
+
+Code contributions should only be using features and language constructs available in v0.10.
+
+{% include note.html content="Check your Node.js version with the command `node -v`.
+" %}
+
+At this time, we are still supporting Node.js v0.10 and do not transpile. We would like to change this in the near future (ie. drop support for versions older than 4/6 or transpile), but extra caution is required as this update would affect a large number of users. Thanks for your patience.
+
+## Submitting a pull request
+
+Follow the [GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html).
+
+ 1. Create a GitHub issue for large changes and discuss the change there before
+    coding. You can skip this step and submit the pull request for minor
+    changes.
+ 1. Fork the repository on GitHub.
+ 1. Create a branch for you change/feature off of the master branch.
+ 1. Make your change. Remember to update tests as well as code! Always
+    run all the tests to assure nothing else was accidentally broken. For bugs, adding a failing test and submitting a pull request usually leads to the bug being fixed quickly. For features, include tests that cover the entire feature. For remote / client facing features, include integration tests in the [loopback-example-app](](https://github.com/strongloop/loopback-example-app).
+ 1. Check for unnecessary whitespace with `git diff --check` before committing.
+ 1. Make commits of logical units and push them to Github.
+ 1. Use a descriptive commit message, and follow
+    [50/72 format](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ 1. Use GitHub's pull requests to submit the patch. Feel free to issue the pull
+    request as soon as you have something partial to show and get reviewed.
+    You can add more commits to your pull request as you are progressing
+    on the implementation.  The title of the pull request should start
+    with "WIP" for "work in progress" when the pull request is not complete
+    yet.
+ 1. Request a code review. Add a specific committer to speed up this process. (for example, `@bajtos`, `@raymondfeng`).
+ 1. Make any requested changes and push to your fork. Make sure your changes are still based on the latest code (use `git rebase upstream/master`).
+
+## Running tests
+
+All LoopBack projects follow the same convention for running tests. To run a projects test suite, change to the project's directory and run:
+
+```sh
+npm test
+```
+
+If a test is failing, you should open an issue on the appropriate repositories GitHub issues page.
+
+#### Signing patches
+
+Like many open source projects, we need you to agree to a contributor license agreement
+before we can merge in your changes.
+
+In summary, by submitting your code, you are granting us a right to use
+that code under the terms of this agreement, including providing it to
+others. You are also certifying that you wrote it, and that you are
+allowed to license it to us. You are not giving up your copyright in
+your work. The license does not change your rights to use your own
+contributions for any other purpose.
+
+Contributor License Agreements are important because they define the
+chain of ownership of a piece of software. Some companies won't allow
+the use of free software without clear agreements around code ownership.
+That's why many open source projects collect similar agreements from
+contributors. The LoopBack CLA is based on the Apache CLA.
+
+To signify your agreement to these terms, add the following line to the
+bottom of your commit message. Use your real name and an actual e-mail
+address.
+
+```
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+Alternatively you can use the git command line to automatically add this
+line, as follows:
+
+```
+$ git commit -sm "Replace rainbows by unicorns"
+```

--- a/pages/en/contrib/doc-contrib.md
+++ b/pages/en/contrib/doc-contrib.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing to LoopBack documentation
 keywords: LoopBack documentation
-tags: [getting_started]
+tags: [community, contributing]
 sidebar: contrib_sidebar
 permalink: /doc/en/contrib/doc-contrib.html
 summary: We welcome contributions to LoopBack documentation!

--- a/pages/en/contrib/index.md
+++ b/pages/en/contrib/index.md
@@ -1,13 +1,50 @@
 ---
 title: Contributing to LoopBack
 keywords: LoopBack community
-tags: [getting_started]
+tags: [community, contributing]
 sidebar: contrib_sidebar
 permalink: /doc/en/contrib/index.html
-summary: We welcome contributions to LoopBack, in both code and documentation!
+summary: Contributions to the LoopBack project are welcome!
 ---
 
-You can contribute to the LoopBack project in many different ways.
+LoopBack has an active and growing open-source community. All work on the project occurs in GitHub, primarily in the following repositories:
 
-{% include note.html content="More detail to come!
-" %}
+*   [loopback](https://github.com/strongloop/loopback)
+*   [loopback-datasource-juggler](https://github.com/strongloop/loopback-datasource-juggler)
+*   [loopback-boot](https://github.com/strongloop/loopback-boot)
+*   [loopback-phase](https://github.com/strongloop/loopback-phase)
+*   [generator-loopback](https://github.com/strongloop/generator-loopback)
+
+See [LoopBack 2.x](/doc/en/lb2/index.html#the-loopback-framework) for a complete list of repositories.
+
+## Contributing
+
+You can contribute to the LoopBack project in several ways. All contributions are welcome!
+
+### Contributing to code
+
+If you're interested in contributing to the code, be sure to read the [code contribution guidelines](code-contrib.html) first. A good place to start is the [list of open issues](https://github.com/strongloop/loopback/issues?q=is%3Aopen+is%3Aissue+label%3A%22Beginner+Friendly%22).
+
+For code donated by community members and other community-led projects, check out the [GitHub StrongLoop Community Org](https://github.com/strongloop-community).
+
+### Contributing to documentation
+
+We welcome input and help with the documentation. If you're interested in contributing to the documentation, see [Contributing to LoopBack documentation](doc-contrib.html).
+
+### Reporting issues
+
+You can also contribute by reporting new issues; please see [Reporting issues](https://github.com/strongloop/loopback/wiki/Reporting-issues) for general guidelines. New issues start in an un-labelled state. During triage, if the requirements and/or steps-to-reproduce are clear, the issue is labelled as "bug" or "enhancement". If the issue description is not good enough, leave a comment asking the reporter to provide the specific information needed, and label the issue as "triage". Issues that are questions will be redirected to the mailing list and closed straight away.
+
+## Communication channels
+
+The LoopBack community carries on lively discussions in several places:
+
+*   [LoopBackJS Google Group](https://groups.google.com/forum/?fromgroups#!forum/loopbackjs)
+*   [LoopBack on Stack Overflow](http://stackoverflow.com/questions/tagged/strongloop)
+*   [LoopBack on Gitter](https://gitter.im/strongloop/loopback)
+
+Feel free to learn and participate by asking and answering questions.
+
+### Blogs and other social media
+
+Do you have a blog post or other content on LoopBack? [Send us a link](mailto:callback@ibm.com) and we'll promote your work and send you some schwag!

--- a/pages/en/contrib/style-guide.md
+++ b/pages/en/contrib/style-guide.md
@@ -1,9 +1,9 @@
 ---
 title: Coding style guide
-tags: [contributing]
+tags: [contributing, community]
 keywords:
 last_updated: Sept 27, 2016
-summary: ""
+summary: "These are LoopBack's general coding style guidelines."
 sidebar: contrib_sidebar
 permalink: /doc/en/contrib/style-guide.html
 ---
@@ -16,7 +16,7 @@ Style conventions for this document:
 
 ## General guidelines
 
-### One arg per line
+### One argument per line
 
 Once you cannot fit all arguments into a single line shorter than 80 chars, it's better to place each argument on a new line.
 
@@ -498,3 +498,8 @@ context('Model', function() {
   ...
 });
 ```
+
+## See also
+
+- [Google C++ Style Guide]: https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml
+- [Google Javascript Style Guide]: https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml


### PR DESCRIPTION
This addresses https://github.com/strongloop/loopback/issues/2776
It also reorganizes the "Contributing" sidebar.

@superkhau 
