### PR TITLE
Add documentation about options.http.path in model definition > relations

### DIFF
--- a/pages/en/lb3/Model-definition-JSON-file.md
+++ b/pages/en/lb3/Model-definition-JSON-file.md
@@ -792,6 +792,11 @@ For example:
       <td>Boolean</td>
       <td>Does not fetch the data if the relation is used in an include statement</td>
     </tr>
+    <tr>
+      <td>options.http.path</td>
+      <td>string</td>
+      <td>Set the relation http path</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
I was looking for a solution to alter the default path of a relation and I stumbled apon this solution which I believe was not documented.