### PR TITLE
correct reference script name

### DIFF
--- a/pages/en/lb3/Defining-and-using-roles.md
+++ b/pages/en/lb3/Defining-and-using-roles.md
@@ -111,7 +111,7 @@ This function takes two parameters: 
 
 For example, here is the role resolver from [loopback-example-access-control](https://github.com/strongloop/loopback-example-access-control/):
 
-{% include code-caption.html content="/server/boot/script.js" %}
+{% include code-caption.html content="/server/boot/role-resolver.js" %}
 ```javascript
 module.exports = function(app) {
   var Role = app.models.Role;


### PR DESCRIPTION
The documentation refers to a nonexistent script.
The correct reference is the proposed change.