### PR TITLE
Update rm-options.md

### DIFF
--- a/_includes/content/rm-options.md
+++ b/_includes/content/rm-options.md
@@ -68,6 +68,13 @@ accepts: [
       <td> </td>
     </tr>
     <tr>
+      <td>documented</td>
+      <td>
+        If set to <code>false</code>, this method will not be present in generated documentation.
+      </td>
+      <td> </td>
+    </tr>
+    <tr>
       <td>returns</td>
       <td>
         Describes the remote method's callback arguments; See <a href="Remote-methods.html#argument-descriptions">Argument descriptions</a>. The <code>err </code>argument is assumed; do not specify.
@@ -217,6 +224,11 @@ The following table describes the properties of each individual argument.
       <td>Default value that will be used to populate loopback-explorer input fields and swagger documentation.
         <strong>Note</strong>: This value will not be passed into remote methods function if argument is not present.
       </td>
+    </tr>
+    <tr>
+      <td>documented</td>
+      <td>Boolean</td>
+      <td>If set to <code>false</code>, this parameter will not be present in generated documentation.</td>
     </tr>
   </tbody>
 </table>

--- a/_includes/content/rm-options.md
+++ b/_includes/content/rm-options.md
@@ -46,7 +46,7 @@ accepts: [
     <tr>
       <td>description</td>
       <td>
-        Text description of the method, used by API documentation generators such as Swagger.
+        Text description of the method, used by API documentation generators such as OpenAPI (formerly Swagger).
         You can put long strings in an array if needed (see note below).
       </td>
       <td> </td>
@@ -62,7 +62,7 @@ accepts: [
     <tr>
       <td>notes</td>
       <td>
-        Additional notes, used by API documentation generators like Swagger.
+        Additional notes, used by OpenAPI (formerly Swagger).
         You can put long strings in an array if needed (see note below).
       </td>
       <td> </td>
@@ -70,7 +70,7 @@ accepts: [
     <tr>
       <td>documented</td>
       <td>
-        If set to <code>false</code>, this method will not be present in generated documentation.
+        If set to <code>false</code>, this method will not be present in generated OpenAPI (formerly Swagger) documentation.
       </td>
       <td> </td>
     </tr>
@@ -180,7 +180,7 @@ The following table describes the properties of each individual argument.
       <td>description</td>
       <td>String or Array</td>
       <td>
-        A text description of the argument. This is used by API documentation generators like Swagger.
+        A text description of the argument. This is used by API documentation generators like OpenAPI (formerly Swagger).
         You can put long strings in an array if needed (see note above).
       </td>
     </tr>
@@ -228,7 +228,7 @@ The following table describes the properties of each individual argument.
     <tr>
       <td>documented</td>
       <td>Boolean</td>
-      <td>If set to <code>false</code>, this parameter will not be present in generated documentation.</td>
+      <td>If set to <code>false</code>, this parameter will not be present in generated OpenAPI (formerly Swagger) documentation.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Add `documented` options for both method & accepts definition.

Related: https://github.com/strongloop/loopback-swagger/pull/107