### PR TITLE
Add READMEs for examples, add to sidebar, add sh script and Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ node('linux && git') {
   stage('download updates') {
     sh './update-readmes.sh'
     sh './update-community-readmes.sh'
+    sh './update-readmes-lb4.sh'
   }
   stage('check updates') {
      sh 'git status'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ node('linux && git') {
       // existing files will have to be done by a human for now.
       sh 'git add pages/en/lb2/readmes'
       sh 'git add pages/en/lb3/readmes'
+      sh 'git add pages/en/lb4/readmes'
       sh 'git add pages/en/community/readmes'
       withEnv(gitEnv) {
         sh 'git commit -m "Update READMEs from other repos"'

--- a/_data/sidebars/lb4_sidebar.yml
+++ b/_data/sidebars/lb4_sidebar.yml
@@ -20,16 +20,29 @@ children:
   output: 'web, pdf'
   children:
 
-  - title: 'Examples & Tutorials'
-    url: Examples-and-tutorials.html
-    output: 'web, pdf'
-
   - title: 'Thinking in LoopBack'
     url: Thinking-in-LoopBack.html
     output: 'web, pdf'
 
   - title: 'FAQ'
     url: FAQ.html
+    output: 'web, pdf'
+
+- title: 'Examples & Tutorials'
+  url: Examples-and-tutorials.html
+  output: 'web, pdf'
+  children:
+
+  - title: 'Hello world example'
+    url: LoopBack4-Hello-World.html
+    output: 'web, pdf'
+
+  - title: 'Microservice example'
+    url: LoopBack4-microservice-example.html
+    output: 'web, pdf'
+
+  - title: 'Extension starter example'
+    url: LoopBack4-extension-starter.html
     output: 'web, pdf'
 
 - title: 'Key concepts'

--- a/pages/en/lb4/Examples-and-tutorials.md
+++ b/pages/en/lb4/Examples-and-tutorials.md
@@ -2,17 +2,18 @@
 lang: en
 title: Examples and tutorials
 keywords: LoopBack 4.0
-tags:
+tags: LoopBack4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Examples-and-tutorials.html
 summary:
 ---
 
-Currently, there are two main examples:
-- "Hello World" - [loopback-next-hello-world](https://github.com/strongloop/loopback-next-hello-world).  Ultimately, this will have an accompanying tutorial to help introduce developers to LB-next.
-- [loopback-next-example](https://github.com/strongloop/loopback-next-example). This will demonstrate how to design your infrastructure using a microservices with LoopBack-next
+The LoopBack 4 examples are:
+- [Hello world example](LoopBack4-Hello-World.html) - The most basic LoopBack 4 app. Ultimately, this will have an accompanying tutorial to help introduce developers to LoopBack 4.
+- [Microservice example](LoopBack4-microservice-example.html) - Demonstrates how to create microservices with LoopBack 4.
+- [Extension starter example](LoopBack4-extension-starter.html) - Demonstrates how to make a LoopBack component / extension.
 
-**Tutorials**
+Tutorials:
 - [Testing Your Application](Testing-your-application.html)
 
 Not yet created:

--- a/pages/en/lb4/LB4-extension-example.md
+++ b/pages/en/lb4/LB4-extension-example.md
@@ -1,0 +1,11 @@
+---
+title: "LoopBack 4 component example"
+lang: en
+layout: readme
+source: loopback4-extension-starter
+keywords: LoopBack4
+tags: example_app
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/LoopBack4-extension-starter.html
+summary: Component/extension example for LoopBack 4  
+---

--- a/pages/en/lb4/LB4-hello-world-example.md
+++ b/pages/en/lb4/LB4-hello-world-example.md
@@ -1,0 +1,11 @@
+---
+title: "LoopBack 4 Hello World"
+lang: en
+layout: readme
+source: loopback-next-hello-world
+keywords: LoopBack4
+tags: example_app
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/LoopBack4-Hello-World.html
+summary: Hello world example for LoopBack 4  
+---

--- a/pages/en/lb4/LB4-microservice-example.md
+++ b/pages/en/lb4/LB4-microservice-example.md
@@ -1,0 +1,13 @@
+---
+title: "LoopBack 4 microservice example"
+lang: en
+layout: readme
+source: loopback-next-example
+keywords: LoopBack4
+tags: example_app
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/LoopBack4-microservice-example.html
+summary: Microservice example for LoopBack 4  
+---
+{% include warning.html content="This example and accompanying documentation are incomplete and a work in progress.
+" %}

--- a/pages/en/lb4/readmes/loopback-next-example.md
+++ b/pages/en/lb4/readmes/loopback-next-example.md
@@ -1,0 +1,59 @@
+# loopback-next-example
+
+[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/strongloop/loopback)
+
+How to build scalable microservices using LoopBack.next.
+
+> What's the difference between LoopBack.next and the current version of
+> Loopback? See [LoopBack 3 vs LoopBack 4](https://github.com/strongloop/loopback-next/wiki/FAQ#loopback-3-vs-loopback-4).
+
+## Installation
+
+Make sure you have the following installed:
+
+- [Node.js](https://nodejs.org/en/download/) >= 7.0.0
+- [TypeScript](https://www.typescriptlang.org/index.html#download-links) >= 2.0.0 `npm i -g typescript`
+- [TypeScript Node](https://github.com/TypeStrong/ts-node#installation) >= 3.0.0 `npm i -g ts-node`
+
+```shell
+# install loopback-next-example
+git clone https://github.com/strongloop/loopback-next-example
+cd loopback-next-example
+npm run build
+```
+
+## Basic use
+
+```shell
+# start all microservices
+npm start
+
+# perform GET request to retrieve account summary data
+curl localhost:3000/account/summary?accountNumber=CHK52321122 # or npm test
+
+# perform GET request to retrieve account data
+curl localhost:3001/accounts?accountNumber=CHK52321122
+
+# stop all microservices
+npm stop
+```
+
+> Helper scripts for the above commands are in [`/bin`](https://github.com/strongloop/loopback-next-example/tree/master/bin)
+directory.
+
+# Team
+
+Ritchie Martori|Simon Ho|Siddhi Pai|Mahesh Patsute|Deepak Rajamohan
+:-:|:-:|:-:|:-:|:-:
+[<img src="https://avatars2.githubusercontent.com/u/462228?v=3&s=60">](http://github.com/ritch)|[<img src="https://avatars1.githubusercontent.com/u/1617364?v=3&s=60">](http://github.com/superkhau)|[<img src="https://avatars0.githubusercontent.com/u/15273582?v=3&u=d53eb3a459e72484c0ffed865c4e41f9ed9b4fdf&s=60">](http://github.com/siddhipai)|[<img src="https://avatars3.githubusercontent.com/u/24725376?v=3&s=60">](http://github.com/mpatsute)|[<img src="https://avatars2.githubusercontent.com/u/7688315?v=3&s=60">](http://github.com/deepakrkris)
+
+[See all contributors](https://github.com/strongloop/loopback-next-example/graphs/contributors)
+
+# Contributing
+
+- [Guidelines](https://github.com/strongloop/loopback-next/wiki/Contributing)
+- [Join the team](https://github.com/strongloop/loopback-next/wiki/Contributing#join-the-team)
+
+# License
+
+MIT

--- a/pages/en/lb4/readmes/loopback-next-hello-world.md
+++ b/pages/en/lb4/readmes/loopback-next-hello-world.md
@@ -1,0 +1,173 @@
+# loopback-next-hello-world
+
+[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/strongloop/loopback) [![Build Status](https://travis-ci.org/strongloop/loopback-next-quick-start.svg?branch=master)](https://travis-ci.org/strongloop/loopback-next-quick-start) [TODO Code coverage - coveralls]
+
+## Table of Contents
+* [Overview](#overview)
+* [Background](#background)
+* [Setup](#setup)
+* [Try It Out!](#tryitout)
+* [Testing](#testing)
+* [Project Structure](#structure)
+* [Writing Controllers](#controllers)
+* [Using a Custom Sequence](#sequence)
+* [TypeScript Configuration](#typescriptConfiguration)
+* [Other Resources](#resources)
+* [Contribute](#contribute)
+
+## <a name="overview"></a>Overview
+
+#### Welcome to the hello-world example for LoopBack.next!
+LoopBack makes it easy to build modern applications that require complex integrations. 
+
+LoopBack.next, the next version of LoopBack, is being designed to make it even easier to extend the framework for your own needs. Loopback.next will also include the latest JavaScript features.
+
+The goal of this tutorial is to show you what a basic, 'hello-world' LoopBack.next app looks like and how it works.
+
+This example will show you how to: 
+
+* create a LoopBack.next server
+* make a request to the server to fetch content
+
+This example will explain:
+
+* the structure of a LoopBack.next application
+* how to add a custom component (TODO)
+* how to add a custom sequence
+
+When you have this example installed and running, you will be able to make a request to the server with a name and get back a HTTP 200 response.
+
+## <a name="background"></a>Background
+
+For in-depth information about the concepts underlying Loopback.next, check out:
+
+* [Crafting LoopBack Next](http://loopback.io/doc/en/lb4/Crafting-LoopBack-Next.html)
+* [Thinking in LoopBack](http://loopback.io/doc/en/lb4/Thinking-in-LoopBack.html)
+
+## <a name="setup"></a>Setup 
+
+1. Install `node`:
+
+	You should have Node.js version 8.x or newer installed.
+	
+	> NOTE: Want to switch Node versions quickly and easily? Try [`nvm`](https://github.com/creationix/nvm/blob/master/README.md). 
+		
+	For the latest information on project dependencies for LoopBack, please check this link: 
+[http://loopback.io/doc/en/lb4/Installation.html](http://loopback.io/doc/en/lb4/Installation.html).
+
+2. Clone this repo: 
+	
+	`git clone https://github.com/strongloop/loopback-next-hello-world.git`
+
+3. Switch to your new directory: 
+	
+	`cd loopback-next-hello-world`
+
+4. Install your dependencies: 
+
+	`npm install`
+
+5. Start the application! 
+	
+	`npm start`
+
+> Note: `npm start` automatically builds the project via the `prestart` npm script in `package.json`. If you would like to build this project separately, use `npm run build`.
+ 
+## <a name="tryitout"></a>Try It Out!
+
+Run `curl localhost:3000/helloworld?name=YOUR_NAME` to try out your new LoopBack server.
+
+Example:
+```
+curl localhost:3000/helloworld?name=Anne
+```
+The output will be:
+```
+Hello world Anne {"username":"a","password":"a"}
+```
+
+## <a name="testing"></a>Testing
+
+To test this application use `npm test`.
+
+## <a name="structure"></a>Project structure
+
+A TypeScript project will have separate `src` and `lib` directories, for source and distributable files. TypeScript (.ts) files from your `src` folder are compiled into JavaScript (.js) files and output in the `lib` folder.  
+
+| Name | Description|
+|------|------------|
+|.github/ISSUE_TEMPLATE.md|use this template to report an issue |
+|.github/PULL\_REQUEST\_TEMPLATE.MD|use this template to help you open a pull request |
+|lib/|this directory is created when you build your project and contains the distributable code built by TypeScript. This is the code you deploy.|
+|node_modules|this directory contains your npm modules|
+|src/|this directory contains your source code. TypeScript compiles this code and outputs it to the `lib/` directory.|
+|src/controllers|This folder contains controllers, which implement the operations defined in your OpenAPI spec file|
+|src/controllers/hello-world.api.ts|the OpenAPI spec file|
+|src/controllers/hello-world.ts|this controller implements the helloWorld operation|
+|src/providers/|providers implement the functionalities defined by components|
+|src/providers/auth-strategy.ts|this file contains the authentication strategy that is bound to the [Authentication component](https://github.com/strongloop/loopback-next/tree/master/packages/authentication)|
+|src/application.ts|this file defines your application (components + sequence)|
+|src/index.ts|this is the entry point of your application|
+|src/sequence.ts|this file contains your custom sequence|
+|test/|this directory contains your tests|
+|package.json	|this documents this project's dependencies and their versions, and also includes important repository, author, and license information|
+|README.md|this is the file you're reading right now!|
+|tsconfig.json|the configuration settings for TypeScript compilation|
+
+#### <a name="controllers"></a>Controllers
+
+Controllers implement the operations defined in your OpenAPI spec file. Find a guide to writing and testing controllers in LoopBack.next [here](http://loopback.io/doc/en/lb4/Thinking-in-LoopBack.html#incrementally-implement-features).
+
+#### <a name="sequence"></a>Adding a Custom Sequence
+
+A [sequence](http://loopback.io/doc/en/lb4/Sequence.html) is a stateless grouping of actions that allow you to control how your application responds to requests. All LoopBack.next applications have a default sequence with actions that find the route, parse the parameters, invoke the route (that is, runs the associated controller), await the result of that route, send the response, and catch any errors.
+
+You can create custom sequences that can inject new logic or behaviors at any point, accepting the output of any action and passing data on to the next action. Sequences must provide a response to a request, and they are registered when you define your application (in your `application.ts` file).
+
+```ts
+import {MySequence} from './sequence';
+app.sequence(MySequence);
+```
+
+
+### <a name="typescriptConfiguration"></a>TypeScript Configuration
+
+In your `tsconfig.json` file, you can specify options for TypeScript to use when compiling your project. 
+
+Here is the `tsconfig.json` for this project: 
+
+```json{
+  "compilerOptions": {                     
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./lib",
+    "experimentalDecorators": true,
+    "baseUrl": "./src"    
+  },
+  "exclude": [
+    "node_modules/**"
+  ]
+}
+```
+| compilerOption | Description |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `"module": "commonjs"`             | The **output** module type (in your `.js` files). Node uses commonjs, so that is what we use          |
+| `"target": "es2017"`                  | The output language level                               |
+| `"outDir": "./lib"`                 | Location to output `.js` files                                                        |
+| `"baseUrl": "./src"`                   |  |
+| `experimentalDecorators`                     | enables support for decorators (more information: [https://www.typescriptlang.org/docs/handbook/decorators.html](https://www.typescriptlang.org/docs/handbook/decorators.html))|
+
+> NOTE: We recommend you use [VSCode](https://code.visualstudio.com/) for this hello-world example because it has built-in TypeScript support, but you can use any editor. For more information about using TypeScript with your editor of choice, check out [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support).
+
+Find more information about TypeScript [here](https://www.typescriptlang.org/docs/).
+
+
+## <a name="resources"></a>Other Resources
+* Current [LoopBack documentation](http://loopback.io)
+* [LoopBack.next repo](https://github.com/strongloop/loopback-next)
+* Check out the [Strongloop blog](https://strongloop.com/strongblog/tag_LoopBack.html) for more posts about LoopBack
+* To keep up-to-date with LoopBack announcements, sign up for the Strongloop newsletter [here](https://strongloop.com/newsletter/).
+
+## <a name="contribute"></a>Contribute to LoopBack
+* [Guidelines](http://loopback.io/doc/en/contrib/index.html)
+* [Join the LoopBack.next contributors list](https://github.com/strongloop/loopback-next/issues/110)

--- a/pages/en/lb4/readmes/loopback4-extension-starter.md
+++ b/pages/en/lb4/readmes/loopback4-extension-starter.md
@@ -18,10 +18,10 @@ Controllers are responsible for handling endpoints for different transport proto
 Decorators are functions which are capable of providing annotations for class methods and arguments. Decorators generally take the form `@decorator`. _Annotations are hints given to a method at runtime to change certain behavior._
 
 ### Mixins
-LoopBack 4 supports mixins at the `Application` level. Mixins allow you to add new methods, modify or override existing methods. 
+LoopBack 4 supports mixins at the `Application` level. Mixins allow you to add new methods, modify or override existing methods.
 
 ### Providers
-A Provider is a class which provides a `value()` function that is called by `Context` when an entity requests the value to be injected. 
+A Provider is a class which provides a `value()` function that is called by `Context` when an entity requests the value to be injected.
 
 ### Repositories
 A Repository provides an interface for interacting with a database.
@@ -32,19 +32,19 @@ Get started by either downloading this project or cloning it as follows:
 `git clone https://github.com/strongloop/loopback4-extension-starter.git`
 
 ## Basic Usage
-An extension can be made using just one of the various extension types but most complex extensions will involve multiple extension types working together. 
+An extension can be made using just one of the various extension types but most complex extensions will involve multiple extension types working together.
 
-After you have a copy of the `loopback4-extension-starter` you can modify it as needed to create your own extension by understand each extension type by reading about it and understanding it's starter example. 
+After you have a copy of the `loopback4-extension-starter` you can modify it as needed to create your own extension by understand each extension type by reading about it and understanding it's starter example.
 
 ### Project Layout
 
 #### `src/`
-This directory contains all your extension's source code. This is where you should be working to create your extension. It has a top level `index.ts` for exporting all other files, `keys.ts` for defining your binding keys and constants, `types.ts` for defining your types and interfaces. 
+This directory contains all your extension's source code. This is where you should be working to create your extension. It has a top level `index.ts` for exporting all other files, `keys.ts` for defining your binding keys and constants, `types.ts` for defining your types and interfaces.
 
-Each of the different extension types also contains a corresponding directory to keep your extension organized. 
+Each of the different extension types also contains a corresponding directory to keep your extension organized.
 
 #### `test/`
-This directory contains directories for different kinds of tests for your extension, namely `acceptance`, `integration`, and `unit`. The directory struture inside each of those should be similar to the `src/` directory. 
+This directory contains directories for different kinds of tests for your extension, namely `acceptance`, `integration`, and `unit`. The directory struture inside each of those should be similar to the `src/` directory.
 
 #### Other files
 You'll want to update the following files as needed for your extension:

--- a/pages/en/lb4/readmes/loopback4-extension-starter.md
+++ b/pages/en/lb4/readmes/loopback4-extension-starter.md
@@ -1,0 +1,71 @@
+# loopback4-extension-starter
+
+## Summary
+A quick starting point for LoopBack 4 Extension developers.
+
+## Overview
+LoopBack 4 is built to be extensible from the ground up. As such, extension developers can write various kinds of extensions. This starter repository is meant to be a starting point for your own extensions. This extension starter project will provide you with the recommended project layout, simple examples you can build upon, configuration and more.
+
+Some of the extensions supported by LoopBack 4 are:
+
+### Components
+Components provide a way for extensions to package their *Providers* to their Dependency Keys for ease of use by Application Developers.
+
+### Controllers
+Controllers are responsible for handling endpoints for different transport protocols such as REST / GRPC.
+
+### Decorators
+Decorators are functions which are capable of providing annotations for class methods and arguments. Decorators generally take the form `@decorator`. _Annotations are hints given to a method at runtime to change certain behavior._
+
+### Mixins
+LoopBack 4 supports mixins at the `Application` level. Mixins allow you to add new methods, modify or override existing methods. 
+
+### Providers
+A Provider is a class which provides a `value()` function that is called by `Context` when an entity requests the value to be injected. 
+
+### Repositories
+A Repository provides an interface for interacting with a database.
+
+## Installation
+Get started by either downloading this project or cloning it as follows:
+
+`git clone https://github.com/strongloop/loopback4-extension-starter.git`
+
+## Basic Usage
+An extension can be made using just one of the various extension types but most complex extensions will involve multiple extension types working together. 
+
+After you have a copy of the `loopback4-extension-starter` you can modify it as needed to create your own extension by understand each extension type by reading about it and understanding it's starter example. 
+
+### Project Layout
+
+#### `src/`
+This directory contains all your extension's source code. This is where you should be working to create your extension. It has a top level `index.ts` for exporting all other files, `keys.ts` for defining your binding keys and constants, `types.ts` for defining your types and interfaces. 
+
+Each of the different extension types also contains a corresponding directory to keep your extension organized. 
+
+#### `test/`
+This directory contains directories for different kinds of tests for your extension, namely `acceptance`, `integration`, and `unit`. The directory struture inside each of those should be similar to the `src/` directory. 
+
+#### Other files
+You'll want to update the following files as needed for your extension:
+
+- `CODEOWNDERS` - Update it to include your information
+- `LICENSE` - Default is MIT. Update as needed
+- `package.json` - Update project name, description, author, git url, etc.
+- Any config files such as `.gitignore`, `.prettierrc`, `tsconfig`, etc.
+
+## Related Resources
+- _Coming Soon_ - Writing Extensions for LoopBack 4
+
+## Contributions
+- [Guidelines](https://github.com/strongloop/loopback-next/wiki/Contributing#guidelines)
+- [Join the team](https://github.com/strongloop/loopback-next/issues/110)
+
+## Tests
+run `npm test` from the root folder.
+
+## Contributors
+See [all contributors](https://github.com/strongloop/loopback-next/graphs/contributors).
+
+## License
+MIT

--- a/update-readmes-lb4.sh
+++ b/update-readmes-lb4.sh
@@ -28,7 +28,7 @@ LIST_END
     # actual example project, so we need to add the branch name to the readme
     # name.
     if [ "$branch" != "master" ]; then
-      DEST="pages/en/lb3/readmes/$repo-$branch.md"
+      DEST="pages/en/lb4/readmes/$repo-$branch.md"
     fi
     echo "fetching $org/$repo/$branch from GitHub's raw content domain..."
     curl -s $GHURL > $DEST

--- a/update-readmes-lb4.sh
+++ b/update-readmes-lb4.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# The following is a 3 column list of org, repo, and branch.
+# - If the branch is NOT specified, then the README for that project
+#   will be pulled from npmjs.org instead and will reflect the latest
+#   release.
+# - If the branch IS specified, it will be used to fetch the README.md
+#   from the given github repo. If that branch is NOT master, then the
+#   branch name will be appended to the local readme file name.
+(cat <<LIST_END
+strongloop loopback-next-example master
+strongloop loopback-next-hello-world master
+strongloop loopback4-extension-starter master
+LIST_END
+) | while read org repo branch; do
+  # Write the README.md to a file named after the repo
+  DEST="pages/en/lb4/readmes/$repo.md"
+  # When fetching from a branch of a gh repo
+  GHURL="https://raw.githubusercontent.com/$org/$repo/$branch/README.md"
+  # When fetching from the latest release of a node module
+  NPMURL="https://registry.npmjs.org/$repo"
+  if [ -z "$branch" ]; then
+    # No branch means latest release, so fetch from npmjs.org
+    echo "fetching $org/$repo from latest npmjs.org release..."
+    curl -s $NPMURL | jq -r '.readme|rtrimstr("\n")' > $DEST
+  else
+    # The loopback-example-database repo contains a separate branch for each
+    # actual example project, so we need to add the branch name to the readme
+    # name.
+    if [ "$branch" != "master" ]; then
+      DEST="pages/en/lb3/readmes/$repo-$branch.md"
+    fi
+    echo "fetching $org/$repo/$branch from GitHub's raw content domain..."
+    curl -s $GHURL > $DEST
+  fi
+done


### PR DESCRIPTION
This brings LB4 in line with how v3 and v2 handle READMEs of examples, etc., that are in separate repos.  See [Including READMES](http://loopback.io/doc/en/contrib/Including-READMEs.html) for details.

This PR adds the READMEs for the 3 examples: 
- loopback-next-example
- loopback-next-hello-world
- loopback4-extension-starter

And it adds a new shell script, `update-readmes-lb4.sh` that pulls them from npm or GitHub if the module is not published to npm.  Also adds the script to the Jenkinsfile that runs whenever the repo is updated, so the READMEs are kept in sync with the other repos.

NOTE: Currently, the READMEs themselves need some editing, but since they live in other repos, that should be done in PRs in those repos.  IMHO, pre-beta it's OK if they are not polished, complete, etc., but we should get them fixed for beta release.
