### PR TITLE
update LB4 release name

### DIFF
--- a/_includes/content/v4notice.html
+++ b/_includes/content/v4notice.html
@@ -1,3 +1,3 @@
-<div class="v3notice" style="text-align:center;">LoopBack 4 is currently in Developer Preview #1 release.</br/>
+<div class="v3notice" style="text-align:center;">LoopBack 4 is currently in Developer Preview #2 release.</br/>
 <a href="http://loopback.io/doc/en/lb3/index.html" class="no_icon">LoopBack version 3</a> is the current release.
  </div>

--- a/doc/index.md
+++ b/doc/index.md
@@ -17,7 +17,7 @@ Getting Started with Node for:
 
 This site contains documentation for:
 
-- **[LoopBack 4](en/lb4)** - Developer Preview #1 release.  <br/> _Check out the next step in the evolution of LoopBack!_
+- **[LoopBack 4](en/lb4)** - Developer Preview #2 release.  <br/> _Check out the next step in the evolution of LoopBack!_
 - **[LoopBack 3.x](en/lb3)** - Current production release.
 - **[LoopBack 2.x](en/lb2)** - [Long-term support](/doc/en/contrib/Long-term-support.html) release.
 - **[Contributing to LoopBack](en/contrib/)** - How to contribute to the LoopBack project.


### PR DESCRIPTION
Update LB4 release name in loopback.io.  
I've searched for the occurrences of "Developer Preview", and there are 2 places.

connected to: https://github.com/strongloop/loopback-next/issues/1059

