### PR TITLE
Link to example of discovery function usage

### DIFF
--- a/pages/en/lb3/Discovering-models-from-relational-databases.md
+++ b/pages/en/lb3/Discovering-models-from-relational-databases.md
@@ -29,7 +29,8 @@ Data sources connected to relational databases automatically get the asynchronou
 
 Follow these basic steps:
 
-1.  Use a script such as that below to discover the schema.
+1.  Run a script to discover the model definitions for use in your application.
+See the [example below](#additional-discovery-functions) for details.
 2.  Use `fs.writeFile()` to save the output in `common/models/model-name.json`.
 3.  Add the new model entry to `server/model-config.json`.
 4.  Run the app:


### PR DESCRIPTION
The existing message doesn't make it clear that the first example is _not_ for dumping model definitions to text, but rather for leveraging discovered definitions at runtime.