### PR TITLE
started => booted [WAITING FOR npm PUBLISH OF loopback-boot]

### DIFF
--- a/pages/en/lb3/Events.md
+++ b/pages/en/lb3/Events.md
@@ -18,7 +18,7 @@ In addition to the [standard Node events](http://nodejs.org/api/events.html), Lo
 
 ## Application events
 
-By default, an application created with the [application generator](Application-generator.html) emits a 'started' event when it starts up, after running [boot scripts](Defining-boot-scripts.html).
+By default, an application created with the [application generator](Application-generator.html) emits a 'booted' event when it starts up, after running [boot scripts](Defining-boot-scripts.html).
 
 ## Model events
 


### PR DESCRIPTION
The changelog indicates the `booted` event was added in 2015-01-08, Version 2.6.0

For reference, the emit is called here https://github.com/strongloop/loopback-boot/blob/master/lib/plugins/application.js#L131