### PR TITLE
fix syntax errors in the readme layout

### DIFF
--- a/_layouts/readme.html
+++ b/_layouts/readme.html
@@ -7,27 +7,27 @@ h1:not(.post-title-main) { display: none; }
 {% if page.source %}
   {% if page.branch %}
     {% assign repo-branch = page.source | append: '/tree/' | append: page.branch %}
-    {% assign readme-file = page.source | append: '-' | append: page.branch | append '.md' %}
+    {% assign readme-file = page.source | append: '-' | append: page.branch | append: '.md' %}
   {% else %}
     {% assign repo-branch = page.source %}
-    {% assign readme-file = page.source | append '.md' %}
+    {% assign readme-file = page.source | append: '.md' %}
   {% endif %}
 
   {% assign readme-loc = page.file | default: 'README.md' %}
   {% if page.file %}
     {% if page.branch %}
-      {% assign readme-file = page.source | append: '-' | append: page.branch | append '/' | append page.file %}
-      {% assign repo-branch = page.source | append: '/tree/' | append: page.branch | append: page.file %}
+      {% assign readme-file = page.source | append: '-' | append: page.branch | append: '/' | append: page.file %}
+      {% assign repo-branch = page.source | append: '/tree/' | append: page.branch | append: '/' | append: page.file %}
     {% else %}
-      {% assign readme-file = page.source | append '/' | append page.file %}
-      {% assign repo-branch = page.source | append: '/tree/' | append: 'master' | append: page.file %}
+      {% assign readme-file = page.source | append: '/' | append: page.file %}
+      {% assign repo-branch = page.source | append: '/tree/' | append: 'master' | append: '/' | append: page.file %}
     {% endif %}
   {% endif %}
 
   {% assign org = page.org | default: "strongloop" %}
   <div class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i>
     <b>Note:</b> This page was generated from the
-    <a href="https://github.com/{{org}}/{{repo-branch}}">{{page.source}} {{readme-loc}}</a>.
+    <a href="https://github.com/{{org}}/{{repo-branch}}">{{page.source}}/{{readme-loc}}</a>.
   </div>
 
   {{content}}


### PR DESCRIPTION
There were some syntax errors slipped into the code. This PR fixes them. I have verified with local `loopback.io` site.