### PR TITLE
Change year of security advisory to 2017

### DIFF
--- a/_data/sidebars/lb3_sidebar.yml
+++ b/_data/sidebars/lb3_sidebar.yml
@@ -128,7 +128,7 @@ children:
   output: 'web, pdf'
   children:
 
-  - title: '03-10-2016'
+  - title: '03-10-2017'
     url: /doc/en/lb3/Security-advisory-03-10-2017.html
     output: 'web, pdf'
 


### PR DESCRIPTION
Sidebar appears to incorrectly label the security advisory as 2016.