### PR TITLE
Add four community projects and update instructions

### DIFF
--- a/_data/repos-community.json
+++ b/_data/repos-community.json
@@ -1,0 +1,8 @@
+{
+  "repos" : [
+  { "org": "strongloop-community", "repoName":  "StrongLoop-IoT-Demo"},
+  { "org": "strongloop-community", "repoName":  "loopback-connector-elastic-search"},
+  { "org": "Sequoia", "repoName":  "loopback-json-schemas"},
+  { "org": "mean-expert-official", "repoName":  "loopback-sdk-builder"}
+ ]
+}

--- a/_data/sidebars/community_sidebar.yml
+++ b/_data/sidebars/community_sidebar.yml
@@ -6,11 +6,22 @@ children:
     url: /doc/en/community/How-to-add-a-project.html
     output: 'web'
 
-  - title: 'Active projects'
-    url: /doc/en/community/Active-projects.html
+  - title: 'Elasticsearch connector'
+    url: /doc/en/community/Elasticsearch-connector.html
     output: 'web'
-    children:
 
-    - title: 'Sample project'
-      url: /doc/en/community/Sample-project.html
-      output: 'web'
+  - title: 'LoopBack SDK Builder'
+    url: /doc/en/community/SDK-builder.html
+    output: 'web'
+
+  - title: 'JSON Schemas'
+    url: /doc/en/community/JSON-schemas.html
+    output: 'web'
+
+  - title: 'IoT demo'
+    url: /doc/en/community/IoT-demo.html
+    output: 'web'
+
+  - title: 'Sample project'
+    url: /doc/en/community/Sample-project.html
+    output: 'web'

--- a/_layouts/readme.html
+++ b/_layouts/readme.html
@@ -5,7 +5,6 @@ toc: 'false'
 <style>
 h1:not(.post-title-main) { display: none; }
 </style>
-
 {% if page.source %}
   {% if page.branch %}
     {% assign repo-branch = page.source | append: '/tree/' | append: page.branch %}
@@ -15,9 +14,10 @@ h1:not(.post-title-main) { display: none; }
     {% assign readme-file = page.source  %}
   {% endif %}
 
+  {% assign org = page.org | default: "strongloop" %}
   <div class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i>
     <b>Note:</b> This page was generated from the
-    <a href="https://github.com/strongloop/{{repo-branch}}">{{page.source}} README</a>.
+    <a href="https://github.com/{{org}}/{{repo-branch}}">{{page.source}} README</a>.
   </div>
 
   {% include toc.html %}

--- a/pages/en/community/Elastic-search-connector.md
+++ b/pages/en/community/Elastic-search-connector.md
@@ -1,0 +1,13 @@
+---
+title: "Elastic Search connector"
+lang: en
+layout: readme
+toc: false
+source: loopback-connector-elastic-search
+org: strongloop-community
+keywords: LoopBack
+tags: [community]
+sidebar: community_sidebar
+permalink: /doc/en/community/Elasticsearch-connector.html
+summary: The Elasticsearch connector enables LoopBack applications to connect to Elasticsearch data sources.
+---

--- a/pages/en/community/How-to-add-a-project.md
+++ b/pages/en/community/How-to-add-a-project.md
@@ -9,27 +9,89 @@ permalink: /doc/en/community/How-to-add-a-project.html
 
 To add your community project here, follow these steps:
 
