### PR TITLE
docs(boot): Move boot docs to top level

### DIFF
--- a/_data/sidebars/lb4_sidebar.yml
+++ b/_data/sidebars/lb4_sidebar.yml
@@ -41,10 +41,6 @@ children:
     url: Dependency-injection.html
     output: 'web, pdf'
 
-  - title: 'Booting an Application'
-    url: Booting-an-Application.html
-    output: 'web, pdf'
-
   - title: 'Controllers'
     url: Controllers.html
     output: 'web, pdf'
@@ -68,6 +64,10 @@ children:
   - title: 'Decorators'
     url: Decorators.html
     output: 'web, pdf'
+
+- title: 'Booting an Application'
+  url: Booting-an-Application.html
+  output: 'web, pdf'
 
 - title: 'Using Components'
   url: Using-components.html


### PR DESCRIPTION
The `Booting an application` page does not seem to fit under `Key Concept` in the official documentation. 
I'm suggesting to move it to the top level. 

connected to https://github.com/strongloop/loopback-next/issues/988