### PR TITLE
docs: Update app and controller generator in CLI doc

### DIFF
--- a/pages/en/lb4/Application-generator.md
+++ b/pages/en/lb4/Application-generator.md
@@ -18,6 +18,15 @@ lb4 [app] [options] [<name>]
 
 ### Options
 
+`--applicationName`
+: Application name.
+
+`--description`
+: Description of the application.
+
+`--outDir`
+: Project root directory for the application.
+
 `--tslint`
 : Add TSLint to LoopBack4 application project.
 

--- a/pages/en/lb4/Controller-generator.md
+++ b/pages/en/lb4/Controller-generator.md
@@ -20,6 +20,13 @@ lb4 controller [options] [<name>]
 
 ### Options
 
+`--controllerType`
+: Type of the controller.
+
+Valid types are `BASIC` and `REST`.  
+`BASIC` corresponds to an empty controller, whereas `REST` corresponds to
+REST controller with CRUD methods.
+
 {% include_relative includes/CLI-std-options.md %}
 
 ### Arguments
@@ -36,8 +43,8 @@ the prompt is skipped and the controller is built with the name from the
 command-line argument.
 - Type of the controller. You can select from the following types:
   * **Empty Controller** - An empty controller definition
-  * **Basic CRUD Controller** - A controller wired up to a model and repository
-  definition, with pre-defined CRUD methods.
+  * **REST Controller with CRUD Methods** - A controller wired up to a model 
+  and repository definition, with pre-defined CRUD methods.
 
 #### Empty Controller
 If you select the Empty Controller, it will generate a nearly-empty template


### PR DESCRIPTION
- Application generator: add back the options
- Controller generator: add valid controller types and update inconsistent naming for the controller types. 

Related to: strongloop/loopback-next#988