### PR TITLE
Fix after remote error hook example

### DIFF
--- a/pages/en/lb2/Remote-hooks.md
+++ b/pages/en/lb2/Remote-hooks.md
@@ -224,7 +224,7 @@ Attach extra metadata to error objects:
 {% include code-caption.html content="common/models/dog.js" %}
 ```javascript
 Dog.afterRemoteError('**', function(ctx, next) {
-  if (!ctx.error.details) ctx.result.details = {};
+  if (!ctx.error.details) ctx.error.details = {};
   ctx.error.details.info = 'intercepted by a hook';
   next();
 })

--- a/pages/en/lb3/Remote-hooks.md
+++ b/pages/en/lb3/Remote-hooks.md
@@ -224,7 +224,7 @@ Attach extra metadata to error objects:
 {% include code-caption.html content="common/models/dog.js" %}
 ```javascript
 Dog.afterRemoteError('**', function(ctx, next) {
-  if (!ctx.error.details) ctx.result.details = {};
+  if (!ctx.error.details) ctx.error.details = {};
   ctx.error.details.info = 'intercepted by a hook';
   next();
 })


### PR DESCRIPTION
Since this is an `afterRemoteError` hook, you need to add additional properties to `ctx.error` not `ctx.result`.