### PR TITLE
Fix urls on the getting started page

### DIFF
--- a/pages/en/lb4/Getting-started.md
+++ b/pages/en/lb4/Getting-started.md
@@ -92,8 +92,8 @@ Now `package.json` should include these dependencies (you may see different vers
 
 **To continue, follow one of these procedures**:
 
-- [JavaScript project](#javascript-project)
-- [TypeScript project](#typescript-project)
+- [JavaScript project](#try-a-javascript-project)
+- [TypeScript project](#try-a-typescript-project)
 
 ## Try a JavaScript project
 


### PR DESCRIPTION
Fix the urls on the getting started page.
It shouldn't be #javascript-project but it should be #try-a-javascript-project otherwise the link doesn't go anywhere.
Super simple fix.