### PR TITLE
Add ts-node as a loopback 4.0 prerequisite

### DIFF
--- a/pages/en/lb4/Installation.md
+++ b/pages/en/lb4/Installation.md
@@ -21,6 +21,13 @@ To get started with LoopBack 4, install the following:
 
    This installs the TypeScript compiler command, `tsc`.
 
+  ```
+  $ npm i -g ts-node
+  ```
+
+   This installs the TypeScript execution environment command for node, `ts-node`
+
+
 {% include tip.html content="
 You're installing `typescript` globally as a shortcut to get you started quickly,
 but it's not considered a best practice with Node.js.


### PR DESCRIPTION
I was going through the getting started and I bumped into ts-node being needed.
Getting started documentation mentions installing it locally but then the `ts-node` command doesn't get recognized by the shell.