### PR TITLE
fix: update path for example-todo readme

### DIFF
--- a/update-v4-readmes.sh
+++ b/update-v4-readmes.sh
@@ -15,7 +15,7 @@
 #
 (cat <<LIST_END
 strongloop loopback-next master packages/metadata/README.md
-strongloop loopback-next master packages/example-todo/README.md
+strongloop loopback-next master examples/todo/README.md
 LIST_END
 ) | while read org repo branch file module; do
   if [ -z "$file" ]; then


### PR DESCRIPTION
This currently breaks loopback.io from publishing