### PR TITLE
Explain limitation of where filter

### DIFF
--- a/pages/en/lb2/Where-filter.md
+++ b/pages/en/lb2/Where-filter.md
@@ -30,6 +30,37 @@ For example, here is a query to find cars with `odo` is less than 30,000:
 
 You can also use [stringified JSON format](/doc/{{page.lang}}/lb2/Querying-data.html#using-stringified-json-in-rest-queries) in a REST query.
 
+{% include important.html content="
+There is a 20 filters limitation using this format from [qs](https://github.com/ljharb/qs#parsing-arrays) where it maps arrays with over 20 indices to an object,
+which converts your filter into an `Object` where it is expecting an `Array`, See [Issue](https://github.com/strongloop/loopback/issues/2824) for more details.
+A work around would be to override the query parsing middleware, with your own options as the following, or to use a stringified JSON instead.
+" %}
+
+### How to work-around the 20 filters limit in query format
+
+**Encode the large filter object as JSON**
+```
+http://localhost:3000/api/Books
+?filter={"where":{"or":[{"id":1},{"id":2},...,{"id":20"},{"id":21}]}}
+```
+
+**Override Limit**
+
+```js
+// In `server/server.js`, before boot is called
+var loopback = require('loopback');
+var boot = require('loopback-boot');
+var qs = require('qs');
+
+var app = module.exports = loopback();
+app.set('query parser', function(value, option) {
+  return qs.parse(value, {arrayLimit: 500});
+});
+
+app.start = function() {
+  ...
+```
+
 ## Node API
 
 {% include content/angular-methods-caveat.html lang=page.lang %}
@@ -257,8 +288,8 @@ see [Regular Expressions (Mozilla Developer Network)](https://developer.mozilla
 
 {% include tip.html content="
 The above where clause syntax is for queries. For updates and deletes, omit the `{ where : ... }` wrapper.
-See [Where clause for other methods](#where-clause-for-other-methods) below."
-%}
+See [Where clause for other methods](#where-clause-for-other-methods) below.
+" %}
 
 For example, this query returns all cars for which the model starts with a capital "T":
 


### PR DESCRIPTION
Where filter in `api/Books?filter[where][or][0][id]=1` format
can only handle 20 parameters.
See strongloop/loopback/issues/2824 for more details

it will look something like the following picture to save you some compile time if you only want to make text changes.

![screen shot 2016-10-12 at 6 43 43 pm](https://cloud.githubusercontent.com/assets/1787590/19330423/542ecc68-90ac-11e6-98cd-8711bed83ec3.png)

@crandmck PTAL 
