### PR TITLE
Example in doc: defaultForType not more suported 

### DIFF
--- a/pages/en/lb3/Email-connector.md
+++ b/pages/en/lb3/Email-connector.md
@@ -90,7 +90,6 @@ For GMail, configure your email data source as follows:
 ...
 "Email": {
   "name": "mail",
-  "defaultForType": "mail",
   "connector": "mail",
   "transports": [{
     "type": "SMTP",


### PR DESCRIPTION
Hello, 
I try to send a email with gmail config, but lb say me: DataSource "defaultForType" is not more supported. So I make a small correction of this example.

 #Cordially