### PR TITLE
findById takes filter as second argument

### DIFF
--- a/pages/en/lb3/Using-current-context.md
+++ b/pages/en/lb3/Using-current-context.md
@@ -70,7 +70,7 @@ module.exports = function(MyModel) {
   MyModel.log = function(messageId, options) {
     const Message = this.app.models.Message;
     // IMPORTANT: forward the options arg
-    return Message.findById(messageId, options)
+    return Message.findById(messageId, null, options)
       .then(msg => {
         const token = options && options.accessToken;
         const userId = token && token.userId;


### PR DESCRIPTION
For the `options` argument to be passed correctly by the `findById`-method, I believe the second argument should be `filter`, or `null` if none. Current implementation in documentation would let the method believe `options` is a `filter`-object, and therefore not propagate the context correctly.

Please correct me if I'm wrong!