### PR TITLE
Fix typo in function name

### DIFF
--- a/pages/en/lb3/Creating-a-database-schema-from-models.md
+++ b/pages/en/lb3/Creating-a-database-schema-from-models.md
@@ -155,7 +155,7 @@ For more information, see the [MongoDB documentation](http://docs.mongodb.org/m
 **See also**: See also [autoupdate()](http://apidocs.strongloop.com/loopback-datasource-juggler/#datasource-prototype-autoupdate) in LoopBack API reference.
 
 If there are existing tables in a database, running `automigrate()` will drop and re-create the tables: Therefore, data will be lost.
-To avoid this problem use `auto-update()`.
+To avoid this problem, use `autoupdate()`.
 Instead of dropping tables and recreating them, `autoupdate()` calculates the difference between the LoopBack model and the database table
 definition and alters the table accordingly. This way, the column data will be kept as long as the property is not deleted from the model.
 

--- a/pages/en/lb3/readmes/loopback-connector-cloudant.md
+++ b/pages/en/lb3/readmes/loopback-connector-cloudant.md
@@ -119,6 +119,37 @@ User.destroyAll (function () {
 })
 ```
 
+#### Note on using `updateOrCreate` functionality:
+**Cloudant does not support the idea of updating a document. All "updates" on a document are _destructive_ replacements.**
+
+For example:
+
+```
+// original document
+{
+  "id": ...,
+  "_rev": ...,
+  "prop1": "1",
+  "prop2": "2",
+}
+
+// data to be updated
+ds.updateOrCreate('User', {
+  prop1: 'updated1',
+}, function (err, res) {});
+
+// document after update
+{
+  "id": ...,
+  "_rev": ...,
+  "prop1": "updated1",
+}
+```
+
+**Please note how property `prop2` was completely dropped upon update.**
+
+**Solution:** Do not pass partial values for the data object to be updated. If there are properties that are not being updated, please include the old value to keep data persistent.
+
 ## Feature backlog
 
 * Index-only model properties marked with index=true


### PR DESCRIPTION
Just a small fix as part of our doc review for discovery and migration.