### PR TITLE
Add "npm start" as a shortcut for "bundle exec..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Bundler will look in the Gemfile for which gems to install. The `github-pages` g
 Run Jekyll using the following command:
 
 ```
-$ bundle exec jekyll serve
+$ npm start
 ```
 
 Then, load [http://localhost:4001/](http://localhost:4001/) on your browser.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "This file: Node-dependant workflow scripts for the jekyll-based site",
   "scripts": {
+    "start": "bundle exec jekyll serve",
     "fetch-readmes": "get-readmes --repos=./_data --out=./_includes/readmes",
     "lint-readmes" : "markdownlint _includes/readmes/"
   },


### PR DESCRIPTION
I never remember what's the full bundle command to run. OTOH, "npm start" is a commonly used command in Node.js land.