### PR TITLE
Add markdown linting script

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD018": true,
+  "MD003": { "style": "atx" }
+}

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ summary: A brief tutorial on creating an Angular client app using the Loopback A
 
 {% include readmes/loopback-example-angular.md %}
 ```
+
+### Linting Readmes
+
+There is an additional `npm script` that "lints" the readmes for markdown formatting problems. It is currently "experimental", see #49 for more info.
+
+You can run this script thus:
+
+```js
+$ npm run lint-readmes
+```

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ port: 4001
 exclude:
   - .idea/
   - .gitignore
+  - node_modules
 # these are the files and directories that jekyll will exclude from the build
 
 feedback_email: rmckinn@us.ibm.com

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "1.0.0",
   "description": "This file: Node-dependant workflow scripts for the jekyll-based site",
   "scripts": {
-    "fetch-readmes": "get-readmes --repos=./_data --out=./_includes/readmes"
+    "fetch-readmes": "get-readmes --repos=./_data --out=./_includes/readmes",
+    "lint-readmes" : "markdownlint _includes/readmes/"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Strongloop/loopback.io.git"
   },
   "devDependencies": {
-    "getreadmes": "github:strongloop/get-readmes"
+    "getreadmes": "github:strongloop/get-readmes",
+    "markdownlint-cli": "github:sequoia/markdownlint-cli"
   }
 }


### PR DESCRIPTION
Related to #49 (tho it does not necessarily close it). See #49 for extensive discussion of the problem & solution contained herein.

This PR does **not** tie the linting task into the `fetch-readmes` task as almost all readmes would fail currently. Once all readmes are cleaned up & commit hooks are set up on targeted repos, we can add the check here as well if needed.
