### PR TITLE
Update BelongsTo-relation.md

### DIFF
--- a/pages/en/lb3/BelongsTo-relations.md
+++ b/pages/en/lb3/BelongsTo-relations.md
@@ -97,9 +97,9 @@ The results of method calls are cached internally and available via later synchr
     </tr>
     <tr>
       <td>
-        <pre>order.customer(function(err, customer) {<br>  ...<br>});</pre>
+        <pre>order.customer([filter], function(err, customer) {<br>  ...<br>});</pre>
       </td>
-      <td>Get the customer for the order asynchronously</td>
+      <td>Get the customer for the order asynchronously, optionally using provided [filter]</td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
Asynchronous fetch of a belongsTo relation can take filter argument first to for example use the include filter to include related models.

The filter argument is completely missing now from documentation. I found it by just trying if it's there like in some other relations and it was.