### PR TITLE
Link to Announcements list in top navigation

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -26,6 +26,8 @@ topnav_dropdowns:
       folderitems:
         - title: Docs Github Repo
           external_url: https://github.com/strongloop/loopback.io
+        - title: Announcements Mailing List
+          external_url: https://groups.google.com/forum/#!forum/loopbackjs-announcements
         - title: Developer Forum
           external_url: https://groups.google.com/forum/#!forum/loopbackjs
         - title: Gitter Chat Room


### PR DESCRIPTION
See https://github.com/strongloop/loopback/issues/3042

<img width="364" alt="screen shot 2017-03-09 at 12 14 46" src="https://cloud.githubusercontent.com/assets/1140553/23747996/140fe90c-04c2-11e7-87a0-793904e56074.png">

I searched for all existing links to `groups.google` and the topnav was the only place that seemed relevant for changing.