### PR TITLE
install gems on travis for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ branches:
   only:
   - gh-pages
 
+before_install:
+  bundle install
+
 before_deploy:
   - npm run build
   - npm run discovery-upload


### PR DESCRIPTION
install gems on travis so we can build the site -- needed for uploading `_site/posts.json` to Watson Discovery.