### PR TITLE
Bugfix in doc, polymorphic foreign key

### DIFF
--- a/pages/en/lb3/Polymorphic-relations.md
+++ b/pages/en/lb3/Polymorphic-relations.md
@@ -248,10 +248,10 @@ First define relations in through model ImageLink.
       "type": "belongsTo",
       "model": "Picture",
       "foreignKey": ""
-    },
-    "imageable": {
-      "type": "belongsTo",
-      "polymorphic": true
+      "imageable": {
+        "type": "belongsTo",
+        "polymorphic": true
+      }
     }
   }
 ...


### PR DESCRIPTION
Definition should be contained inside relation. 

This fixes the error: 
`/.../node_modules/loopback-datasource-juggler/lib/datasource.js:2050
    pkType = foreignModel.properties[pkName].type;
                                             ^
TypeError: Cannot read property 'type' of undefined`
