### PR TITLE
docs: add extension generator on cli page

### DIFF
--- a/_includes/content/lb4-project-commands.html
+++ b/_includes/content/lb4-project-commands.html
@@ -12,6 +12,12 @@
 </td></tr>
 
 <tr>
+  <td><code>lb4 extension</code>
+  </td><td> Create a new LoopBack4 extension
+  </td><td> <a href="Extension-generator.html">Extension generator</a>
+  </td></tr>
+
+<tr>
 <td><code>lb4 example</code>
 </td><td> Download one of LoopBack example projects
 </td><td> <a href="Download-examples.html">Download examples</a>


### PR DESCRIPTION
Currently in the CLI docs page http://loopback.io/doc/en/lb4/Command-line-interface.html, there is missing extension generator entry in the table. 