### PR TITLE
docs: simplify to RestApplication

### DIFF
--- a/pages/en/lb4/Defining-and-validating-the-API.md
+++ b/pages/en/lb4/Defining-and-validating-the-API.md
@@ -292,15 +292,12 @@ You also need to associate the controllers implementing the spec with the app us
 // application.ts
 // This should be the export from the previous example.
 import spec from "../apidefs/swagger";
-import { Application } from "@loopback/core";
-import { RestComponent, RestServer } from "@loopback/rest";
+import { RestApplication, RestServer } from "@loopback/rest";
 import { ProductController, DealController, CategoryController } from "./controllers";
-export class YourMicroservice extends Application {
+export class YourMicroservice extends RestApplication {
 
   constructor() {
-    super({
-      components: [RestComponent],
-    });
+    super();
     const app = this;
 
     app.controller(ProductController);

--- a/pages/en/lb4/Dependency-Injection.md
+++ b/pages/en/lb4/Dependency-Injection.md
@@ -47,8 +47,7 @@ There are several different ways for configuring the values to inject, the simpl
 // TypeScript example
 
 import {BasicStrategy} from 'passport-http';
-import {Application} from '@loopback/core';
-import {RestServer} from '@loopback/rest';
+import {RestApplication, RestServer} from '@loopback/rest';
 // basic scaffolding stuff happens in between...
 
 const server = await app.getServer(RestServer); // The REST server has its own context!

--- a/pages/en/lb4/Routes.md
+++ b/pages/en/lb4/Routes.md
@@ -76,13 +76,10 @@ The example below defines a `Route` that will be matched for `GET /`. When the `
 The route is then attached to a valid server context running underneath the
 application.
 ```ts
-import {Application} from '@loopback/core';
-import {RestServer, Route, RestComponent} from '@loopback/rest';
+import {RestApplication, RestServer, Route} from '@loopback/rest';
 import {OperationObject} from '@loopback/openapi-spec';
 
-const app = new Application({
-  components: [RestComponent]
-});
+const app = new RestApplication();
 const spec: OperationObject = {
   parameters: [{name: 'name', in: 'query', type: 'string'}],
   responses: {
@@ -136,13 +133,10 @@ export class GreetController {
 
 {% include code-caption.html content="index.ts" %}
 ```ts
-import { Application } from '@loopback/core';
-import { RestComponent } from '@loopback/rest';
+import { RestApplication } from '@loopback/rest';
 import { GreetController } from './src/controllers/greet.controller';
 
-const app = new Application({
-  components: [RestComponent]
-});
+const app = new RestApplication();
 
 app.controller(GreetController);
 

--- a/pages/en/lb4/Sequence.md
+++ b/pages/en/lb4/Sequence.md
@@ -90,12 +90,9 @@ In order for LoopBack to use your custom sequence, you must register it on any
 applicable `Server` instances before starting your `Application`:
 
 ```js
-import {Application} from '@loopback/core';
-import {RestComponent, RestServer} from '@loopback/rest';
+import {RestApplication, RestServer} from '@loopback/rest';
 
-const app = new Application({
-  components: [RestComponent],
-});
+const app = new RestApplication();
 
 // or
 (async function start() {

--- a/pages/en/lb4/Server.md
+++ b/pages/en/lb4/Server.md
@@ -15,17 +15,14 @@ The [Server](https://apidocs.strongloop.com/@loopback%2fcore/#Server) interface 
 
 ## Usage
 
-LoopBack 4 currently offers the [`@loopback/rest`](https://github.com/strongloop/loopback-next/tree/master/packages/rest) package out of the box which provides an HTTP based server implementation handling requests over REST called `RestServer`. In order to use it in your application, all you need to do is register the `RestComponent` to your application class, and it will provide you with an instance of RestServer listening on port 3000. The following shows how to make use of it:
+LoopBack 4 currently offers the [`@loopback/rest`](https://github.com/strongloop/loopback-next/tree/master/packages/rest) package out of the box which provides an HTTP based server implementation handling requests over REST called `RestServer`. In order to use it in your application, all you need to do is have your application class extend `RestApplication`, and it will provide you with an instance of RestServer listening on port 3000. The following shows how to make use of it:
 
 ```ts
-import {Application} from '@loopback/core';
-import {RestComponent, RestServer} from '@loopback/rest';
+import {RestApplication, RestServer} from '@loopback/rest';
 
-export class HelloWorldApp extends Application {
+export class HelloWorldApp extends RestApplication {
   constructor() {
-    super({
-      components: [RestComponent],
-    });
+    super();
   }
 
   async start() {
@@ -51,14 +48,11 @@ export class HelloWorldApp extends Application {
 You can add server instances to your application via the `app.server()` method individually or as an array using `app.servers()` method. Using `app.server()` allows you to uniquely name your binding key for your specific server instance. The following example demonstrates how to use these functions:
 
 ```ts
-import {Application} from '@loopback/core';
-import {RestComponent, RestServer} from '@loopback/rest';
+import {RestApplication, RestServer} from '@loopback/rest';
 
-export class HelloWorldApp extends Application {
+export class HelloWorldApp extends RestApplication {
   constructor() {
-    super({
-      components: [RestComponent],
-    });
+    super();
     // This server instance will be bound under "servers.fooServer".
     this.server(RestServer, 'fooServer');
     // Creates a binding for "servers.MQTTServer" and a binding for


### PR DESCRIPTION
- updated all instances of using application creation using this format to use RestApplication:
  ```ts
  class MyApp extends Application {
    constructor() {
      super({
        components: [RestComponent],
      });
    }
  }
  ```
  to
  ```ts
  class MyApp extends RestApplication {
    constructor() {
      super();
    }
  }
  ```

- connected to https://github.com/strongloop/loopback-next/issues/846