### PR TITLE
Allow logged in users to read coffeeshops

### DIFF
--- a/pages/en/lb3/Define-access-controls.md
+++ b/pages/en/lb3/Define-access-controls.md
@@ -79,6 +79,17 @@ The tool will prompt you to provide the required information, as summarized belo
 ? Select the permission to apply: Explicitly grant access
 ```
 
+
+**Allow authenticated users to read coffeeshops**; that is, if you're logged in, you can view all coffeeshops.
+
+```
+? Select the model to apply the ACL entry to: CoffeeShop
+? Select the ACL scope: All methods and properties
+? Select the access type: Read
+? Select the role Any authenticated user
+? Select the permission to apply Explicitly grant access
+```
+
 Now, **enable the author of a review (its "owner") to make any changes to it**.
 
 ```

--- a/pages/en/lb3/Define-access-controls.md
+++ b/pages/en/lb3/Define-access-controls.md
@@ -69,7 +69,7 @@ The tool will prompt you to provide the required information, as summarized belo
 ? Select the permission to apply: Explicitly grant access
 ```
 
-**Allow authenticated users to write a review**; that is, if you're logged in, you can add a review.
+**Allow authenticated users to write a review**; that is, if you're logged in, you can add reviews.
 
 ```
 ? Select the model to apply the ACL entry to: Review


### PR DESCRIPTION
Users won't be allowed to view any coffeshops (and therefore the coffeshop list will be empty) if not explicitly allowing users to read coffeshops, because all endpoints are denied explicitly at the first hand.