### PR TITLE
docs(cli): add extension generator page

### DIFF
--- a/_data/sidebars/lb4_sidebar.yml
+++ b/_data/sidebars/lb4_sidebar.yml
@@ -94,6 +94,10 @@ children:
     url: Controller-generator.html
     output: 'web, pdf'
 
+  - title: 'Extension generator'
+    url: Extension-generator.html
+    output: 'web, pdf'
+
   - title: 'Download examples'
     url: Download-examples.html
     output: 'web, pdf'

--- a/pages/en/lb4/Extending-LoopBack-4.md
+++ b/pages/en/lb4/Extending-LoopBack-4.md
@@ -149,10 +149,5 @@ An application-level component usually contributes:
 
 ### Learn from existing ones
 
-- [loopback4-example-log-extension](https://github.com/strongloop/loopback4-example-log-extension)
+- [loopback4-example-log-extension](https://github.com/strongloop/loopback-next/tree/master/packages/example-log-extension)
 - [@loopback/authentication](https://github.com/strongloop/loopback-next/tree/master/packages/authentication)
-
-### Create your own from the starter
-
-The [loopback4-extension-starter](https://github.com/strongloop/loopback4-extension-starter) project provides a template to create your own LoopBack 4 extensions as a component. Please follow the instructions to get started. 
-

--- a/pages/en/lb4/Extension-generator.md
+++ b/pages/en/lb4/Extension-generator.md
@@ -1,0 +1,66 @@
+---
+lang: en
+title: 'Extension generator'
+keywords: LoopBack 4.0, LoopBack 4
+tags:
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Extension-generator.html
+summary:
+---
+
+### Synopsis
+
+Creates a new LoopBack4 extension.
+
+```
+lb4 extension [options] [<name>]
+```
+
+### Options
+
+`--description`
+: Description of the extension.
+
+`--outDir`
+: Project root directory for the extension.
+
+`--tslint`
+: Add TSLint to LoopBack4 extension project.
+
+`--prettier` 
+: Add Prettier to LoopBack4 extension project.
+
+`--mocha`
+: Add Mocha to LoopBack4 extension project.
+
+`--loopbackBuild`
+: Add @loopback/build module's script set to LoopBack4 extension project.
+
+{% include_relative includes/CLI-std-options.md %}
+
+### Arguments
+
+`<name>` - Optional name of the extension given as an argument to the command. 
+If provided, the tool will use that as the default when prompting for the name.
+
+### Interactive Prompts
+
+The tool will prompt you for:
+
+- Name of the extension as will be shown in `package.json`.
+If the name had been supplied from the command-line, the prompt is skipped and the extension is built with the name from the command-line argument.
+Must follow npm naming conventions.
+
+- Description of the extension as will be shown in `package.json`.
+
+- Name of the directory in which to create your extension.
+Defaults to the name of the extension previously entered.
+
+- Optional modules to add to the extension. These modules are helpful tools to help format, test, and build a LoopBack4 extension.
+Defaults to `true` for all of the modules.
+The prompted modules are:
+
+  - [`tslint`](https://www.npmjs.com/package/tslint)
+  - [`prettier`](https://www.npmjs.com/package/prettier)
+  - [`mocha`](https://www.npmjs.com/package/mocha)
+  - [`@loopback/build`](https://www.npmjs.com/package/@loopback/build)


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/1031
Information on lb4 extension is missing.
