### PR TITLE
Add community maintainers to fa-owners page

### DIFF
--- a/_data/fa-owners.yml
+++ b/_data/fa-owners.yml
@@ -7,6 +7,8 @@
     - loopback-api-definition
     - loopback-component-explorer
     - loopback-swagger
+    community:
+    - STRML
 
 'Boot':
   - area: Boot
@@ -84,7 +86,7 @@
     - loopback-connector-kv-memcached
     - loopback-connector-kv-redis
     files:
-    - https://github.com/strongloop/loopback/tree/master/common/models
+    - https://github.com/strongloop/loopback/tree/master/common/models/key-value-model.js
     - https://github.com/strongloop/loopback-datasource-juggler/blob/master/connectors/kv-memory.js
     - https://github.com/strongloop/loopback-datasource-juggler/blob/master/lib/kvao.js
     smes:
@@ -204,6 +206,9 @@
     - jannyHou
     - Amir-61
     - superkhau
+    community:
+    - fabien
+    - clarkorz
 
   - area: 'Validation'
     label: juggler-validation
@@ -217,7 +222,7 @@
     - superkhau
 
 'LoopBack':
-  - area: 'Auth'
+  - area: 'Authentication and access control'
     label: loopback-auth
     owner:
     - sq-lb-epitome
@@ -227,8 +232,16 @@
     - loopback-example-ssl
     - loopback-example-user-management
     - loopback-policy
+    files:
+    - https://github.com/strongloop/loopback/tree/master/common/models/access-token.js
+    - https://github.com/strongloop/loopback/tree/master/common/models/acl.js
+    - https://github.com/strongloop/loopback/tree/master/common/models/role-mapping.js
+    - https://github.com/strongloop/loopback/tree/master/common/models/role.js
+    - https://github.com/strongloop/loopback/tree/master/lib/acces-context.js
     smes:
     - loay
+    community:
+    - ebarault
 
   - area: 'Glue'
     label: glue
@@ -313,6 +326,8 @@
     smes:
     - davidcheung
     - 0candy
+    community:
+    - zmln
 
   - area: 'iOS'
     label: sdk-ios
@@ -338,7 +353,7 @@
     - rashmihunt
 
 'Other':
-  - area: Other
+  - area: Project infrastructure
     label: N/A
     owner:
     - sq-lb-apex
@@ -351,3 +366,14 @@
     files:
     - https://github.com/strongloop-internal/loopback-knowledge-base
     smes:
+
+  - area: loopback-context
+    label: N/A
+    owner:
+    - qs-lb-asteroid
+    repos:
+    - loopback-context
+    smes:
+    - bajtos
+    community:
+    - josieusa

--- a/pages/en/contrib/functional-area-owners.md
+++ b/pages/en/contrib/functional-area-owners.md
@@ -20,12 +20,12 @@ redirect_from:
 {% for category in site.data.fa-owners %}
   <h2>{{category[0]}}</h2>
 
-  <table width="800" border="1">
+  <table width="930" border="1">
   <thead><tr>
     <th width="170">GitHub Label</th>
     <th width="150">Owner</th>
-    <th width="250">Repo(s)</th>
-    <th width="130">SME(s)</th>
+    <th width="300">Repo(s)</th>
+    <th width="180">SME(s)</th>
     <th width="130">Community maintainers</th>
 
   </tr></thead>

--- a/pages/en/contrib/functional-area-owners.md
+++ b/pages/en/contrib/functional-area-owners.md
@@ -24,14 +24,15 @@ redirect_from:
   <thead><tr>
     <th width="170">GitHub Label</th>
     <th width="150">Owner</th>
-    <th width="300">Repo(s)</th>
-    <th width="180">SME(s)</th>
+    <th width="250">Repo(s)</th>
+    <th width="130">SME(s)</th>
+    <th width="130">Community maintainers</th>
 
   </tr></thead>
   <tbody>
     {% for fa in category[1] %}
       {% if category[0] != fa.area %}
-        <tr><td colspan="4" style="margin: 0; background-color: #ddd; font-weight: bold; text-align: center;"> {{ fa.area }} </td></tr>
+        <tr><td colspan="5" style="margin: 0; background-color: #ddd; font-weight: bold; text-align: center;"> {{ fa.area }} </td></tr>
       {% endif %}
       <tr>
         <td> {{fa.label}}</td>
@@ -41,6 +42,7 @@ redirect_from:
             {% include show-links.html type='file' list=fa.files %}
         </td>
         <td> {% include show-links.html type='person' list=fa.smes %} </td>
+        <td> {% include show-links.html type='person' list=fa.community %} </td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
I find it difficult to find all our maintainers from the community and what is their area of expertise and interest. To address that issue, I am proposing to add community maintainers to our "Functional areas owners" page.

Important: listing a community maintainer on this page DOES NOT change the expectations, specifically there is no obligation to be actively involved in day-to-day discussions, pull request reviews and issue triaging/bug fixing.

I see this information as a way to help all of us to more easily find people to ask for another opinion when making a change that could have bigger impact or may be viewed as controversial.

Any ideas how to capture the above in the doc page itself? For example, I can change the table heading to "community experts" instead of "community maintainers"; or add a note at the top of the page to clarify the role of community maintainers.

---

I filled the data in this initial version from past contributions and team/commit settings.

 - @STRML is listed in "API definition" for his contributions  o loopback-component-explorer and loopback-swagger. 
 - @fabien is listed in "Relations" for his contributions to relations and embedded relations.
 - @clarkorz is listed in "Relations"
 - @ebarault is listed in "Authentication and access control"
 - @zmln is listed in "SDKS > Angular 1.x" for his work on gulp-loopback-sdk-angular
 - @josieusa is listed in a new section "loopback-context"

Please let me know if you are happy with my proposal or whether there is anything to change or improve.

@raymondfeng @ritch I am not sure if covered all community maintainers we have, please let me know if I missed somebody.

cc @superkhau 