### PR TITLE
fix: enable travis build on gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ node_js:
 os:
   - linux
 
+branches:
+  only:
+  - gh-pages
+
 deploy:
   provider: pages
   skip-cleanup: true


### PR DESCRIPTION
Turns out Travis doesn't build `gh-pages` by default unless it's explicitly safe-listed. Auto-update didn't work today since my PR from yesterday updated `.travis.yml` to deploy to `gh-pages` instead of the staging branch for testing. 

Docs: https://docs.travis-ci.com/user/customizing-the-build/#Building-Specific-Branches