### PR TITLE
Explicitly declare User variable

### DIFF
--- a/pages/en/lb3/Using-current-context.md
+++ b/pages/en/lb3/Using-current-context.md
@@ -207,6 +207,7 @@ module.exports = function(app) {
     .addBefore('invoke', 'options-from-request')
     .use(function(ctx, next) {
       if (!ctx.args.options.accessToken) return next();
+      const User = app.models.User;
       User.findById(ctx.args.options.accessToken.userId, function(err, user) {
         if (err) return next(err);
         ctx.args.options.currentUser = user;


### PR DESCRIPTION
Copy/pasting this snippet creates throws: `ReferenceError: User is not defined`.
Fix by explicitly define where to find variable.
