### PR TITLE
docs: update tutorial page

### DIFF
--- a/pages/en/lb4/Examples-and-tutorials.md
+++ b/pages/en/lb4/Examples-and-tutorials.md
@@ -8,19 +8,10 @@ permalink: /doc/en/lb4/Examples-and-tutorials.html
 summary:
 ---
 
-Currently, there are two main examples:
-- "Hello World" - [loopback-next-hello-world](https://github.com/strongloop/loopback-next-hello-world).  Ultimately, this will have an accompanying tutorial to help introduce developers to LB-next.
-- [loopback-next-example](https://github.com/strongloop/loopback-next-example). This will demonstrate how to design your infrastructure using a microservices with LoopBack-next
-
-**Tutorials**
-- [Testing Your Application](Testing-your-application.html)
-
-Not yet created:
-
-- Setting up Routes
-- Application Logic
-- Persisting Data with Repositories
-- Orchestrating REST and SOAP Services
-- Defining Who Can Access What
-- Repository Composition
-- Installing Connectors
+The LoopBack 4 tutorials are:
+- [loopback4-example-hello-world](https://github.com/strongloop/loopback4-example-hello-world).  
+  - Tutorial on setting up a simple hello-world application using LoopBack 4.
+- [loopback4-example-getting-started](https://github.com/strongloop/loopback4-example-getting-started). 
+  - Tutorial on building a simple application with LoopBack 4 key concepts. 
+- [loopback4-example-log-extension](https://github.com/strongloop/loopback4-example-log-extension).  
+  - Tutorial on building an application demo a log extension.


### PR DESCRIPTION
According to the discussion in [here](https://github.com/strongloop/loopback-next/issues/645#issuecomment-338282828), the list of tutorials in the [Examples and Tutorials](http://loopback.io/doc/en/lb4/Examples-and-tutorials.html) page is out of date. 

In this PR,
- update the list of tutorials
- remove the "Not yet created".  
   - We probably don't want to set the wrong expectations to our users that the upcoming tutorials unless it's planned. 
