### PR TITLE
docs: fix links in Booting an Application

### DIFF
--- a/pages/en/lb4/Booting-an-Application.md
+++ b/pages/en/lb4/Booting-an-Application.md
@@ -185,7 +185,7 @@ a part of the `@loopback/boot` package and loaded automatically via `BootMixin`.
 
 ### Controller Booter
 
-This Booter's purpose is to discover [Controller](http://loopback.io/doc/en/lb4/Controllers.html) type Artifacts and to bind
+This Booter's purpose is to discover [Controller](Controllers.html) type Artifacts and to bind
 them to the Application's Context.
 
 You can configure the conventions used in your
@@ -201,7 +201,7 @@ of your Application. The `controllers` object supports the following options:
 
 ### Repository Booter
 
-This Booter's purpose is to discover [Repository]() type Artifacts and to bind
+This Booter's purpose is to discover [Repository](Repository.html) type Artifacts and to bind
 them to the Application's Context. The use of this Booter requires `RepositoryMixin`
 from `@loopback/repository` to be mixed into your Application class.
 


### PR DESCRIPTION
Add missing link for `Repository` and make `Controller` link relative (as in other docs)