### PR TITLE
lb4: update and improve Examples-and-tutorials

### DIFF
--- a/pages/en/lb4/Examples-and-tutorials.md
+++ b/pages/en/lb4/Examples-and-tutorials.md
@@ -8,10 +8,30 @@ permalink: /doc/en/lb4/Examples-and-tutorials.html
 summary:
 ---
 
-The LoopBack 4 tutorials are:
-- [loopback4-example-hello-world](https://github.com/strongloop/loopback4-example-hello-world).  
-  - Tutorial on setting up a simple hello-world application using LoopBack 4.
-- [loopback4-example-getting-started](https://github.com/strongloop/loopback4-example-getting-started). 
-  - Tutorial on building a simple application with LoopBack 4 key concepts. 
-- [loopback4-example-log-extension](https://github.com/strongloop/loopback4-example-log-extension).  
-  - Tutorial on building an application demo a log extension.
+LoopBack 4 comes with the following example projects:
+
+- **[hello-world](https://github.com/strongloop/loopback-next/tree/master/packages/example-hello-world)**:
+  Tutorial on setting up a simple hello-world application using LoopBack 4.
+
+- **[getting-started](https://github.com/strongloop/loopback-next/tree/master/packages/example-getting-started)**:
+  Tutorial on building a simple application with LoopBack 4 key concepts.
+
+- **[log-extension](https://github.com/strongloop/loopback-next/tree/master/packages/example-log-extension)**:
+  Tutorial on building a log extension.
+
+- **[rpc-server](https://github.com/strongloop/loopback-next/tree/master/packages/example-rpc-server)**:
+  An example showing how to implement a made-up RPC protocol.
+
+You can download any of the example projects usig our CLI tool `lb4`:
+
+
+```
+$ lb4 example
+? What example would you like to clone? (Use arrow keys)
+❯ getting-started: An application and tutorial on how to build with LoopBack 4.
+  hello-world: A simple hello-world Application using LoopBack 4
+  log-extension: An example extension project for LoopBack 4
+  rpc-server: A basic RPC server using a made-up protocol.
+```
+
+Please follow the instructions in [Install LoopBack4 CLI](Getting-started.html#install-loopback-4-cli) if you don't have `lb4` installed yet.


### PR DESCRIPTION
As part of https://github.com/strongloop/loopback-next/issues/836:
 - add rpc-server
 - change example URLs to point to our monorepo
 - add instructions for obtaining individual examples

Screenshot of the new page:

<img width="873" alt="screen shot 2018-02-01 at 14 30 04" src="https://user-images.githubusercontent.com/1140553/35681040-6f55723a-075c-11e8-82b7-8023c102906d.png">
