### PR TITLE
docs(faq): add crafting LB4 link

### DIFF
--- a/pages/en/lb3/readmes/loopback-connector-cloudant.md
+++ b/pages/en/lb3/readmes/loopback-connector-cloudant.md
@@ -164,7 +164,7 @@ Property&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  | Type | Description
 ----------| -----| --------
 database  | String | Database name
 modelIndex | String | Specify the model name to document mapping, defaults to `loopback__model__name`.
-modelSelector | JSON | Use the Cloudant Query selector syntax to associate models to existing data. NOTE: modelSelector and modelIndex are mutually exclusive; see [Selector syntax](https://docs.cloudant.com/cloudant_query.html#selector-syntax).
+modelSelector | JSON | Use the Cloudant Query selector syntax to associate models to existing data. NOTE: modelSelector and modelIndex are mutually exclusive; see [Selector syntax](https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#selector-syntax).
 
 ### _rev Property
 

--- a/pages/en/lb4/FAQ.md
+++ b/pages/en/lb4/FAQ.md
@@ -16,6 +16,8 @@ summary: LoopBack 4 is a completely new framework, sometimes referred to as Loop
 - Suitable for small and large teams
 - Minimally opinionated, enforce your team's opinions instead
 
+See [Crafting LoopBack 4](Crafting-LoopBack-4.html) for more details.
+
 ### What’s the timeline for LoopBack 4?
 
 See [Upcoming releases](https://github.com/strongloop/loopback-next/wiki/Upcoming-Releases).


### PR DESCRIPTION
Add the crafting LB4 link to FAQ section `What’s the vision behind LoopBack 4?`.

Related to: https://github.com/strongloop/loopback-next/issues/988