### PR TITLE
fix(lb4): use overloaded functions for bindings

### DIFF
--- a/pages/en/lb4/Application.md
+++ b/pages/en/lb4/Application.md
@@ -154,7 +154,7 @@ export class MyApplication extends RestApplication {
 
 #### Components
 ```ts
-app.components([MyComponent, RestComponent]);
+app.component([MyComponent, RestComponent]);
 ```
 The components collection allows bulk binding of component constructors within
 your `Application` instance's context.
@@ -164,7 +164,7 @@ see [Using Components](Using-components.html).
 
 #### Controllers
 ```ts
-app.controllers([FooController, BarController]);
+app.controller([FooController, BarController]);
 ```
 Much like the components collection, the controllers collection allows bulk
 binding of [Controllers](Controllers.html) to
@@ -172,7 +172,7 @@ the `Application` context.
 
 #### Servers
 ```ts
-app.servers([MyServer, GrpcServer]);
+app.server([MyServer, GrpcServer]);
 ```
 The servers collection is also like the previous collections and allows
 bulk binding of [Servers](Server.html).


### PR DESCRIPTION
- connected to https://github.com/strongloop/loopback-next/issues/742 and https://github.com/strongloop/loopback-next/pull/975