### PR TITLE
Small typo in the doc

### DIFF
--- a/pages/en/lb3/HasAndBelongsToMany-relations.md
+++ b/pages/en/lb3/HasAndBelongsToMany-relations.md
@@ -101,7 +101,7 @@ For example: `assembly.parts.create(...)`.
     </tr>
     <tr>
       <td>
-        <pre>assembly.parts.add(part,
+        <pre>assembly.parts.add(partId,
   function(err) {<br>  ...<br>});</pre>
       </td>
       <td>Add a part to the assembly.</td>


### PR DESCRIPTION
the `add()` method on declaring model takes the model instance `id` of the object and not the model instance.