### PR TITLE
added angular2 sdk to lb3 documents

### DIFF
--- a/pages/en/lb3/Angular-2-SDK.md
+++ b/pages/en/lb3/Angular-2-SDK.md
@@ -1,0 +1,15 @@
+---
+title: "Angular 2 SDK"
+lang: en
+layout: page
+keywords: LoopBack
+tags: [angularjs]
+sidebar: lb3_sidebar
+permalink: /doc/en/lb3/Angular-2-SDK.html
+summary:
+---
+The [loopback-sdk-builder](https://github.com/mean-expert-official/loopback-sdk-builder) module enables you to create an [Angular 2](http://angular.io/) client SDK for a LoopBack application.  It is a community module forked from the official loopback-sdk-angular and refactored to support Angular 2.
+
+{% include note.html content="
+This module is provided and supported by the LoopBack community (led by [Jonathan Casarrubias](https://github.com/jonathan-casarrubias)). StrongLoop and IBM are not directly responsible for it and do not provide support for it.
+" %}


### PR DESCRIPTION
you were missing a page in lb3 documentation
http://loopback.io/doc/en/lb3/Angular-2-SDK
-->page not found 
in lb 2 its here 
http://loopback.io/doc/en/lb2/Angular-2-SDK
i just copied it in the folder for you. I am not sure how the translations work seems like most of them were empty-ish. so this is just in english
