### PR TITLE
Fixing sidebar visual bug

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,6 @@
 {% include custom/sidebarconfigs.html %}
 <!-- NOTE: sidebar = site.data.sidebars.mydoc_sidebar.entries -->
 <div class="sidebarTitle"><a href="{{sidebar.url}}">{{sidebar.title}}</a></div>
-<ul id="mysidebar" class="nav nav-list">
+<ul id="mysidebar" class="nav-list">
   {% include sidebar_menu_list_items.liquid menuitems=sidebar.children %}
 </ul>

--- a/_includes/sidebar_menu_list_items.liquid
+++ b/_includes/sidebar_menu_list_items.liquid
@@ -2,7 +2,7 @@
 
   {% comment %} Is this supposed to be ouput on the `web`site?{% endcomment %}
   {% if item.output contains "web" %}
-  <li class="{% if item.children.size > 0 %} tree-parent {% endif %} {% if page.url == item.url %}active{% endif %}">
+  <li class="{% if item.children.size > 0 %} tree-parent {%else%} leaf-node {% endif %} {% if page.url == item.url %}active{% endif %}">
     {% if item.children.size > 0 %} <a class="show-hide" href="#"></span> {% endif %}
     <a class="page-link" href="{{item.url}}">{{ item.title }}</a>
       {% if item.children.size > 0 %}

--- a/_includes/sidebar_menu_list_items.liquid
+++ b/_includes/sidebar_menu_list_items.liquid
@@ -4,9 +4,9 @@
   {% if item.output contains "web" %}
   <li class="{% if item.children.size > 0 %} tree-parent {% endif %} {% if page.url == item.url %}active{% endif %}">
     {% if item.children.size > 0 %} <a class="show-hide" href="#"></span> {% endif %}
-    <a href="{{item.url}}">{{ item.title }}</a>
+    <a class="page-link" href="{{item.url}}">{{ item.title }}</a>
       {% if item.children.size > 0 %}
-      <ul class="nav nav-list">
+      <ul class="nav-list">
           {% include sidebar_menu_list_items.liquid menuitems=item.children %}
       </ul>
       {% endif %}

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -672,8 +672,15 @@ ul#mysidebar, #mysidebar ul{
   border-radius:5px;
 }
 
-#mysidebar .tree-parent>.page-link {
+#mysidebar .page-link {
   margin-left: 1em;
+}
+
+#mysidebar .leaf-node>.page-link::before{
+  content: "▪";
+  float:left;
+  width:1em;
+  margin-left:-1em;
 }
 
 #mysidebar .show-hide{

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -637,56 +637,71 @@ ol.series li {
 }
 
 /* tree nav */
-.nav-list{
-  padding-left: 1em;
-}
+
 #mysidebar {
   display:block;
+}
+
+#mysidebar ul {
+  list-style: none;
+  margin-left:1em;
+}
+
+ul#mysidebar, #mysidebar ul{
+  list-style: none;
+  padding-left:0;
+} 
+
+#mysidebar li{
+  margin-top:.1em;
+  line-height:1.1em;
+}
+
+#mysidebar li > a{
+    display: block;
+}
+
+#mysidebar .page-link{
+  padding: 3px 5px;
+  border-radius:5px;
+}
+
+#mysidebar .tree-parent>.page-link {
+  margin-left: 1em;
+}
+
+#mysidebar .show-hide{
+  float:left;
+  width:.8em;
+  padding-left:.3em;
 }
 
 .tree-parent.expanded .nav-list{
   display:block;
 }
 
-#mysidebar .nav li {
-  margin-left:1em;
-}
-
-.nav > li > a {
-  padding:2px;
-  border-radius:10px;
-}
-
-.nav > li > a + a {
-  margin-left:1em;
-  padding-left:10px;
-}
-
-li.tree-parent{
-  margin-left:-1em;
-  padding-left:1em;
-}
-
-li.tree-parent a.show-hide{
-  width:1em;
-  float: left;
-}
-.nav > li.active > a.show-hide,
-.nav > li > a.show-hide:hover,
-.nav > li > a.show-hide:active{
+#mysidebar li.active a.show-hide,
+#mysidebar a.show-hide:hover,
+#mysidebar a.show-hide:active{
   background:none;
   border:none;
+  text-decoration: none;
 }
 
-.nav > li.active > a,
-.nav > li> a:hover{
-  background-color: lightblue;
+#mysidebar li.active>a.page-link,
+#mysidebar a.page-link:hover{
+  background: lightblue;
+  text-decoration: none;
 }
 
-li.tree-parent>a.show-hide::before{
+li.tree-parent.expanded {
+  background: linear-gradient(to right, white, white 4px, lightgray 4px, lightgray 10px, white 10px, white);
+}
+
+#mysidebar a.show-hide::before{
   content: "+";
 }
-li.tree-parent.expanded>a.show-hide::before{
+#mysidebar .expanded>a.show-hide::before{
   content: "-";
 }
 /* */

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -636,6 +636,12 @@ ol.series li {
     border-color: #248ec2 !important;
 }
 
+/* topbar nav */
+
+.topnavlinks .nav > li > a {
+    padding: 2px;
+}
+
 /* tree nav */
 
 #mysidebar {
@@ -692,10 +698,6 @@ ul#mysidebar, #mysidebar ul{
 #mysidebar a.page-link:hover{
   background: lightblue;
   text-decoration: none;
-}
-
-li.tree-parent.expanded {
-  background: linear-gradient(to right, white, white 4px, lightgray 4px, lightgray 10px, white 10px, white);
 }
 
 #mysidebar a.show-hide::before{


### PR DESCRIPTION
Take a look and let me know how you like these styles.

lining the "+" up with leaf page titles (essentially, moving the page titles left) caused a visual issue wherein the indentation on page titles for sub-menus was too little to see. Fix options were:
1. indent whole list more : works but for 2, 3, 4 deep menus these indentations add up
2. visually offset child menus: this is what I went with, see below. I know it doesn't look that pretty but it gets the job done in terms of communicating hierarchy. Let me know if you'd like it changed.

![screen shot 2016-09-30 at 5 54 27 pm](https://cloud.githubusercontent.com/assets/317498/19008151/4471eea0-8737-11e6-93e1-86be0c4beaa7.png)
