### PR TITLE
chore: tweaks to scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
 os:
   - linux
 
+script:
+  skip
+
 branches:
   only:
   - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ deploy:
   on:
     branch: gh-pages
   script:
-    - /bin/bash ./update-readmes.sh
-    - /bin/bash ./update-community-readmes.sh
-    - /bin/bash ./update-v4-readmes.sh
-    - npm test
+    - npm run fetch-readmes
   email: slnode@ca.ibm.com
   name: StrongLoop Bot
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This file: Node-dependant workflow scripts for the jekyll-based site",
   "scripts": {
     "start": "bundle exec jekyll serve --incremental",
-    "fetch-readmes": "./update-readmes.sh --repos=./_data --out=./_includes/readmes && ./update-v4-readmes.sh",
+    "fetch-readmes": "./update-readmes.sh --repos=./_data --out=./_includes/readmes && ./update-v4-readmes.sh && ./update-community-readmes.sh",
     "lint-readmes": "markdownlint _includes/readmes/",
     "postinstall": "npm run swagger-ui && npm run copydocs",
     "swagger-ui": "node ./api-explorer/upgrade-swagger-ui.js",
@@ -18,8 +18,8 @@
     "url": "git+https://github.com/Strongloop/loopback.io.git"
   },
   "devDependencies": {
-    "fs-extra": "^5.0.0",
     "@loopback/docs": "latest",
+    "fs-extra": "^5.0.0",
     "getreadmes": "github:strongloop/get-readmes",
     "markdownlint-cli": "github:sequoia/markdownlint-cli",
     "swagger-ui-dist": "^3.13.1"

--- a/update-lb4-docs.js
+++ b/update-lb4-docs.js
@@ -35,6 +35,9 @@ function copyDocs(src, dest) {
   }
 }
 
+// Remove the original folder so we remove files deleted from @loopback/docs
+removeDir(destDocs);
+
 // copy the latest docs from @loopback/docs to pages/en/lb4 directory
 copyDocs(srcDocs, destDocs);
 
@@ -43,8 +46,6 @@ copyDocs(srcSidebars, destSidebars);
 
 //clean up sidebar dir
 removeDir(srcSidebars);
-
-
 
 const fileToUpdate = path.resolve(destDocs, 'Testing-the-API.md');
 


### PR DESCRIPTION
loopback.io deploys are failing since old files aren't removed from `@loopback/docs`. This PR:

- removes old folder before copying files from `@loopback/docs`
- Tweaks travis.yml and package.json scripts. 
