### PR TITLE
Add preferred team style for cb moved to the next line

### DIFF
--- a/pages/en/contrib/style-guide.md
+++ b/pages/en/contrib/style-guide.md
@@ -578,6 +578,37 @@ describe('my class', () => {
   }
 });
 ```
+### Callback function moved to the next line
+
+The following examples show the preferred style when callback needs to move to the next line due to line length exceeding max line length defined by eslint:
+
+**Good**:
+
+```js
+it('my long test description ...',
+function(done) {
+  ...
+});
+```
+
+**Bad**:
+
+```js
+it('my long test description ...', 
+  function(done) {
+    …
+  });
+```
+
+**Bad**:
+
+```js
+it('my long test description ...', 
+  function(done) {
+    …
+  }
+);
+```
 
 ### Test naming
 


### PR DESCRIPTION
In order to avoid inconsistency, this PR documents the preferred style guide team prefers/follows when the callback needs to go to the next line due to line length exceeding max line length defined by eslint: 

I listed all reasonable choices here, but since **option A** is the one which team has followed mostly I chose it as a good example to avoid inconsistency; what we do care is consistency; let's decide which one should be followed by LoopBack team. If you do not have objection, please lets stick to option **A**.

**A:**
```
      it('my long test description ...',
      function(done) {
        ...
      });
```
**B:**

```
      it('my long test description ...’, 
        function(done) {
          …
        });
```

**C:**

```
      it(‘my long test description ...’, 
        function(done) {
          …
        }
      );
```

/to: @strongloop/loopback-dev @superkhau PTAL, Thanks!