### PR TITLE
Move RestServer config out of `async start`

### DIFF
--- a/pages/en/lb4/Application.md
+++ b/pages/en/lb4/Application.md
@@ -32,7 +32,6 @@ tasks as a part of your setup:
 import {Application} from '@loopback/core';
 import {RestComponent, RestServer} from '@loopback/rest';
 import {SamoflangeController, DoohickeyController} from './controllers';
-import {WidgetApi} from './apidef/';
 
 export class WidgetApplication extends Application {
   constructor() {
@@ -50,16 +49,6 @@ export class WidgetApplication extends Application {
     app.component(RestComponent);
     app.controller(SamoflangeController);
     app.controller(DoohickeyController);
-  }
-
-  async start() {
-    // This is where you would asynchronously retrieve servers, providers and
-    // other components to configure them before launch.
-    const server = await app.getServer(RestServer);
-    server.api(WidgetApi);
-    // The superclass start method will call start on all servers that are
-    // bound to the application.
-    return await super.start();
   }
 
   async stop() {

--- a/pages/en/lb4/Application.md
+++ b/pages/en/lb4/Application.md
@@ -38,7 +38,12 @@ export class WidgetApplication extends Application {
   constructor() {
     // This is where you would pass configuration to the base constructor
     // (as well as handle your own!)
-    super();
+    super({
+      rest: {
+        port: 8080
+      }
+    });
+
     const app = this; // For clarity.
     // You can bind to the Application-level context here.
     // app.bind('foo').to(bar);
@@ -51,7 +56,6 @@ export class WidgetApplication extends Application {
     // This is where you would asynchronously retrieve servers, providers and
     // other components to configure them before launch.
     const server = await app.getServer(RestServer);
-    server.bind('rest.port').to(8080);
     server.api(WidgetApi);
     // The superclass start method will call start on all servers that are
     // bound to the application.

--- a/pages/en/lb4/Application.md
+++ b/pages/en/lb4/Application.md
@@ -184,6 +184,15 @@ export class MyApplication extends RestApplication {
 ## Tips for application setup
 Here are some tips to help avoid common pitfalls and mistakes.
 
+### Extend from `RestApplication` when using `RestServer`
+If you want to use `RestServer` from our `@loopback/rest` package, we recommend you extend
+`RestApplication` in your app instead of manually binding `RestServer` or
+`RestComponent`. `RestApplication` already uses `RestComponent` and makes
+useful functions in `RestServer` like `handler()` available at the app level.
+This means you can call these `RestServer` functions to do all of your
+server-level setups in the app constructor without having to explicitly retrieve
+an instance of your server.
+
 ### Use unique bindings
 Use binding names that are prefixed with a unique string that does not overlap
 with loopback's bindings. As an example, if your application is built for

--- a/pages/en/lb4/Defining-and-validating-the-API.md
+++ b/pages/en/lb4/Defining-and-validating-the-API.md
@@ -289,7 +289,7 @@ _.merge(spec, CategoryAPI);
 export default spec;
 ```
 
-You can then bind the full spec to the application using `server.spec()`. This is done on the server level, because each server instance can expose a different (sub)set of API.
+You can then bind the full spec to the application using `app.api()`. Normally, this is done on the server level because each server instance can expose a different (sub)set of API, but since `RestApplication` uses only one REST server, you can bind the spec at application level.
 
 You also need to associate the controllers implementing the spec with the app using `app.controller(GreetController)`. This is not done on the server level because a controller may be used with multiple server instances, and types!
 
@@ -302,20 +302,18 @@ import { ProductController, DealController, CategoryController } from "./control
 export class YourMicroservice extends RestApplication {
 
   constructor() {
-    super();
+    super({
+      rest: {
+        port: 3001
+      }
+    });
     const app = this;
 
     app.controller(ProductController);
     app.controller(DealController);
     app.controller(CategoryController);
-
-  }
-  async start() {
-    const server = await app.getServer(RestServer);
-    // inject your spec here!
-    server.api(spec);
-    server.bind("rest.port").to(3001);
-    await super.start();
+    //inject your spec
+    app.api(spec);
   }
   // etc...
 }

--- a/pages/en/lb4/Defining-and-validating-the-API.md
+++ b/pages/en/lb4/Defining-and-validating-the-API.md
@@ -289,9 +289,17 @@ _.merge(spec, CategoryAPI);
 export default spec;
 ```
 
-You can then bind the full spec to the application using `app.api()`. Normally, this is done on the server level because each server instance can expose a different (sub)set of API, but since `RestApplication` uses only one REST server, you can bind the spec at application level.
+You can then bind the full spec to the application using `app.api()`.
+This works well for applications with a single REST server, because
+there is only one API definition involved.
 
-You also need to associate the controllers implementing the spec with the app using `app.controller(GreetController)`. This is not done on the server level because a controller may be used with multiple server instances, and types!
+If you are building an application with multiple REST servers,
+where each server provides a different API, then you need 
+to call `server.api()` instead.
+
+You also need to associate the controllers implementing the spec with the app
+using `app.controller(GreetController)`. This is not done on the server level
+because a controller may be used with multiple server instances, and types!
 
 ```ts
 // application.ts

--- a/pages/en/lb4/Routes.md
+++ b/pages/en/lb4/Routes.md
@@ -74,7 +74,7 @@ server.api(spec);
 
 The example below defines a `Route` that will be matched for `GET /`. When the `Route` is matched, the `greet` Operation (above) will be called. It accepts an OpenAPI [OperationObject](https://github.com/OAI/OpenAPI-Specification/blob/0e51e2a1b2d668f434e44e5818a0cdad1be090b4/versions/2.0.md#operationObject) which is defined using `spec`.
 The route is then attached to a valid server context running underneath the
-application.
+application. 
 ```ts
 import {RestApplication, RestServer, Route} from '@loopback/rest';
 import {OperationObject} from '@loopback/openapi-spec';
@@ -96,9 +96,8 @@ function greet(name: string) {
 }
 
 (async function start() {
-  const server = await app.getServer(RestServer);
   const route = new Route('get', '/', spec, greet);
-  server.route(route);
+  app.route(route); // attaches route to RestServer
   await app.start();
 })();
 ```

--- a/pages/en/lb4/Routes.md
+++ b/pages/en/lb4/Routes.md
@@ -74,12 +74,11 @@ server.api(spec);
 
 The example below defines a `Route` that will be matched for `GET /`. When the `Route` is matched, the `greet` Operation (above) will be called. It accepts an OpenAPI [OperationObject](https://github.com/OAI/OpenAPI-Specification/blob/0e51e2a1b2d668f434e44e5818a0cdad1be090b4/versions/2.0.md#operationObject) which is defined using `spec`.
 The route is then attached to a valid server context running underneath the
-application. 
+application.
 ```ts
 import {RestApplication, RestServer, Route} from '@loopback/rest';
 import {OperationObject} from '@loopback/openapi-spec';
 
-const app = new RestApplication();
 const spec: OperationObject = {
   parameters: [{name: 'name', in: 'query', type: 'string'}],
   responses: {
@@ -95,11 +94,11 @@ function greet(name: string) {
   return `hello ${name}`;
 }
 
-(async function start() {
-  const route = new Route('get', '/', spec, greet);
-  app.route(route); // attaches route to RestServer
-  await app.start();
-})();
+const app = new RestApplication();
+const route = new Route('get', '/', spec, greet);
+app.route(route); // attaches route to RestServer
+
+app.start();
 ```
 
 ### Using Route decorators with controller methods
@@ -139,9 +138,7 @@ const app = new RestApplication();
 
 app.controller(GreetController);
 
-(async function start() {
-  await app.start();
-})();
+app.start();
 ```
 
 ## Invoking operations using Routes

--- a/pages/en/lb4/Sequence.md
+++ b/pages/en/lb4/Sequence.md
@@ -93,11 +93,9 @@ before starting your `Application`:
 import {RestApplication, RestServer} from '@loopback/rest';
 
 const app = new RestApplication();
+app.sequence(MySequencce);
 
-(async function start() {
-  app.sequence(MySequence);
-  await app.start();
-})();
+app.start();
 ```
 
 ## Advanced topics

--- a/pages/en/lb4/Sequence.md
+++ b/pages/en/lb4/Sequence.md
@@ -86,18 +86,16 @@ class MySequence extends DefaultSequence {
 }
 ```
 
-In order for LoopBack to use your custom sequence, you must register it on any
-applicable `Server` instances before starting your `Application`:
+In order for LoopBack to use your custom sequence, you must register it
+before starting your `Application`:
 
 ```js
 import {RestApplication, RestServer} from '@loopback/rest';
 
 const app = new RestApplication();
 
-// or
 (async function start() {
-  const server = await app.getServer(RestServer);
-  server.sequence(MySequence);
+  app.sequence(MySequence);
   await app.start();
 })();
 ```

--- a/pages/en/lb4/Server.md
+++ b/pages/en/lb4/Server.md
@@ -50,9 +50,10 @@ export class HelloWorldApp extends RestApplication {
 You can add server instances to your application via the `app.server()` method individually or as an array using `app.servers()` method. Using `app.server()` allows you to uniquely name your binding key for your specific server instance. The following example demonstrates how to use these functions:
 
 ```ts
-import {RestApplication, RestServer} from '@loopback/rest';
+import {Application} from '@loopback/core';
+import {RestServer} from '@loopback/rest';
 
-export class HelloWorldApp extends RestApplication {
+export class HelloWorldApp extends Application {
   constructor() {
     super();
     // This server instance will be bound under "servers.fooServer".

--- a/pages/en/lb4/Server.md
+++ b/pages/en/lb4/Server.md
@@ -23,16 +23,18 @@ import {RestApplication, RestServer} from '@loopback/rest';
 export class HelloWorldApp extends RestApplication {
   constructor() {
     super();
+    // give our RestServer instance a sequence handler function which
+    // returns the Hello World string for all requests
+    // with RestApplication, handler function can be registered
+    // at app level
+    app.handler((sequence, request, response) => {
+      sequence.send(response, 'Hello World!');
+    });
   }
 
   async start() {
     // get a singleton HTTP server instance
     const rest = await this.getServer(RestServer);
-    // give our RestServer instance a sequence handler function which
-    // returns the Hello World string for all requests
-    rest.handler((sequence, request, response) => {
-      sequence.send(response, 'Hello World!');
-    });
     // call start on application class, which in turn starts all registered
     // servers
     await super.start();


### PR DESCRIPTION
This PR would utilize the new changes made in https://github.com/strongloop/loopback-next/pull/994 so that `async start` is not overridden if it can be overridden.

I left a couple of decisions undecided because I wasn't sure whether i should be changing some of these or not. Here are my main concerns:
- In the `WidgetApplication` example under `Application.md`, `server.api(WidgetApi)` is used in start. The function call can't be moved into the constructor since the app is only extending from `Application` and not `RestApplication`; `api()` function can't be called because it doesn't exist for the application. Should the example be left as it is?
- In `Context.md`, we configure multiple servers inside the start function. I think this should be left as is, but does anybody think otherwise?