### PR TITLE
Adding relation options description

### DIFF
--- a/pages/en/lb3/Model-definition-JSON-file.md
+++ b/pages/en/lb3/Model-definition-JSON-file.md
@@ -787,6 +787,26 @@ For example:
       <td>String</td>
       <td>Name of model creating hasManyThrough relation. See example below.</td>
     </tr>
+    <tr>
+      <td>options</td>
+      <td>Object</td>
+      <td>
+        <table>
+	  <tbody>
+	    <tr>
+	      <th>Key</th>
+              <th>Type</th>
+              <th>Description</th>
+	    </tr>
+	    <tr>
+	      <td>disableInclude</td>
+	      <td>Boolean</td>
+	      <td>Does not fetch the data if the relation is used in an include statement</td>
+	    </tr>
+	  </tbody>
+	</table>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/pages/en/lb3/Model-definition-JSON-file.md
+++ b/pages/en/lb3/Model-definition-JSON-file.md
@@ -788,24 +788,9 @@ For example:
       <td>Name of model creating hasManyThrough relation. See example below.</td>
     </tr>
     <tr>
-      <td>options</td>
-      <td>Object</td>
-      <td>
-        <table>
-	  <tbody>
-	    <tr>
-	      <th>Key</th>
-              <th>Type</th>
-              <th>Description</th>
-	    </tr>
-	    <tr>
-	      <td>disableInclude</td>
-	      <td>Boolean</td>
-	      <td>Does not fetch the data if the relation is used in an include statement</td>
-	    </tr>
-	  </tbody>
-	</table>
-      </td>
+      <td>options.disableInclude</td>
+      <td>Boolean</td>
+      <td>Does not fetch the data if the relation is used in an include statement</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
The 'options' property was missing form the definition of the Relations property.  Adding it to the v3 documentation