### PR TITLE
Correct middleware for `loopback-getting-started`

### DIFF
--- a/pages/en/lb2/Add-a-static-web-page.md
+++ b/pages/en/lb2/Add-a-static-web-page.md
@@ -60,6 +60,24 @@ When you create an application with the [Application generator](Application-gene
         "credentials": true,
         "maxAge": 86400
       }
+    },
+    "helmet#xssFilter": {},
+    "helmet#frameguard": {
+      "params": [
+        "deny"
+      ]
+    },
+    "helmet#hsts": {
+      "params": {
+        "maxAge": 0,
+        "includeSubdomains": true
+      }
+    },
+    "helmet#hidePoweredBy": {},
+    "helmet#ieNoOpen": {},
+    "helmet#noSniff": {},
+    "helmet#noCache": {
+      "enabled": false
     }
   },
   "session": {},
@@ -67,7 +85,9 @@ When you create an application with the [Application generator](Application-gene
   "parse": {},
   "routes": {
     "loopback#rest": {
-      "paths": ["${restApiRoot}"]
+      "paths": [
+        "${restApiRoot}"
+      ]
     }
   },
   "files": {},
@@ -75,7 +95,7 @@ When you create an application with the [Application generator](Application-gene
     "loopback#urlNotFound": {}
   },
   "final:after": {
-    "loopback#errorHandler": {}
+    "strong-error-handler": {}
   }
 }
 ```

--- a/pages/en/lb3/Add-a-static-web-page.md
+++ b/pages/en/lb3/Add-a-static-web-page.md
@@ -60,6 +60,24 @@ When you create an application with the [Application generator](Application-gene
         "credentials": true,
         "maxAge": 86400
       }
+    },
+    "helmet#xssFilter": {},
+    "helmet#frameguard": {
+      "params": [
+        "deny"
+      ]
+    },
+    "helmet#hsts": {
+      "params": {
+        "maxAge": 0,
+        "includeSubdomains": true
+      }
+    },
+    "helmet#hidePoweredBy": {},
+    "helmet#ieNoOpen": {},
+    "helmet#noSniff": {},
+    "helmet#noCache": {
+      "enabled": false
     }
   },
   "session": {},
@@ -67,7 +85,9 @@ When you create an application with the [Application generator](Application-gene
   "parse": {},
   "routes": {
     "loopback#rest": {
-      "paths": ["${restApiRoot}"]
+      "paths": [
+        "${restApiRoot}"
+      ]
     }
   },
   "files": {},
@@ -75,7 +95,7 @@ When you create an application with the [Application generator](Application-gene
     "loopback#urlNotFound": {}
   },
   "final:after": {
-    "loopback#errorHandler": {}
+    "strong-error-handler": {}
   }
 }
 ```


### PR DESCRIPTION
Connect to https://github.com/strongloop-internal/scrum-loopback/issues/1360

* Corrects the content of `server/middleware.json` mentioned [here in our doc for LB3.x]( http://loopback.io/doc/en/lb3/Add-a-static-web-page.html#introduction-to-middleware) and [here in doc for LB2.x](http://loopback.io/doc/en/lb2/Add-a-static-web-page.html#introduction-to-middleware) which were not identical with the ones generated by LoopBack app and could cause confusion.

/to: @smartmouse 