### PR TITLE
 Correction for efault value of `forceId` for LB2.x

### DIFF
--- a/pages/en/lb2/Model-definition-JSON-file.md
+++ b/pages/en/lb2/Model-definition-JSON-file.md
@@ -104,7 +104,7 @@ Properties are required unless otherwise designated.
       <td>forceId</td>
       <td>Boolean</td>
       <td>
-        The default value is set to true whenever a model uses an auto-generated ID. If it is set to true it prevents users from setting the auto-id value manually.
+        The default value is set to false. If it is set to true it prevents users from setting the auto-id value manually.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
* Correction for default value of `forceId` for LB2.x