### PR TITLE
Fix user setup in AccessTokenInvalidation

### DIFF
--- a/pages/en/lb2/AccessToken-invalidation.md
+++ b/pages/en/lb2/AccessToken-invalidation.md
@@ -54,6 +54,7 @@ Example of a `Customer` model extending the built-in `User` model:
   "base": "User",
   "idInjection": true,
   "options": {
+    "injectOptionsFromRemoteContext": true,
     "validateUpsert": true
   },
   "properties": {},


### PR DESCRIPTION
The example model JSON was missing the entry enabling `injectOptionsFromRemoteContext`

cc @crandmck 