### PR TITLE
fixing hypenation of json propname issue

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -410,6 +410,15 @@ table td {
     hyphens: auto;
 }
 
+/** 
+prevent hypens of config property names.
+Many tables show || propName | description | default ||
+"propName" should NOT be hyphenated to prop-Name
+*/
+table tr td:first-child {
+    hyphens: none;
+}
+
 section table tr.success {
     background-color: #dff0d8 !important;
 }


### PR DESCRIPTION
From [here](https://loopback.io/doc/en/lb2/config.json.html):
![screen shot 2017-04-04 at 4 56 11 pm](https://cloud.githubusercontent.com/assets/317498/24678207/a4afb330-1957-11e7-8ef9-de1b6fa3ca4c.png)

`legacyExplorer` and `restApiRoot` must **not** be hyphenated.