### PR TITLE
Important documentation change to avoid mistakes.

### DIFF
--- a/pages/en/lb3/Redis-connector.md
+++ b/pages/en/lb3/Redis-connector.md
@@ -67,7 +67,10 @@ Edit `datasources.json` to add other properties that enable you to connect the
     <tr>
       <td>host</td>
       <td>String</td>
-      <td>Database host name. When this property is set, also the property **port** needs to be set.</td>
+      <td>
+        Database host name.
+        When this property is set, also the property **port** needs to be set.
+      </td>
     </tr>
     <tr>
       <td>password</td>

--- a/pages/en/lb3/Redis-connector.md
+++ b/pages/en/lb3/Redis-connector.md
@@ -67,7 +67,7 @@ Edit `datasources.json` to add other properties that enable you to connect the
     <tr>
       <td>host</td>
       <td>String</td>
-      <td>Database host name</td>
+      <td>Database host name. When this property is set, also the property **port** needs to be set.</td>
     </tr>
     <tr>
       <td>password</td>


### PR DESCRIPTION
When passing the host without a port the connector isn't able to create instances of redis client.