### PR TITLE
fixed search bar styling for tablet device width

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -50,7 +50,7 @@
 		{% endif %}
                 <!-- comment out this block if you want to hide search -->
                 <li>
-                  <div style="max-width: 400px; height: 50px; background-color: #72ac4a; margin-left: 10px;"><!-- Google Custom Search -->
+                  <div class="lb-search-container"><!-- Google Custom Search -->
                     <script>
                       (function() {
                         var cx = '008208300112466859893:btbpudzecwg';

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -80,6 +80,24 @@ margin-top: -40px
 
 body h1 {margin-top:40px;}
 
+.lb-search-container {
+  padding: 0 10px;
+  background-color: #72ac4a;
+}
+
+@media only screen and (min-width: 768px) {
+  .lb-search-container {
+    padding-right: 0;
+    width: 200px;
+  }
+}
+
+@media only screen and (min-width: 992px) {
+  .lb-search-container {
+    width: 350px;
+  }
+}
+
 .post-content img {
     margin: 12px 0px 3px 0px;
     width: auto;
@@ -155,9 +173,6 @@ table > caption + thead > tr:first-child > td,
 table > colgroup + thead > tr:first-child > td,
 table > thead:first-child > tr:first-child > td {
     border-top: 0;
-}
-table > tbody + tbody {
-    b
 }
 table > tbody > tr:nth-of-type(odd) {
     background-color: #f9f9f9;
@@ -921,8 +936,7 @@ span.soft {
     border: 1px solid #dedede;
 }
 
-
-@media only screen and (min-width: 900px), @media only screen and (min-device-width: 900px) {
+@media only screen and (min-width: 900px), only screen and (min-device-width: 900px) {
     .col-md-9 img {
         max-width: 700px;
         max-height: 700px;
@@ -1253,7 +1267,72 @@ pre.query_syntax {
 }
 
 table.gsc-search-box, form.gsc-search-box, div.gsc-control-wrapper-cse, div.gsc-control-cse.gsc-control-cse-en, #___gcse_0 {
+  margin: 0 !important;
   border-style: none !important;
+}
+
+td.gsc-input {
+  padding: 8px 0 !important;
+}
+
+input.gsc-input {
+  width: 100% !important;
+  padding-right: 24px !important;
+  background-position-x: 4px !important;
+}
+
+td.gsc-search-button {
+  position: relative;
+  padding: 0 !important;
+}
+
+td.gsc-search-button:after {
+  content: '\f002';
+  font-family: FontAwesome;
+  color: #333;
+  font-weight: normal;
+  font-style: normal;
+
+  display: block;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  width: 16px;
+  height: 16px;
+
+  margin: auto;
+
+  font-size: 16px;
+  line-height: 16px;
+}
+
+input.gsc-search-button {
+  font-size: 0 !important;
+  margin: 0 !important;
+  min-width: 26px !important;
+  border-radius: 0 4px 4px 0 !important;
+}
+
+td.gsc-clear-button {
+  position: relative;
+  padding: 0;
+  width: auto !important;
+}
+
+div.gsc-clear-button {
+  position: absolute !important;
+  left: -48px;
+  top: 0;
+  bottom: 0;
+
+  width: 16px;
+  height: 16px;
+
+  padding: 0 !important;
+  margin: auto 0 !important;
 }
 
 table.gsc-search-box, table.gsc-search-box td.gsc-input {
@@ -1265,6 +1344,31 @@ table.gsc-search-box, table.gsc-search-box td.gsc-input {
 td.gsc-input, td.gsc-search-button, td.gsc-clear-button {
   background-color: #72ac4a;
   border-style: none !important;
+}
+
+.gsc-results-close-btn {
+  top: 14px !important;
+  right: 14px !important;
+}
+
+.gsc-orderby-container {
+  vertical-align: middle;
+}
+
+.gsc-selected-option {
+  white-space: nowrap;
+}
+
+.gsc-resultsHeader {
+  display: none !important;
+}
+
+.gsc-webResult.gsc-result {
+  border: none !important;
+}
+
+table.gsc-table-result {
+  margin: 0 !important;
 }
 
 /*


### PR DESCRIPTION
Hi,

The page has some rendering issues for tablet device width. I propose the following patched styles for the search bar and the list of results. 

## Search bar proposed styles
![image](https://user-images.githubusercontent.com/4801792/27015448-d174e3fc-4f05-11e7-86bc-34120f5a9513.png)

## Fix for styles in tablet device width
Before:
![image](https://user-images.githubusercontent.com/4801792/27015468-0b115cd0-4f06-11e7-89bd-8b47e9ddc9e1.png)

After:
![image](https://user-images.githubusercontent.com/4801792/27015479-479e386c-4f06-11e7-9274-31e4412ab391.png)

## Fix for the styles of the results dialog
Before:
![image](https://user-images.githubusercontent.com/4801792/27015529-65681858-4f07-11e7-96cf-8d6361ddef49.png)

After:
![image](https://user-images.githubusercontent.com/4801792/27015530-6b2afe7c-4f07-11e7-823b-54dde774401c.png)


The CSS is tested with Chrome and Firefox, please let me know if you notice any issues.

Signed-off-by: marc <r.marc2b@hotmail.fr>