### PR TITLE
Documents primaryKey option in relations

### DIFF
--- a/pages/en/lb2/BelongsTo-relations.md
+++ b/pages/en/lb2/BelongsTo-relations.md
@@ -66,7 +66,8 @@ For example, here is the model JSON file for the order model in
     "customer": {
       "type": "belongsTo",
       "model": "Customer",
-      "foreignKey": ""
+      "foreignKey": "",
+      "primaryKey": "id" // optional
     }
   },
   ...

--- a/pages/en/lb2/HasMany-relations.md
+++ b/pages/en/lb2/HasMany-relations.md
@@ -39,7 +39,8 @@ For example, here is the model JSON file for the customer model in [loopback-ex
     "reviews": {
       "type": "hasMany",
       "model": "Review",
-      "foreignKey": "authorId"
+      "foreignKey": "authorId",
+      "primaryKey": "id" // optional
     },
   ...
 ```

--- a/pages/en/lb2/HasOne-relations.md
+++ b/pages/en/lb2/HasOne-relations.md
@@ -44,7 +44,8 @@ For example, consider two models: supplier and account.
     "supplier_acct": {
       "type": "hasOne",
       "model": "account",
-      "foreignKey": "supplierId"
+      "foreignKey": "supplierId",
+      "primaryKey": "id" // optional
     }
   },
   "acls": [],


### PR DESCRIPTION
This was only documented in the `hasOne` relation documentation even though it's supported in `belongsTo`, `hasMany` & `hasOne`.