### PR TITLE
Fix CORS migration to LB 3.0

### DIFF
--- a/pages/en/lb3/Migrating-to-3.0.md
+++ b/pages/en/lb3/Migrating-to-3.0.md
@@ -441,3 +441,17 @@ follow these steps:
       // ...
     }
     ```
+
+ 3. Edit the `remoting` section in your `server/config.json` and set `cors` to
+  `false`:
+
+    ```js
+    {
+      // ...
+      "remoting": {
+        // ...
+        "cors": false,
+        // ...
+      }
+    }
+    ```


### PR DESCRIPTION
Add a missing step to disable the built-in CORS middleware in `server/config.json`.

@crandmck please review

@elkorep I think this was the missing step you encountered while upgrading your older LB 2.x app.