### PR TITLE
Update Making-authenticated-requests.md

### DIFF
--- a/pages/en/lb3/Making-authenticated-requests.md
+++ b/pages/en/lb3/Making-authenticated-requests.md
@@ -85,8 +85,6 @@ var token = new AccessToken({
 token.destroy();
 // remove all user tokens
 AccessToken.destroyAll({
-  where: {
-    userId: USER_ID
-  }
+  userId: USER_ID
 });
 ```


### PR DESCRIPTION
`PersistedModel.destroyAll` takes an optional `where filter` instead of a `Filter JSON object`

[link to the docs](https://apidocs.strongloop.com/loopback/#persistedmodel-destroyall)