### PR TITLE
Add --incremental to "npm start" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This file: Node-dependant workflow scripts for the jekyll-based site",
   "scripts": {
-    "start": "bundle exec jekyll serve",
+    "start": "bundle exec jekyll serve --incremental",
     "fetch-readmes": "get-readmes --repos=./_data --out=./_includes/readmes",
     "lint-readmes" : "markdownlint _includes/readmes/"
   },


### PR DESCRIPTION
Enable incremental (re)build when running jekyll via "npm start".