### PR TITLE
fix small errors in Key Concepts

### DIFF
--- a/pages/en/lb4/Application.md
+++ b/pages/en/lb4/Application.md
@@ -31,7 +31,7 @@ tasks as a part of your setup:
 ```ts
 import {Application} from '@loopback/core';
 import {RestComponent, RestServer} from '@loopback/rest';
-import {SamoflangeController, DoohickeyController} from './src/controllers';
+import {SamoflangeController, DoohickeyController} from './controllers';
 import {WidgetApi} from './apidef/';
 
 export class WidgetApplication extends Application {
@@ -110,13 +110,13 @@ application's configuration:
 export class MyApplication extends Application {
   constructor() {
     super();
+    this.server(RestServer);
+    this.controller(FooController);
+    this.bind('fooCorp.logger').toProvider(LogProvider);
+    this.bind('repositories.widget')
+      .toClass(WidgetRepository)
+      .inScope(BindingScope.SINGLETON);
   }
-  this.server(RestServer);
-  this.controller(FooController);
-  this.bind('fooCorp.logger').toProvider(LogProvider);
-  this.bind('repositories.widget')
-    .toClass(WidgetRepository)
-    .inScope(BindingScope.SINGLETON);
 }
 ```
 In the above example:

--- a/pages/en/lb4/Sequence.md
+++ b/pages/en/lb4/Sequence.md
@@ -13,30 +13,6 @@ summary:
 A `Sequence` is a stateless grouping of [Actions](#actions) that control how a
 `Server` responds to requests.
 
-```js
-const server = await app.getServer(RestServer);
-server.handler((sequence, request, response) => {
-  const spec = {parameters: {name: 'string', source: 'query'}};
-  const params = sequence.parseParams(request, spec);
-  sequence.send(response, `hello ${params.name}`);
-});
-```
-
-In the following example, we define a `handler` function that uses the
-`Sequence` to respond to every HTTP request our server instance receives
-with `hello $name` (eg. `GET /?name=bob => 'hello bob'`).
-
-```js
-class MySequence extends DefaultSequence {
-  // this is the same as using `server.handler(handle)`
-  handle(request, response) {
-    const spec = {params: {name: {type: 'string', in: 'query'}}};
-    const params = this.parseParams(request, spec);
-    this.send(response, `hello ${params.name}`);
-  }
-}
-```
-
 The contract of a `Sequence` is simple: it must produce a response to a request.
 Creating your own `Sequence` gives you full control over how your `Server`
 instances handle requests and responses. The `DefaultSequence` looks like this:
@@ -47,10 +23,10 @@ instances handle requests and responses. The `DefaultSequence` looks like this:
 -->
 ```js
 class DefaultSequence {
-  async handle(request, response) {
+  async handle(request: ParsedRequest, response: ServerResponse) {
     try {
       const route = this.findRoute(request);
-      const params = this.parseParams(request, route);
+      const params = await this.parseParams(request, route);
       const result = await this.invoke(route, params);
       await this.send(response, result);
     } catch(err) {
@@ -80,11 +56,11 @@ Actions are JavaScript functions that only accept or return `Elements`. Since th
 
 ```js
 class MySequence extends DefaultSequence {
-  async handle(request, response) {
+  async handle(request: ParsedRequest, response: ServerResponse) {
     // findRoute() produces an element
     const route = this.findRoute(request);
     // parseParams() uses the route element and produces the params element
-    const params = this.parseParams(request, route);
+    const params = await this.parseParams(request, route);
     // invoke() uses both the route and params elements to produce the result (OperationRetVal) element
     const result = await this.invoke(route, params);
     // send() uses the result element

--- a/pages/en/lb4/Server.md
+++ b/pages/en/lb4/Server.md
@@ -59,12 +59,12 @@ export class HelloWorldApp extends Application {
     super({
       components: [RestComponent],
     });
+    // This server instance will be bound under "servers.fooServer".
+    this.server(RestServer, 'fooServer');
+    // Creates a binding for "servers.MQTTServer" and a binding for
+    // "servers.SOAPServer";
+    this.servers([MQTTServer, SOAPServer]);
   }
-  // This server instance will be bound under "servers.fooServer".
-  this.server(RestServer, 'fooServer');
-  // Creates a binding for "servers.MQTTServer" and a binding for
-  // "servers.SOAPServer";
-  this.servers([MQTTServer, SOAPServer]);
 }
 ```
 


### PR DESCRIPTION
- fixed some obvious mistakes and outdated code examples in Key Concepts, so that when the code is copy-pasted it works.