### PR TITLE
Move rest.normalizeHttpPath from config.json to model json config

### DIFF
--- a/pages/en/lb3/Model-definition-JSON-file.md
+++ b/pages/en/lb3/Model-definition-JSON-file.md
@@ -186,7 +186,7 @@ Properties are required unless otherwise designated.
     </tr>
 
     <tr>
-      <td>rest.<br/>normalizeHttpPath</td>
+      <td>remoting.<br/>normalizeHttpPath</td>
       <td>Boolean</td>
       <td>false</td>
       <td>

--- a/pages/en/lb3/Model-definition-JSON-file.md
+++ b/pages/en/lb3/Model-definition-JSON-file.md
@@ -41,7 +41,10 @@ For example, here is an excerpt from a model definition file for a customer mode
   "acls": [...],  // See ACLs below
   "scopes": {...},  // See Scopes below
   "indexes" : { ...}, // See Indexes below
-  "methods": [...],  // See Methods below - New for LB2.0 - Remoting metadata
+  "methods": [...],  // See Methods below
+  "remoting": {
+      "normalizeHttpPath": true
+    },  
   "http": {"path": "/foo/mypath"}
 }
 ```
@@ -53,38 +56,24 @@ Properties are required unless otherwise designated.
 <table>
   <thead>
     <tr>
-      <th width="120">Property</th>
+      <th width="160">Property</th>
       <th width="100">Type</th>
       <th>Default</th>
       <th>Description</th>
     </tr>
   </thead>
+
   <tbody>
     <tr>
-      <td>name</td>
-      <td>String</td>
-      <td>None</td>
-      <td>Name of the model.</td>
-    </tr>
-    <tr>
-      <td>description</td>
-      <td>String or Array</td>
-      <td>None</td>
+      <td>acls</td>
+      <td>Array</td>
+      <td>N/A</td>
       <td>
-        Optional description of the model.<br/><br/>
-        You can split long descriptions into arrays of strings (lines) to keep line lengths manageable; for example:
-        <pre>[ "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-"sed do eiusmod tempor incididunt ut labore et dolore",<br> "magna aliqua." ] </pre>
+        Set of <code>ACL</code> specifications that describes access control for the model.
+        See <a href="#acls">ACLs</a> below.
       </td>
     </tr>
-    <tr>
-      <td>plural</td>
-      <td>String</td>
-      <td>Plural of <code>name</code> property using standard English conventions.</td>       
-      <td>
-        Plural form of the model name.  
-      </td>
-    </tr>
+
     <tr>
       <td>base</td>
       <td>String</td>
@@ -93,19 +82,19 @@ Properties are required unless otherwise designated.
         Name of another model that this model extends. The model will "inherit" properties and methods of the base model.
       </td>
     </tr>
+
     <tr>
-      <td>idInjection</td>
-      <td>Boolean</td>
-      <td><code>true</code></td>       
+      <td>description</td>
+      <td>String or Array</td>
+      <td>None</td>
       <td>
-        Whether to automatically add an <code>id</code> property to the model:
-        <ul>
-          <li><code>true</code>: <code>id</code> property is added to the model automatically. This is the default.</li>
-          <li><code>false</code>: <code>id</code> property is not added to the model</li>
-        </ul>
-        See <a href="#id-properties">ID properties</a> for more information.  The <code>idInjection</code> property in <code>options</code> (if present) takes precedence.
+        Optional description of the model.<br/><br/>
+        You can split long descriptions into arrays of strings (lines) to keep line lengths manageable; for example:
+        <pre style="font-size: 75%;">[ "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+  "sed do eiusmod tempor incididunt ut labore et dolore",<br>  "magna aliqua." ] </pre>
       </td>
     </tr>
+
     <tr>
       <td>forceId</td>
       <td>Boolean</td>
@@ -114,6 +103,7 @@ Properties are required unless otherwise designated.
         If true, prevents clients from setting the auto-generated ID value manually.
       </td>
     </tr>
+
     <tr>
       <td>http.path</td>
       <td>None</td>
@@ -136,6 +126,28 @@ Properties are required unless otherwise designated.
         </ul>
       </td>
     </tr>
+
+    <tr>
+      <td>idInjection</td>
+      <td>Boolean</td>
+      <td><code>true</code></td>       
+      <td>
+        Whether to automatically add an <code>id</code> property to the model:
+        <ul>
+          <li><code>true</code>: <code>id</code> property is added to the model automatically. This is the default.</li>
+          <li><code>false</code>: <code>id</code> property is not added to the model</li>
+        </ul>
+        See <a href="#id-properties">ID properties</a> for more information.  The <code>idInjection</code> property in <code>options</code> (if present) takes precedence.
+      </td>
+    </tr>
+
+    <tr>
+      <td>name</td>
+      <td>String</td>
+      <td>None</td>
+      <td>Name of the model.</td>
+    </tr>
+
     <tr>
       <td>options</td>
       <td>Object</td>
@@ -144,6 +156,16 @@ Properties are required unless otherwise designated.
         JSON object that specifies model options. See <a href="#options">Options</a> below.
       </td>
     </tr>
+
+    <tr>
+      <td>plural</td>
+      <td>String</td>
+      <td>Plural of <code>name</code> property using standard English conventions.</td>       
+      <td>
+        Plural form of the model name.  
+      </td>
+    </tr>
+
     <tr>
       <td>properties</td>
       <td>Object</td>
@@ -152,6 +174,7 @@ Properties are required unless otherwise designated.
         JSON object that specifies the properties in the model. See <a href="#properties">Properties</a> below.
       </td>
     </tr>
+
     <tr>
       <td>relations</td>
       <td>Object</td>
@@ -161,26 +184,35 @@ Properties are required unless otherwise designated.
         See <a href="#relations">Relations</a> below.
       </td>
     </tr>
+
     <tr>
-      <td>acls</td>
-      <td>Array</td>
-      <td>N/A</td>
+      <td>rest.<br/>normalizeHttpPath</td>
+      <td>Boolean</td>
+      <td>false</td>
       <td>
-        Set of <code>ACL</code> specifications that describes access control for the model.
-        See <a href="#acls">ACLs</a> below.
+        If <code>true</code>, in HTTP paths, converts:
+        <ul>
+          <li>Uppercase letters to lowercase.</li>
+          <li>Underscores (&#95;) to dashes (-).</li>
+          <li>CamelCase to dash-delimited.</li>
+        </ul>
+        Does not affect placeholders (for example ":id").
+        For example, "MyClass" or "My_class" becomes "my-class".
       </td>
     </tr>
-    <tr>
-      <td>scopes</td>
-      <td>Object</td>
-      <td>N/A</td>
-      <td>See <a href="#scopes">Scopes</a> below.</td>
-    </tr>
+
     <tr>
       <td>replaceOnPUT</td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>If true, <a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replaceorcreate">replaceOrCreate()</a>  and <a href="https://apidocs.strongloop.com/loopback/#persistedmodel-replacebyid">replaceById()</a> use the HTTP PUT method; if false, updateOrCreate() and <a href="https://apidocs.strongloop.com/loopback/#persistedmodel-prototype-updateattributes">updateAttributes()</a>/patchAttributes() use the HTTP PUT method.<br/>For more information, see <a href="Exposing-models-over-REST.html#replaceonput-flag">Exposing models over REST</a>.</td>
+    </tr>
+
+    <tr>
+      <td>scopes</td>
+      <td>Object</td>
+      <td>N/A</td>
+      <td>See <a href="#scopes">Scopes</a> below.</td>
     </tr>
   </tbody>
 </table>

--- a/pages/en/lb3/config.json.md
+++ b/pages/en/lb3/config.json.md
@@ -94,7 +94,6 @@ Properties under the `remoting` top-level property determine how the application
 "remoting": {
   "context": false,
   "rest": {
-    "normalizeHttpPath": false,
     "xml": false,
     "handleErrors": false
   },
@@ -176,21 +175,6 @@ The following table describes the remoting properties.  For more information on 
         If false, then the REST adapter delegates handling unknown paths to the top-level application by calling <code>next()</code>.
       </td>
       <td>true</td>
-    </tr>
-    <tr>
-      <td>rest.<br/>normalizeHttpPath</td>
-      <td>Boolean</td>
-      <td>
-        If <code>true</code>, in HTTP paths, converts:
-        <ul>
-          <li>Uppercase letters to lowercase.</li>
-          <li>Underscores (&#95;) to dashes (-).</li>
-          <li>CamelCase to dash-delimited.</li>
-        </ul>
-        Does not affect placeholders (for example ":id").
-        For example, "MyClass" or "My_class" becomes "my-class".
-      </td>
-      <td>false</td>
     </tr>
     <tr>
       <td>rest.<br/>supportedTypes</td>


### PR DESCRIPTION
Per https://github.com/strongloop/loopback/issues/608

@Freundschaft @bajtos PTAL

Moves doc for the `rest.normalizeHttpPath` property from `config.json` to the model JSON file doc.  NOTE: I also alphabetized the "top-level properties" in Model JSON file to make it easier to find a given property.