### PR TITLE
made object key naming style consistent

### DIFF
--- a/pages/ja/lb3/Storage-component.md
+++ b/pages/ja/lb3/Storage-component.md
@@ -257,9 +257,9 @@ as shown in the following table.
       <td rowspan="3">
 <pre style="font-size:11px;">{
  provider: 'google',
- 'keyFilename': 'path/to/keyfile.json',
- 'projectId': '...',
- 'nameConflict': 'makeUnique'
+ keyFilename: 'path/to/keyfile.json',
+ projectId: '...',
+ nameConflict: 'makeUnique'
 }</pre>
       </td>
     </tr>


### PR DESCRIPTION
object keys now consistent according to es-lint rule 'quote-props'