### PR TITLE
chore: add build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "This file: Node-dependant workflow scripts for the jekyll-based site",
   "scripts": {
+    "build": "npm run fetch-readmes && bundle exec jekyll build",
     "start": "bundle exec jekyll serve --incremental",
     "fetch-readmes": "./update-readmes.sh --repos=./_data --out=./_includes/readmes && ./update-v4-readmes.sh && ./update-community-readmes.sh",
     "lint-readmes": "markdownlint _includes/readmes/",
@@ -18,7 +19,7 @@
     "url": "git+https://github.com/Strongloop/loopback.io.git"
   },
   "devDependencies": {
-    "@loopback/docs": "latest",
+    "@loopback/docs": "*",
     "fs-extra": "^5.0.0",
     "getreadmes": "github:strongloop/get-readmes",
     "markdownlint-cli": "github:sequoia/markdownlint-cli",

--- a/update-lb4-docs.js
+++ b/update-lb4-docs.js
@@ -44,9 +44,6 @@ copyDocs(srcDocs, destDocs);
 //copy over sidebar for LoopBack 4
 copyDocs(srcSidebars, destSidebars);
 
-//clean up sidebar dir
-removeDir(srcSidebars);
-
 const fileToUpdate = path.resolve(destDocs, 'Testing-the-API.md');
 
 // bug in `jekyll-relative-links` plugin; probably safe to remove when


### PR DESCRIPTION
- Change `latest` to `*` so when bootstrapped in `loopback-next` it installs the local copy. 
- Added a build script. 
- Don't delete the `srcSidebars` since in the monorepo it would delete the actual sidebar file.