### PR TITLE
Documents primaryKey option in relations

### DIFF
--- a/pages/en/lb3/BelongsTo-relations.md
+++ b/pages/en/lb3/BelongsTo-relations.md
@@ -59,7 +59,8 @@ For example, here is the model JSON file for the order model in
     "customer": {
       "type": "belongsTo",
       "model": "Customer",
-      "foreignKey": ""
+      "foreignKey": "",
+      "primaryKey": "id" // optional
     }
   },
   ...

--- a/pages/en/lb3/HasMany-relations.md
+++ b/pages/en/lb3/HasMany-relations.md
@@ -37,7 +37,8 @@ For example, here is the model JSON file for the customer model in [loopback-ex
     "reviews": {
       "type": "hasMany",
       "model": "Review",
-      "foreignKey": "authorId"
+      "foreignKey": "authorId",
+      "primaryKey": "id" // optional
     },
   ...
 ```


### PR DESCRIPTION
This was only documented in the `hasOne` relation documentation even though it's supported in `belongsTo` & `hasMany` as well.

Source code support for this can be found here 
https://github.com/strongloop/loopback-datasource-juggler/blob/master/lib/relation-definition.js#L1237
https://github.com/strongloop/loopback-datasource-juggler/blob/master/lib/relation-definition.js#L599