### PR TITLE
Update doc for include filter

### DIFF
--- a/pages/en/lb2/Include-filter.md
+++ b/pages/en/lb2/Include-filter.md
@@ -31,13 +31,13 @@ You can also use [stringified JSON format](Querying-data.html#using-stringified
 ```javascript
 {include: 'relatedModel'}
 {include: ['relatedModel1', 'relatedModel2', ...]}
-{include: {relatedModel1: [{relatedModel2: 'propertyName'} , 'relatedModel']}}
+{include: {relatedModel1: [{relatedModel2: 'relationName'} , 'relatedModel']}}
 ```
 
 Where:
 
 * _relatedModel_, _relatedModel1_, and _relatedModel2_ are the names (pluralized) of related models.
-* _propertyName_ is the name of a property in the related model.
+* _relationName_ is the name of a relation in the related model.
 
 ### Examples
 


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback#2922

Scenario:
Take example of `Post.find({include: {owner: 'orders'}}, function() { /* ... */ });`

The `orders` has to be a relation name but not property name.