### PR TITLE
Remove property lazyConnect in doc

### DIFF
--- a/pages/en/lb2/datasources.json.md
+++ b/pages/en/lb2/datasources.json.md
@@ -65,10 +65,6 @@ All data sources support a few standard properties. Beyond that, specific proper
       </td>
     </tr>
     <tr>
-      <td>lazyConnect</td>
-      <td>If true, then defer connection.  If false, connects to the data source when the app starts.</td>
-    </tr>    
-    <tr>
       <td>name</td>
       <td>Name of the data source being defined.</td>
     </tr>


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback/issues/2850

There is a bug of ds config property `lazyConnect`, it won't affect our internal use (when used by apic), but it's better not documented to let users set it.

It's not a easy fix so as a workaround I delete `lazyConnect` in doc.
