### PR TITLE
Fix link with example modules

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -14,8 +14,8 @@ item: examples
           <div class="c-container -padded">
             <div class="c-grid">
               <div class="_col -col-2-3">
-                <h2 class="c-heading -h3"><a href="https://github.com/strongloop/loopback-example">LoopBack example module</a></h2>
-                <p>Provides links to all the LoopBack example apps <a href="https://github.com/strongloop/loopback-example" class="fa fa-long-arrow-right"></a></p>
+                <h2 class="c-heading -h3"><a href="https://github.com/strongloop?q=example">LoopBack example modules</a></h2>
+                <p>Provides links to all the LoopBack example apps <a href="https://github.com/strongloop?q=example" class="fa fa-long-arrow-right"></a></p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
Two links inside the documentation website were broken.

From my understading there was repo called [strongloop/loopback-example](https://github.com/strongloop/loopback-example) and for some reason it does not exist anymore.

To replace the broken link I have added a new link with all loopback example apps available in strongloop profile.