### PR TITLE
fix: add question mark to proxy url

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -78,7 +78,7 @@
 
     $('.search-bar').val(queryObj.q.replace('+', ' '));
 
-    var urlBase = "https://openwhisk.ng.bluemix.net/api/v1/web/slbld%40ca.ibm.com_loopback/default/search.json";
+    var urlBase = "https://openwhisk.ng.bluemix.net/api/v1/web/slbld%40ca.ibm.com_loopback/default/search.json?";
     var url = urlBase + query;
 
     $.get(url).done(function(data) {


### PR DESCRIPTION
I missed the trailing `?` mark at the end of the proxy url when I updated the URL to the actual instance instead of my account.