### PR TITLE
docs: clarify API Explorer default

### DIFF
--- a/pages/en/lb3/Application-generator.md
+++ b/pages/en/lb3/Application-generator.md
@@ -39,7 +39,7 @@ slc loopback [options] [<name>]
 : Configure the app for deployment to IBM Cloud. With this option, the tool will present   additional prompts for generating IBM Cloud application artifacts.
 
 `--explorer`
-: Add Loopback Explorer to the project. Default is true.
+: Add Loopback Explorer to the project. If `lb` and `slc loopback` commands are used, the default is true, otherwise the default is false.
 
 `-n, --name <name>`
 : Only with IBM API Connect developer toolkit; specify name of LoopBack application project.


### PR DESCRIPTION
To clarify the default behavior of whether the API Explorer will be generated using the CLI.  
Cross-posting the expected behavior in https://github.com/strongloop/loopback.io/issues/553#issuecomment-348522832
> the expected behavior is:
> if lb [app] [options] [<name>] is used, API explorer will be created by default
> if apic loopback --type api [options] is used, API explorer will not be created by default

Note: changes only applicable to LB3 documentation.  LB2 docs does not show this option.

connected to: https://github.com/strongloop/loopback.io/issues/553