-1. Fork the [strongloop/loopback.io repository](https://github.com/strongloop/loopback.io.git) (see [Fork a repo](https://help.github.com/articles/fork-a-repo/) for instructions).
+First, fork the [strongloop/loopback.io repository](https://github.com/strongloop/loopback.io.git) (see [Fork a repo](https://help.github.com/articles/fork-a-repo/) for instructions).
+
+Now, you have two options:
+
+- If your project repository has a good, detailed README, you can reuse it.  Follow the steps in [Reuse your README](#reuse-your-readme).
+- If your project doesn't have a complete README, you can create a custom page.  Follow the steps in [Create a custom project page](#create-a-custom-page).
+
+## Reuse your README
+
+This site has tools and processes for incorporating README files from external repositories.
+For a full description, see [Including READMEs from other repositories](/doc/en/contrib/Including-READMEs.html).  In brief, we use a script to pull down READMEs over the network, then incorporate them into the site.  Currently, to update the READMEs, we periodically run the script manually.
+
+To reuse your project README, follow these steps:
+
+1. Copy one of the existing project pages that uses a README, for example  `loopback.io/pages/en/community/IoT-demo.md`.
+  - Save it into the same directory (`pages/en/community`), and name it based on your project name, for example `pages/en/community/My-awesome-project.md`.
+1. Edit the front matter at the top of the file (see below):
+  - Change the `title` property to be the name of your project.
+  - Change the `source` property to the name of your repository; in the example below `source: StrongLoop-IoT-Demo`.
+  - Change the `org` property to the name of the organization that contains the repository; for example `org: my-org`.
+  - Change the `permalink` property to match the name of the file, for example `/doc/en/community/My-awesome-project.html`.
+  - Add any `keywords` you want for search-engine optimization (optional).
+  - If you don't want an automatically-generated page TOC, add `toc: false`.
+1. Edit the rest of the page to fill in the information for your project, replacing the sample content and instructions.
+
+### Front matter for README page
+
+```
+---
+title: "Internet of Things demo"
+lang: en
+layout: readme
+source: StrongLoop-IoT-Demo
+org: strongloop-community
+keywords: LoopBack
+tags: [community]
+sidebar: community_sidebar
+permalink: /doc/en/community/IoT-demo.html
+summary: Example application that demonstrates using LoopBack for Internet of Things.
+---
+```
+
+### Add your repo to the list of community READMEs
+
+Of course, you could just copy/paste your README file into  `pages/en/community/readmes`, and name it `the-repo-name.md`.  But to ensure that the content stays up-to-date with
+changes to the README file in your repo:
+
+1. Add your project repo to `_data/repos-community.json`; for example:
+
+```
+  { "org": "strongloop-community", "repoName":  "loopback-connector-elastic-search"},
+```
+
+Replace the `org` property with your organization name and the `repoName` property with
+your repository name.
+
+The `get-readmes` script that updates the READMEs reads this JSON file.  
+
+### Test the script
+
+Now, follow these steps to run `get-readmes`:
+
+```
+git clone https://github.com/strongloop/get-readmes.git
+cd get-readmes
+npm install
+cd ..
+./update-community-readmes.sh
+```
+
+## Create a custom page
+
+If you don't want to reuse your README for any reason, follow these steps:
+
 1. Copy the `loopback.io/pages/en/community/Sample-project.md` file, save it into the same directory (`pages/en/community`), and name it based on your project name, for example `pages/en/community/My-awesome-project.md`.
 1. Edit the front matter at the top of the file (see below):
   - Change the `title` property to be the name of your project.
   - Change the `permalink` property to match the name of the file, for example `/doc/en/community/My-awesome-project.html`.
   - Add any `keywords` you want for search-engine optimization (optional).
   - If you want an automatically-generated page TOC, delete `toc: false`.
-
 1. Edit the rest of the page to fill in the information for your project, replacing the sample content and instructions.
-1. Edit the community sidebar navigation file `_data/sidebars/community_sidebar.yml` and add an entry for your new file under the `Active projects` folder, for example:
-<pre style="margin-left: 30px;">
-- title: 'Active projects'
-  output: 'web'
-  children:
 
-  - title: 'Sample project'
-    url: /doc/en/community/Sample-project.html
-    output: 'web'
-</pre>
-
-### Front matter
+### Front matter for custom page
 
 This is the template front matter in the [Sample project page](Sample-project):
 
@@ -43,6 +105,18 @@ sidebar: community_sidebar
 permalink: /doc/en/community/Sample-project.html
 ---
 ```
+
+## Add your page to the sidebar
+
+Edit the community sidebar navigation file `_data/sidebars/community_sidebar.yml` and add an entry for your  file, for example:
+<pre style="margin-left: 30px;">
+- title: 'Sample project'
+  url: /doc/en/community/Sample-project.html
+  output: 'web'
+</pre>
+
+{% include note.html content="Mke sure the `url` property in the sidebar matches the page's `permalink` property.
+" %}
 
 ## Test your change
 

--- a/pages/en/community/How-to-add-a-project.md
+++ b/pages/en/community/How-to-add-a-project.md
@@ -32,6 +32,7 @@ To reuse your project README, follow these steps:
   - Change the `permalink` property to match the name of the file, for example `/doc/en/community/My-awesome-project.html`.
   - Add any `keywords` you want for search-engine optimization (optional).
   - If you don't want an automatically-generated page TOC, add `toc: false`.
+  - Add a short summary of the project in the `summary` property (optional).
 1. Edit the rest of the page to fill in the information for your project, replacing the sample content and instructions.
 
 ### Front matter for README page

--- a/pages/en/community/IoT-demo.md
+++ b/pages/en/community/IoT-demo.md
@@ -1,0 +1,12 @@
+---
+title: "Internet of Things demo"
+lang: en
+layout: readme
+source: StrongLoop-IoT-Demo
+org: strongloop-community
+keywords: LoopBack
+tags: [community]
+sidebar: community_sidebar
+permalink: /doc/en/community/IoT-demo.html
+summary: Example application that demonstrates using LoopBack for Internet of Things.
+---

--- a/pages/en/community/JSON-schemas.md
+++ b/pages/en/community/JSON-schemas.md
@@ -1,0 +1,12 @@
+---
+title: "JSON Schemas"
+lang: en
+layout: readme
+source: loopback-json-schemas
+org: Sequoia
+keywords: LoopBack
+tags: [community]
+sidebar: community_sidebar
+permalink: /doc/en/community/JSON-schemas.html
+summary:  JSON schemas for the LoopBack framework.
+---

--- a/pages/en/community/SDK-builder.md
+++ b/pages/en/community/SDK-builder.md
@@ -1,0 +1,12 @@
+---
+title: "LoopBack SDK Builder"
+lang: en
+layout: readme
+org: mean-expert-official
+source: loopback-sdk-builder
+keywords: LoopBack
+tags: [community]
+sidebar: community_sidebar
+permalink: /doc/en/community/SDK-builder.html
+summary: The LoopBack SDK Builder gnerates LoopBack client applications for  Angular 2 / TypeScript that can run in web, progressive, and native mobile applications using the Angular CLI, Angular Mobile Toolkit, Ionic 2, or NativeScript 2.
+---

--- a/pages/en/community/Sample-project.md
+++ b/pages/en/community/Sample-project.md
@@ -11,35 +11,17 @@ permalink: /doc/en/community/Sample-project.html
 
 Prvovide a link to the community project, usually a GitHub and/or npm URL.
 
-For example:
-
-https://github.com/crcn/sift.js
-
 ## Overview
 
 Provide a brief introduction of the project's functionality here.
-
-Example: Validate objects & filter arrays with MongoDB queries.
 
 ## Features
 
 Provide a list of the features here.
 
-Example:
-
-- Querying an in-memory array of JavaScript objects in nodeJs
-- Filtering of immutable data structures
-- Etc.
-
 ## Benefits of the project
 
 Describe how your project benefits the LoopBack developer.
-
-Example:
-
-Improve our memory-connector.
-
-Use in-memory as the mechanism for regular loopback functionalities (such as building query) for handling Data (eg. ACL handling).
 
 ## Demo or sample code
 

--- a/pages/en/community/readmes/StrongLoop-IoT-Demo.md
+++ b/pages/en/community/readmes/StrongLoop-IoT-Demo.md
@@ -1,0 +1,63 @@
+# StrongLoop IoT Demo
+
+This is a [LoopBack](http://loopback.io) application, developed for demostrating the connection of StrongLoop to the Internet of Things.
+
+## Required Hardware:
+
+* [Intel Edison](https://www.sparkfun.com/products/13024) Module
+* [Sparkfun 9-Degrees of Freedom Block](https://www.sparkfun.com/products/13033)
+* [Sparkfun Base Block](https://www.sparkfun.com/products/13045)
+* [Sparkfun Battery Block](https://www.sparkfun.com/products/13037)
+* USB Mini-C cable
+
+## Required Software:
+
+* This Code
+* [Sensor Application](https://github.com/strongloop-community/LSM9DS0)
+* [MongoDB](http://mongodb.org)
+    * [MongoDB C-Libraries](https://github.com/mongodb/mongo-c-driver)
+
+## How it works:
+
+The sensor reading application is a native C program that runs locally on the Intel Edison device and reads the 9-Degrees of Freedom board mentioned above.
+It then inserts these values to the Mongo DB instance as JSON objects via the StrongLoop APIs.
+The StrongLoop APIs then make this data available to the client application vi a series of web pages that graph and display the sensor readings.
+![Data Display](docs/Safari019.jpg "Data Display Page")
+Notice the 'Show Live Data' button in the upper left corner. Clicking this button causes the page stream live data from the device to the graph in real-time.
+
+## Installing Demo Software
+
+First, you'll need the hardware above, and be able to log into the device.
+once you can log in, you;re ready to install all of the software (this repo included):
+
+* Log into the device...
+* Install some core libs:
+  * `echo "src all http://iotdk.intel.com/repos/1.1/iotdk/all" >> /etc/opkg/base-feeds.conf`
+  * `echo "src x86 http://iotdk.intel.com/repos/1.1/iotdk/x86" >> /etc/opkg/base-feeds.conf`
+  * `echo "src i586 http://iotdk.intel.com/repos/1.1/iotdk/i586" >> /etc/opkg/base-feeds.conf`
+* Update package manager and install git:
+  * opkg update
+  * opkg upgrade
+  * opkg install git
+* Grab the controller script from this repo and install all other software:
+  * wget --no-check-certificate https://raw.githubusercontent.com/strongloop-community/StrongLoop-IoT-Demo/master/demo-ctrl.sh
+  * chmod +x demo-ctrl.sh
+  * ./demo-ctrl.sh install  
+  _This could take hours and will install and configure all the software packages required for the demo._
+* Calibrate the sensors:
+  * cd LSM9DS0
+  * ./calibrate-mag  
+  (Note that this requires interaction with the device!)
+  * ./calibrate-acc-gyro  
+  (Note that this is VERY sensitive. Make sure the device is on a flat surface, with absolutely no motion. It can even pick up sound, so turn off any music! Even with these measures it may take a couple tries to succeed.)
+
+## Running the Demo
+
+* Log into the device...
+* run `./demo-ctrl.sh start`
+* Wait for the output to tell you to connect:  
+`Connect to your application at http://192.168.1.13:3000/`  
+(Or whatever your IP is)
+* Choose a Sensor from the top nav and move the device around!
+* Hit the "Live" button to see the charts update dynamically
+

--- a/pages/en/community/readmes/loopback-connector-elastic-search.md
+++ b/pages/en/community/readmes/loopback-connector-elastic-search.md
@@ -1,0 +1,358 @@
+# loopback-connector-elastic-search
+
+[![Join the chat at https://gitter.im/strongloop-community/loopback-connector-elastic-search](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/strongloop-community/loopback-connector-elastic-search?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Basic Elasticsearch datasource connector for [Loopback](http://strongloop.com/node-js/loopback/).
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Overview](#overview)
+- [Install this connector in your loopback app](#install-this-connector-in-your-loopback-app)
+- [Configuring connector](#configuring-connector)
+  - [Required properties](#required)
+  - [Recommended properties](#recommended)
+  - [Optional properties](#optional)
+  - [Sample for copy paste](#sample)
+- [About the example app](#about-the-example-app)
+  - [Run both example and ES in docker](#run-both-example-and-es-in-docker)
+  - [Run example locally and ES in docker](#run-example-locally-and-es-in-docker)
+  - [Run example locally](#run-example-locally)
+- [Troubleshooting](#troubleshooting)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [Frequently Asked Questions](#faqs)
+- [Release notes](#release-notes)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+1. `lib` directory has the entire source code for this connector
+  1. this is what gets downloaded to your `node_modules` folder when you run `npm install loopback-connector-es --save --save-exact`
+1. `examples` directory has a loopback app which uses this connector
+  1. this is not published to NPM, it is only here for demo purposes
+    1. it will not be downloaded to your `node_modules` folder!
+    1. similarly the `examples/server/datasources.json` and `examples/server/datasources.<env>.js` files are there for this demo app to use
+    1. you can copy their content over to `<yourApp>/server/datasources.json` or `<yourApp>/server/datasources.<env>.js` if you want and edit it there but don't start editing the files inside `examples/server` itself and expect changes to take place in your app!
+1. `test` directory has unit tests
+  1. it does not reuse the loopback app from the `examples` folder
+  1. instead, loopback and ES/datasource are built and injected programatically
+  1. this directory is not published to NPM.
+    1. Refer to `.npmignore` if you're still confused about what's part of the *published* connector and what's not.
+1. You will find the `datasources.json` files in this repo mention various configurations:
+  1. `elasticsearch-ssl`
+  2. `elasticsearch-plain`
+  3. `db`
+  4. You don't need them all! They are just examples to help you see the various ways in which you can configure a datasource. Delete the ones you don't need and keep the one you want. For example, most people will start off with `elasticsearch-plain` and then move on to configuring the additional properties that are exemplified in `elasticsearch-ssl`. You can mix & match if you'd like to have mongo and es and memory, all three! These are basics of the "connector" framework in loooback and not something we added.
+1. Don't forget to edit your `model-config.json` file and point the models at the `dataSource` you want to use.
+
+## Install this connector in your loopback app
+
+```
+cd <yourApp>
+npm install loopback-connector-es --save --save-exact
+```
+
+## Configuring connector
+
+### Required:
+- **host:** Elasticsearch engine host address.
+- **port:** Elasticsearch engine port.
+- **name:** Connector name.
+- **connector:** Elasticsearch driver.
+- **index:** Search engine specific index.
+- **apiVersion:** specify the major version of the Elasticsearch nodes you will be connecting to.
+
+### Recommended:
+- **mappings:** an array of elasticsearch mappings for your various loopback models.
+  - if your models are spread out across different indexes then you can provide an additional `index` field as an override for your model
+  - if you don't want to use `type:ModelName` by default, then you can provide an additional `type` field as an override for your model
+
+### Optional:
+- **log:** sets elasticsearch client's logging, you can refer to the docs [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html#config-log)
+- **defaultSize:** total number of results to return per page.
+- **requestTimeout:** this value is in milliseconds
+- **ssl:** useful for setting up a secure channel
+- **protocol:** can be `http` or `https` (`http` is the default if none specified) ... *must* be `https` if you're using `ssl`
+- **auth**: useful if you have access control setup via services like `es-jetty` or `found` or `shield`
+- **amazonES**: configuration for `http-aws-es` NOTE: The package needs to be installed in your project. Its not part of this Connector.
+
+### Sample:
+1. Edit **datasources.json** and set:
+
+  ```
+  "db": {
+    "connector": "es",
+    "name": "<name>",
+    "index": "<index>",
+    "hosts": [
+          {
+            "protocol": "http",
+            "host": "127.0.0.1",
+            "port": 9200,
+            "auth": "username:password"
+          }
+    ],
+    "apiVersion": "<apiVersion>",
+    "log": "trace",
+    "defaultSize": <defaultSize>,
+    "requestTimeout": 30000,
+    "ssl": {
+        "ca": "./../cacert.pem",
+        "rejectUnauthorized": true
+    },
+    "amazonES": {
+         "region": "us-east-1",
+         "accessKey": "AKID",
+         "secretKey": "secret"
+    },
+    "mappings": [
+        {
+            "name": "UserModel",
+            "properties": {
+                "realm": {"type": "string", "index" : "not_analyzed" },
+                "username": {"type": "string", "index" : "not_analyzed" },
+                "password": {"type": "string", "index" : "not_analyzed" },
+                "email": {"type": "string", "analyzer" : "email" }
+            }
+        },
+        {
+            "name": "CoolModel",
+            "index": <useSomeOtherIndex>,
+            "type": <overrideTypeName>,
+            "properties": {
+                "realm": {"type": "string", "index" : "not_analyzed" },
+                "username": {"type": "string", "index" : "not_analyzed" },
+                "password": {"type": "string", "index" : "not_analyzed" },
+                "email": {"type": "string", "analyzer" : "email" }
+            }
+        }
+    ],
+    "settings": {
+      "analysis": {
+        "filter": {
+          "email": {
+            "type": "pattern_capture",
+            "preserve_original": 1,
+            "patterns": [
+              "([^@]+)",
+              "(\\p{L}+)",
+              "(\\d+)",
+              "@(.+)"
+            ]
+          }
+        },
+        "analyzer": {
+          "email": {
+            "tokenizer": "uax_url_email",
+            "filter": ["email", "lowercase", "unique"]
+          }
+        }
+      }
+    }
+  }
+  ```
+2. You can peek at `/examples/server/datasources.json` for more hints.
+
+## About the example app
+
+1. The `examples` directory contains a loopback app which uses this connector.
+1. You can point this example at your own elasticsearch instance or use the quick instances provided via docker.
+
+### Run both example and ES in docker
+
+As a developer, you may want a short lived ES instance that is easy to tear down when you're finished dev testing. We recommend docker to facilitate this.
+
+**Pre-requisites**
+You will need [docker-engine](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed on your system.
+
+**Step-1**
+- Set desired versions for **node** and **Elasticsearch**
+  - here are the [valid values](https://hub.docker.com/r/library/node/tags/) to use for  **Node**
+  - here are the [valid values](https://hub.docker.com/r/library/elasticsearch/tags/) to use for  **Elasticsearch**
+```
+# combination of node v0.10.46 with elasticsearch v1
+export NODE_VERSION=0.10.46
+export ES_VERSION=1
+echo 'NODE_VERSION' $NODE_VERSION && echo 'ES_VERSION' $ES_VERSION
+
+# similarly feel free to try relevant combinations:
+## of node v0.10.46 with elasticsearch v2
+## of node v0.12 with elasticsearch v2
+## of node v0.4 with elasticsearch v2
+## of node v5 with elasticsearch v2
+## elasticsearch v5 will probably not work as there isn't an `elasticsearch` client for it, as of this writing
+## etc.
+```
+**Step-2**
+- Run the setup with `docker-compose` commands.
+
+```
+git clone https://github.com/strongloop-community/loopback-connector-elastic-search.git myEsConnector
+cd myEsConnector/examples
+npm install
+docker-compose up
+```
+
+**Step-3**
+- Visit `localhost:3000/explorer` and you will find our example loopback app running there.
+
+### Run example locally and ES in docker
+
+1. Empty out `examples/server/datasources.json` so that it only has the following content remaining: `{}`
+1. Set the `NODE_ENV` environment variable on your local/host machine
+    1. Set the environment variable `NODE_ENV=sample-es-plain-1` if you want to use `examples/server/datasources.sample-es-plain-1.js`
+    1. Set the environment variable `NODE_ENV=sample-es-plain-2` if you want to use `examples/server/datasources.sample-es-plain-2.js`
+    1. Set the environment variable `NODE_ENV=sample-es-ssl-1` if you want to use `examples/server/datasources.sample-es-ssl-1.js`
+      1. a sample docker instance for this hasn't been configured yet, so it doesn't work out-of-the-box, use it only as readable (not runnable) reference material for now
+  1. You can configure your own `datasources.json` or `datasources.<env>.js` based on what you learn from these sample files.
+    1. Technically, to run the example, you don't need to set `NODE_ENV` **if you won't be configuring via the `.<env>.js` files** ... configuring everything within `datasources.json` is perfectly fine too. Just remember that you will lose the ability to have inline comments and will have to use double-quotes if you stick with `.json`
+1. Start elasticsearch version 1.x and 2.x using:
+
+  ```
+  git clone https://github.com/strongloop-community/loopback-connector-elastic-search.git myEsConnector
+  cd myEsConnector
+  docker-compose -f docker-compose-for-tests.yml up
+
+  # in another terminal window or tab
+  cd myEsConnector/examples
+  npm install
+  DEBUG=boot:test:* node server/server.js
+  ```
+1. Visit `localhost:3000/explorer` and you will find our example loopback app running there.
+
+### Run example locally
+
+1. Install dependencies and start the example server
+
+  ```
+  git clone https://github.com/strongloop-community/loopback-connector-elastic-search.git myEsConnector
+  cd myEsConnector/examples
+  npm install
+  ```
+2. [Configure the connector](#configuring-connector)
+  * Don't forget to create an index in your ES instance: `curl -X POST https://username:password@my.es.cluster.com/shakespeare`
+  * If you mess up and want to delete, you can use: `curl -X DELETE https://username:password@my.es.cluster.com/shakespeare`
+  * Don't forget to set a [valid value](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html#config-api-version) for `apiVersion` field in `examples/server/datasources.json` that matches the version of ES you are running.
+3. Set up a `cacert.pem` file for communicating securely (https) with your ES instance. Download the certificate chain for your ES server using this **sample** (will need to be edited to *use* your provider) command:
+
+  ```
+  cd myEsConnector
+  openssl s_client -connect my.es.cluster.com:9243 -showcerts | tee cacert.pem
+  ```
+  1. The command may not self terminate so you may need to use `ctrl+c`
+  2. It will be saved at the base of your cloned project
+  3. Sometimes extra data is added to the file, you should delete everything after the following lines:
+
+    ```
+    ---
+    No client certificate CA names sent
+    ---
+    ```
+4. Run:
+
+  ```
+  cd myEsConnector/examples
+  DEBUG=boot:test:* node server/server.js
+  ```
+  * The `examples/server/boot/boot.js` file will automatically populate data for UserModels on your behalf when the server starts.
+5. Open this URL in your browser: [http://localhost:3000/explorer](http://localhost:3000/explorer)
+  * Try fetching all the users via the rest api console
+  * You can dump all the data from your ES index, via cmd-line too: `curl -X POST username:password@my.es.cluster.com/shakespeare/_search -d '{"query": {"match_all": {}}}'`
+6. To test a specific filter via GET method, use for example: `{"q" : "friends, romans, countrymen"}`
+
+## Troubleshooting
+
+1. Do you have both `elasticsearch-ssl` and `elasticsearch-plain` in your `datasources.json` file? You just need one of them (not both), based on how you've setup your ES instance.
+1. Did you forget to set `model-config.json` to point at the datasource you configured? Maybe you are using a different or misspelled name than what you thought you had!
+1. Did you forget to set a [valid value](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html#config-api-version) for `apiVersion` field in `datasources.json` that matches the version of ES you are running?
+1. Maybe the version of ES you are using isn't supported by the client that this project uses. Try removing the `elasticsearch` sub-dependency from `<yourApp>/node_modules/loopback-connector-es/node_modules` folder and then install the latest client:
+  1. `cd <yourApp>/node_modules/loopback-connector-es/node_modules`
+  1. then remove the `elasticsearch` folder
+    1. unix/mac quickie: `rm -rf elasticsearch`
+  1. `npm install --save --save-exact https://github.com/elastic/elasticsearch-js.git`
+  1. to "academically" prove to yourself that this will work with the new install:
+    1. on unix/mac you can quickly dump the supported versions to your terminal with: `cat elasticsearch/package.json | grep -A 5 supported_es_branches`
+    2. on other platforms, look into the `elasticsearch/package.json` and search for the `supported_es_branches` json block.
+  1. go back to yourApp's root directory
+    1. unix/mac quickie: `cd <yourApp>`
+  1. And test that you can now use the connector without any issues!
+  1. These changes can easily get washed away for several reasons. So for a more permanent fix that adds the version you want to work on into a release of this connector, please look into [Contributing](#contributing).
+
+## Testing
+
+1. You can edit `test/resource/datasource-test.json` to point at your ES instance and then run `npm test`
+1. If you don't have an ES instance and want to leverage docker based ES instances then:
+  1. Start elasticsearch version 1.x and 2.x using: `docker-compose -f docker-compose-for-tests.yml up`
+  1. Edit the code to pick which datasource you want to test against in `test/init.js`:
+
+  ```
+  var settings = require('./resource/datasource-test.json'); // comment this out if you'll be using either of the following
+  //var settings = require('./resource/datasource-test-v1-plain.json');
+  //var settings = require('./resource/datasource-test-v2-plain.json');
+  ```
+  1. Then run `npm test`
+  2. When you're finished and want to tear down the docker instances, run: `docker-compose -f docker-compose-for-tests.yml down`
+
+## Contributing
+
+1. Feel free to [contribute via PR](https://github.com/strongloop-community/loopback-connector-elastic-search/pulls) or [open an issue](https://github.com/strongloop-community/loopback-connector-elastic-search/issues) for discussion or jump into the [gitter chat room](https://gitter.im/strongloop-community/loopback-connector-elastic-search) if you have ideas.
+1. I recommend that project contributors who are part of the team:
+  1. should merge `master` into `develop` ... if they are behind, before starting the `feature` branch
+  1. should create `feature` branches from the `develop` branch
+  1. should merge `feature` into `develop` then create a `release` branch to:
+    1. update the changelog
+    1. update the readme
+    1. fix any bugs from final testing
+    1. commit locally and run `npm-release x.x.x -m "<some comment>"`
+    1. merge `release` into both `master` and `develop`
+    1. push `master` and `develop` to GitHub
+1. For those who use forks:
+  1. please submit your PR against the `develop` branch, if possible
+  1. if you must submit your PR against the `master` branch ... I understand and I can't stop you. I only hope that there is a good reason like `develop` not being up-to-date with `master` for the work you want to build upon.
+1. `npm-release <versionNumber> -m <commit message>` may be used to publish. Pubilshing to NPM should happen from the `master` branch. It should ideally only happen when there is something release worthy. There's no point in publishing just because of changes to `test` or `examples` folder or any other such entities that aren't part of the "published module" (refer to `.npmignore`) to begin with.
+
+## FAQs
+
+1. How do we enable or disable the logs coming from the underlying elasticsearch client? There may be a need to debug/troubleshoot at times.
+  1. Use the `"log": "trace"` field in your datasources file or omit it. You can refer to the detailed docs [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html#config-log) and [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/logging.html)
+1. How do we enable or disable the logs coming from this connector?
+  1. By default if you do not set the following env variable, they are disabled: `DEBUG=loopback:connector:elasticsearch`
+    1. For example, try running tests with and without it, to see the difference:
+      1. with: `DEBUG=loopback:connector:elasticsearch npm test`
+      1. without: `npm test`
+1. What are the tests about? Can you provide a brief overview?
+  1. Tests are prefixed with `01` or `02` etc. in order to run them in that order by leveraging default alphabetical sorting.
+  1. The `02.basic-querying.test.js` file uses two models to test various CRUD operations that any connector must provide, like `find(), findById(), findByIds(), updateAttributes()` etc.
+    1. the two models are `User` and `Customer`
+    2. their ES *mappings* are laid out in `test/resource/datasource-test.json`
+    3. their loopback *definitions* can be found in the first `before` block that performs setup in `02.basic-querying.test.js` file ... these are the equivalent of a `MyModel.json` in your real loopback app.
+      1. naturally, this is also where we define which property serves as the `id` for the model and if its [generated](https://docs.strongloop.com/display/APIC/Model+definition+JSON+file#ModeldefinitionJSONfile-IDproperties) or not
+1. How do we get elasticserch to take over ID generation?
+  1. An automatically generated id-like field that is maintained by ES is `_uid`. Without some sort of es-field-level-scripting-on-index (if that is possible at all) ... I am not sure how we could ask elasticsearch to take over auto-generating an id-like value for any arbitrary field! So the connector is setup such that adding `id: {type: String, generated: true, id: true}` will tell it to use `_uid` as the actual field backing the `id` ... you can keep using the doing `model.id` abstraction and in the background `_uid` values are mapped to it.
+  1. Will this work for any field marked as with `generated: true` and `id: true`?
+    1. No! The connector isn't coded that way right now ... while it is an interesting idea to couple any such field with ES's `_uid` field inside this connector ... I am not sure if this is the right thing to do. If you had `objectId: {type: String, generated: true, id: true}` then you won't find a real `objectId` field in your ES documents. Would that be ok? Wouldn't that confuse developers who want to write custom queries and run 3rd party app against their ES instance? Don't use `obejctId`, use `_uid` would have to be common knowledge. Is that ok?
+
+## Release notes
+
+  * Release `1.0.6` of this connector updates the underlying elasticsearch client version to `11.0.1`
+  * For this connector, you can configure an `index` name for your ES instance and the loopback model's name is conveniently/automatically mapped as the ES `type`.
+  * Users must setup `string` fields as `not_analyzed` by default for predictable matches just like other loopback backends. And if more flexibility is required, multi-field mappings can be used too.
+
+    ```
+    "name" : {
+        "type" : "multi_field",
+        "fields" : {
+            "name" : {"type" : "string", "index" : "not_analyzed"},
+            "native" : {"type" : "string", "index" : "analyzed"}
+        }
+    }
+    ...
+    // this will treat 'George Harrison' as 'George Harrison' in a search
+    User.find({order: 'name'}, function (err, users) {..}
+    // this will treat 'George Harrison' as two tokens: 'george' and 'harrison' in a search
+    User.find({order: 'name', where: {'name.native': 'Harrison'}}, function (err, users) {..}
+    ```
+  * TBD

--- a/pages/en/community/readmes/loopback-json-schemas.md
+++ b/pages/en/community/readmes/loopback-json-schemas.md
@@ -1,0 +1,51 @@
+# LoopBack JSON Schemas
+This repository contains [JSONSchemas](http://json-schema.org/) for the [LoopBack](http://loopback.io/) framework.
+
+:warning: **These schemas are a work in progress & _do not_ capture every feature & setting.** [Consult docs](https://docs.strongloop.com/display/APIC/Using+LoopBack+with+IBM+API+Connect) for best results :+1:.
+
+:information_source: These schemas target loopback **version 3** which is not 100% compatible with most loopback applications currently in production. I chose to target the next version in the interest of being forward looking & because time is limited.
+
+# Contributing
+
+* [Roadmap in `TODO.md`](TODO.md). :point_left: This is where to contribute if you'd like to help!
+* **In order to get your changes into the `dist` version, you must run `npm run build`!** Please do this before submitting PR. 
+
+# Using the schemas
+## Method 1. Point json files to schemas
+Using an IDE that supports JSONSchemas (I recommend [VS Code](https://code.visualstudio.com/)), point to a schema thus:
+`common/models/customer.json`
+```
+{
+  "$schema" : "https://raw.githubusercontent.com/Sequoia/loopback-json-schemas/master/dist/loopback-model-definition.json"
+}
+```
+## Method 2. Map schemas to file by file paths (VS Code)
+Edit your `jsconfig.json` in VS Code to [map schemas to file paths in your project](https://code.visualstudio.com/Docs/languages/json#_json-schemas-settings):
+```
+
+    {
+      "fileMatch": "/common/models/*.json",
+      "url": "https://raw.githubusercontent.com/Sequoia/loopback-json-schemas/master/dist/loopback-model-definition.json"
+    },
+    {
+```
+
+This will automatically link schemas to paths so you don't have to use **Method 1**. [Read more](https://code.visualstudio.com/Docs/languages/json#_json-schemas-settings).
+
+## Method 3. Use the VS Code plugin
+:warning: WIP! [VS Code Plugin](https://marketplace.visualstudio.com/items?itemName=sequoia.loopback-json-schemas)
+
+This will automatically link schemas to paths so you don't have to use **Method 2**.
+
+# Developing
+* Clone repository & run `npm install`
+* Run `npm serve` to serve for local testing
+  * You can create a separate project (e.g. in [VS Code](https://code.visualstudio.com/)) and point to your local definitions from a json file thus:
+    ```
+    {
+      "$schema" : "http://localhost:8090/shared-refs.json"
+    }
+    ```
+* When you're ready to push & submit a PR, run `npm run build` which
+  1. copies files from `src` to `dist`
+  2. replaces `http://localhost:8090` with the real base url for the schemas. This is currently github but will likely be schema store later.

--- a/pages/en/community/readmes/loopback-sdk-builder.md
+++ b/pages/en/community/readmes/loopback-sdk-builder.md
@@ -1,0 +1,27 @@
+![LoopBack SDK Builder](https://storage.googleapis.com/mean-expert-images/sdk-builder.jpg)
+
+LoopBack SDK Builder
+==================
+
+The [@mean-expert/loopback-sdk-builder](https://www.npmjs.com/package/@mean-expert/loopback-sdk-builder) is a community driven module forked from the official `loopback-sdk-angular` and refactored to support [Angular 2](http://angular.io).
+
+The [LoopBack SDK Builder](https://www.npmjs.com/package/@mean-expert/loopback-sdk-builder) will explore your [LoopBack Application](http://loopback.io) and will automatically build everything you need to start writing your [Angular 2 Applications](http://angular.io) right away. From Interfaces and Models to API Services and Real-time communications.
+
+# Installation
+
+````sh
+$ cd to/loopback/project
+$ npm install --save-dev @mean-expert/loopback-sdk-builder
+````
+
+# Documentation
+
+[LINK TO WIKI DOCUMENTATION](https://github.com/mean-expert-official/loopback-sdk-builder/wiki)
+
+# Features
+
+[LINK TO FEATURES](https://github.com/mean-expert-official/loopback-sdk-builder/wiki#features)
+
+# Contact
+
+Discuss features and ask questions on [@johncasarrubias at Twitter](https://twitter.com/johncasarrubias).

--- a/pages/en/contrib/doc-contrib.md
+++ b/pages/en/contrib/doc-contrib.md
@@ -33,7 +33,6 @@ We attempt to review and merge PRs as soon as possible; in general, we'll try to
 - [Jekyll static site genertor](https://jekyllrb.com/)
 - [Liquid Templates](https://shopify.github.io/liquid/)
 - [GitHub repo for Jekyll Documentation Theme](https://github.com/tomjohnson1492/documentation-theme-jekyll)
-- [Current LoopBack docs in Confluence](http://docs.strongloop.com)
 
 ## What to work on
 

--- a/update-community-readmes.sh
+++ b/update-community-readmes.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# git clone https://github.com/strongloop/get-readmes.git
+node get-readmes/get-readmes.js --out=pages/en/community/readmes --repos=_data/repos-community.json


### PR DESCRIPTION
@jannyHou This PR does the following:
- Adds four community projects: Elasticsearch connector, LoopBack SDK Builder, JSON Schemas, and 
  IoT demo
- I used the technique of simply pulling in the project READMEs, described in http://loopback.io/doc/en/contrib/Including-READMEs.html.
- Updated the instructions so community members can do the same.  I left them the option of creating a custom project page or "reusing" their project README.

If you want to see how this will look when it's merged, follow the instructions in the README to run Jekyll locally.  
