### PR TITLE
Add doc for lb oracle command

### DIFF
--- a/_data/sidebars/lb3_sidebar.yml
+++ b/_data/sidebars/lb3_sidebar.yml
@@ -631,6 +631,10 @@ children:
     url: /doc/en/lb3/Model-generator.html
     output: 'web, pdf'
 
+  - title: 'Oracle installer command'
+    url: /doc/en/lb3/Oracle-installer-command.html
+    output: 'web, pdf'
+
   - title: 'Property generator'
     url: /doc/en/lb3/Property-generator.html
     output: 'web, pdf'

--- a/_includes/navgroups/oracle.md
+++ b/_includes/navgroups/oracle.md
@@ -1,6 +1,8 @@
 {% capture navgroup_content %}
   {% unless page.title == 'Oracle connector' %}
   * [Oracle connector](Oracle-connector.html)
+  {% endunless %}{% unless page.title == 'Oracle installer command' %}
+  * [Oracle installer command](Oracle-installer-command.html)
   {% endunless %}{% unless page.title == 'Installing the Oracle connector' %}
   * [Installing the Oracle connector](Installing-the-Oracle-connector.html)
   {% endunless %}{% unless page.title == 'Oracle Connector Tutorial' %}

--- a/_layouts/navgroup.html
+++ b/_layouts/navgroup.html
@@ -11,14 +11,12 @@ toc: false
     {% assign readme-file = page.source  %}
   {% endif %}
   <style>h1:not(.post-title-main) { display: none; }</style>
+
+  {{content}}
   <div class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i> <b>Note:</b> This page was generated from the <a href="https://github.com/strongloop/{{repo-branch}}">{{page.source}} README</a>.</div>
-{% endif %}
-
-<!-- navgroup -->
-
-{% if page.source %}
+  
   {% capture included-readme %}{% include_relative readmes/{{page.source}}.md %}{% endcapture %}
   {{ included-readme | markdownify }}
+{% else %}
+  {{content}}
 {% endif %}
-
-{{content}}

--- a/pages/en/lb3/Installing-the-Oracle-connector.md
+++ b/pages/en/lb3/Installing-the-Oracle-connector.md
@@ -10,3 +10,8 @@ sidebar: lb3_sidebar
 permalink: /doc/en/lb3/Installing-the-Oracle-connector.html
 summary: The loopback-oracle-installer module takes care of binary dependencies and simplifies the process of installing the Oracle connector.
 ---
+{% include tip.html content="
+Use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
+to easily install and troubleshoot installing `loopback-oracle-installer`
+and the Oracle data source connector.  
+" %}

--- a/pages/en/lb3/Oracle-connector.md
+++ b/pages/en/lb3/Oracle-connector.md
@@ -10,3 +10,8 @@ sidebar: lb3_sidebar
 permalink: /doc/en/lb3/Oracle-connector.html
 summary: The Oracle connector enables LoopBack applications to connect to Oracle data sources.
 ---
+{% include tip.html content="
+Use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
+to easily install and troubleshoot installing `loopback-oracle-installer`
+and the Oracle data source connector.  
+" %}

--- a/pages/en/lb3/Oracle-installer.md
+++ b/pages/en/lb3/Oracle-installer.md
@@ -1,0 +1,49 @@
+---
+title: "Oracle installer command"
+lang: en
+layout: page
+tags: [data_sources, tools]
+sidebar: lb3_sidebar
+permalink: /doc/en/lb3/Oracle-installer-command.html
+summary:
+---
+{% include content/generator-create-app.html lang=page.lang %}
+
+Utilities to install and troubleshoot [loopback-connector-oracle](https://github.com/strongloop/loopback-connector-oracle) module.
+
+### Synopsis
+
+```
+lb oracle [options]
+```
+
+### Options
+
+`--connector`     
+: Install loopback-connector-oracle module
+
+`--driver`
+: Install oracledb module.
+
+`-h, --help`
+: Print the generator's options and usage.
+
+`--verbose`
+: Print verbose information
+
+### Interactive Prompts
+
+The tool determines if the Oracle Instant Client is installed and then checks
+if the `loopback-connector-oracle` module can be loaded.
+The `loopback-connector-oracle` module depends on the Oracle Node.js Driver [oracledb](https://github.com/oracle/node-oracledb),
+which is a binary addon.
+The `oracledb` module requires [Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html) at
+both build and run time. See [Installation Guide for oracledb](https://github.com/oracle/node-oracledb/blob/master/INSTALL.md)
+for more information.
+
+If `loopback-connector-oracle` is ready to use, the tool will print `Oracle connector is ready` and exit.
+Otherwise, it will prompt you to install:
+
+- Oracle Instant Client
+- loopback-connector-oracle
+- oracledb module


### PR DESCRIPTION
This adds `lb oracle` to the CLI command reference, and also adds cross-references from the other Oracle data source connector articles.

Based on https://github.com/strongloop/generator-loopback/blob/master/oracle/README.md, I did not include the "standard options" `--skip-cache` and `--skip-install`.