### PR TITLE
Add missing left bracket in the example

### DIFF
--- a/pages/en/lb2/Order-filter.md
+++ b/pages/en/lb2/Order-filter.md
@@ -19,7 +19,7 @@ Order by one property: 
 
 Order by two or more properties:
 
-`filter[order][0]=propertyName <ASC|DESC>&filter[order][1]propertyName]=<ASC|DESC>...`
+`filter[order][0]=propertyName <ASC|DESC>&filter[order][1][propertyName]=<ASC|DESC>...`
 
 You can also use [stringified JSON format](Querying-data.html#using-stringified-json-in-rest-queries) in a REST query.
 


### PR DESCRIPTION
There's missing left bracket missing in the order by two properties example