### PR TITLE
Wrong Data Type in remoteMethod Tutorial

### DIFF
--- a/pages/en/lb2/Extend-your-API.md
+++ b/pages/en/lb2/Extend-your-API.md
@@ -127,7 +127,7 @@ module.exports = function(CoffeeShop) {
         'getName',
         {
           http: {path: '/getname', verb: 'get'},
-          accepts: {arg: 'id', type: 'number', http: { source: 'query' } },
+          accepts: {arg: 'id', type: 'string', http: { source: 'query' } },
           returns: {arg: 'name', type: 'string'}
         }
     );


### PR DESCRIPTION
Because the argument is an ID in the getName Method, the datatype has to be a string and not a number.