### PR TITLE
Update status of our mobile SDKs

### DIFF
--- a/pages/en/lb3/Android-SDK.md
+++ b/pages/en/lb3/Android-SDK.md
@@ -10,12 +10,15 @@ permalink: /doc/en/lb3/Android-SDK.html
 summary: The Android SDK provides a simple Java API that enables an Android app to interact with a LoopBack server application.
 ---
 
-{% include content/strongloop-labs.html lang=page.lang %}
+{% include warning.html content="
+As a former StrongLoop Labs project, the Android SDK may lack usability, completeness, documentation, and robustness, and may be outdated. StrongLoop/IBM is no longer maintaining this project actively, however we do provide support for our paying customers through usual IBM support channels.
+" %}
+
 
 {% include see-also.html content="
 * [Download Android SDK](http://81b70ddedaf4b27b1592-b5e75689411476c98957e7dab0242f50.r56.cf2.rackcdn.com/loopback-sdk-android-1.5.3-eclipse-bundle.zip)
 * [Android SDK API docs](http://apidocs.loopback.io/loopback-sdk-android/api/index.html)
-* [loopback-android-getting-started](https://github.com/strongloop/loopback-android-getting-started)
+* [loopback-android-getting-started](https://github.com/strongloop-community/loopback-android-getting-started)
 " %}
 
 {% include toc.html %}
@@ -55,7 +58,7 @@ The guide app comes ready to compile with Android Studio and each tab in the app
 ### Prerequisites
 
 If you haven't already created your application backend, see
-[loopback-android-getting-started](https://github.com/strongloop/loopback-android-getting-started).
+[loopback-android-getting-started](https://github.com/strongloop-community/loopback-android-getting-started).
 The Android guide app will connect to the this backend sample app.
 
 Before you start, make sure you've installed the [Eclipse Android Development Tools](http://developer.android.com/sdk/index.html) (ADT).
@@ -153,7 +156,7 @@ Click the LoopBack app icon in the home screen to view the LoopBack Android guid
 **Problem**: Build fails with the message `Unable to resolve target 'android-18'`.
 
 **Resolution**: You need to install Android 4.3 (API 18) SDK.
-See [Prerequisites](https://github.com/strongloop/loopback-android/blob/master/docs/GettingStarted.md#prerequisites) 
+See [Prerequisites](https://github.com/strongloop-community/loopback-android/blob/master/docs/GettingStarted.md#prerequisites) 
 for instructions on how to install SDK components.
 
 If you don't want to install an older SDK and want to use the most recent one (for example, Android 4.4 API 19), follow these steps:
@@ -284,7 +287,7 @@ var Widget = app.model('widget', {
 ```
 
 Because of this the class name (`'widget'`, above) needs to match the name that model was given on the server.
-If you don't have a model, [see the LoopBack documentation](https://github.com/strongloop/loopback-sdk-android/blob/master/docs/Subclassing.md) for more information. 
+If you don't have a model, [see the LoopBack documentation](https://github.com/strongloop-community/loopback-sdk-android/blob/master/docs/Subclassing.md) for more information. 
 The model _must_ exist (even if the schema is empty) before it can be interacted with.
 
 Use this to make creating Models easier. Match the name or create your own.

--- a/pages/en/lb3/Push-notifications-for-Android-apps.md
+++ b/pages/en/lb3/Push-notifications-for-Android-apps.md
@@ -10,10 +10,14 @@ permalink: /doc/en/lb3/Push-notifications-for-Android-apps.html
 summary:
 ---
 
+{% include warning.html content="
+As a former StrongLoop Labs project, the Android SDK may lack usability, completeness, documentation, and robustness, and may be outdated. StrongLoop/IBM is no longer maintaining this project actively, however we do provide support for our paying customers through usual IBM support channels.
+" %}
+
 {% include see-also.html content="
 
 * [Android SDK API docs](http://apidocs.loopback.io/loopback-sdk-android/api/index.html)
-* [loopback-android-getting-started](https://github.com/strongloop/loopback-android-getting-started)
+* [loopback-android-getting-started](https://github.com/strongloop-community/loopback-android-getting-started)
 * [Push notifications](Push-notifications.html)
 " %}
 

--- a/pages/en/lb3/Push-notifications-for-iOS-apps.md
+++ b/pages/en/lb3/Push-notifications-for-iOS-apps.md
@@ -2,12 +2,20 @@
 title: "Push notifications for iOS apps"
 lang: en
 layout: page
+toc: false
 keywords: LoopBack
 tags:
 sidebar: lb3_sidebar
 permalink: /doc/en/lb3/Push-notifications-for-iOS-apps.html
 summary:
 ---
+
+
+{% include warning.html content="
+As a former StrongLoop Labs project, the iOS SDK may lack usability, completeness, documentation, and robustness, and may be outdated. StrongLoop/IBM is no longer maintaining this project actively, however we do provide support for our paying customers through usual IBM support channels.
+" %}
+
+{% include toc.html %}
 
 ## Overview
 

--- a/pages/en/lb3/Push-notifications-using-Android-SDK.md
+++ b/pages/en/lb3/Push-notifications-using-Android-SDK.md
@@ -2,6 +2,7 @@
 title: "Push notifications using Android SDK"
 lang: en
 layout: page
+toc: false
 keywords: LoopBack
 tags:
 sidebar: lb3_sidebar
@@ -9,10 +10,16 @@ permalink: /doc/en/lb3/Push-notifications-using-Android-SDK.html
 summary:
 ---
 
+{% include warning.html content="
+As a former StrongLoop Labs project, the Android SDK may lack usability, completeness, documentation, and robustness, and may be outdated. StrongLoop/IBM is no longer maintaining this project actively, however we do provide support for our paying customers through usual IBM support channels.
+" %}
+
 {% include see-also.html content="
 * [Android SDK API docs](http://apidocs.loopback.io/loopback-sdk-android/api/index.html)
-* [loopback-android-getting-started](https://github.com/strongloop/loopback-android-getting-started)
+* [loopback-android-getting-started](https://github.com/strongloop-community/loopback-android-getting-started)
 " %}
+
+{% include toc.html %}
 
 ## Overview
 

--- a/pages/en/lb3/Working-with-files-using-the-Android-SDK.md
+++ b/pages/en/lb3/Working-with-files-using-the-Android-SDK.md
@@ -10,6 +10,10 @@ permalink: /doc/en/lb3/Working-with-files-using-the-Android-SDK.html
 summary:
 ---
 
+{% include warning.html content="
+As a former StrongLoop Labs project, the Android SDK may lack usability, completeness, documentation, and robustness, and may be outdated. StrongLoop/IBM is no longer maintaining this project actively, however we do provide support for our paying customers through usual IBM support channels.
+" %}
+
 {% include see-also.html content="
 
 * [Android SDK API docs](http://apidocs.loopback.io/loopback-sdk-android/api/index.html)

--- a/pages/en/lb3/iOS-SDK.md
+++ b/pages/en/lb3/iOS-SDK.md
@@ -9,7 +9,10 @@ sidebar: lb3_sidebar
 permalink: /doc/en/lb3/iOS-SDK.html
 summary: The LoopBack iOS SDK provides a native iOS API that enables an iOS app to interact with a LoopBack server application.
 ---
-{% include content/strongloop-labs.html lang=page.lang %}
+
+{% include warning.html content="
+As a former StrongLoop Labs project, the iOS SDK may lack usability, completeness, documentation, and robustness, and may be outdated. StrongLoop/IBM is no longer maintaining this project actively, however we do provide support for our paying customers through usual IBM support channels.
+" %}
 
 {% include toc.html %}
 
@@ -40,7 +43,7 @@ The guide app comes ready to compile with XCode, and each tab in the app guides 
 
 From your usual projects directory:
 
-1.  Download the LoopBack guide application to your local machine from [GitHub](https://github.com/strongloop/loopback-ios-getting-started): 
+1.  Download the LoopBack guide application to your local machine from [GitHub](https://github.com/strongloop-community/loopback-ios-getting-started): 
 
     ```shell
 $ git clone git@github.com:strongloop/loopback-ios-getting-started.git

--- a/update-readmes.sh
+++ b/update-readmes.sh
@@ -28,7 +28,7 @@ strongloop loopback-connector-remote master
 strongloop loopback-connector-rest master
 strongloop loopback-connector-soap master
 strongloop strong-soap master
-strongloop loopback-android-getting-started master
+strongloop-community loopback-android-getting-started master
 strongloop loopback-example-angular master
 strongloop loopback-example-app-logic master
 strongloop loopback-example-access-control master
@@ -45,7 +45,7 @@ strongloop loopback-example-passport master
 strongloop loopback-example-relations master
 strongloop loopback-example-storage master
 strongloop loopback-example-user-management master
-strongloop loopback-ios-getting-started master
+strongloop-community loopback-ios-getting-started master
 strongloop strong-error-handler master
 strongloop strong-remoting master
 strongloop angular-live-set


### PR DESCRIPTION
 - Add warnings saying the modules are no longer maintained
 - Fix GitHub URLs in update-readmes.sh and doc pages to use strongloop-community instead of strongloop

See also:
 - https://github.com/strongloop-community/loopback-sdk-android/pull/124 
 - https://github.com/strongloop-community/loopback-sdk-ios/pull/137