### PR TITLE
Added async examples to the Adding logic to Models pages

### DIFF
--- a/pages/en/lb2/Operation-hooks.md
+++ b/pages/en/lb2/Operation-hooks.md
@@ -145,6 +145,19 @@ and _`observer`_ is `function observer(context, callback)`. Child models inher
   </tbody>
 </table>
 
+
+### Using async/await
+
+Operation hooks can also return a promise instead of calling the next parameter.
+
+{% include code-caption.html content="/common/models/MyModel.js" %}
+```javascript
+MyModel.observe('before save', async function(ctx) {
+  //...
+  return;
+});
+```
+
 ### Operation hook context object
 
 The `context` object is specific to operation hooks and does not have any relation to the context object passed to remote hooks registered via `Model.beforeRemote` and `Model.afterRemote`.

--- a/pages/en/lb2/Remote-hooks.md
+++ b/pages/en/lb2/Remote-hooks.md
@@ -79,6 +79,17 @@ Where:
 The syntax above includes a call to `next()` as a reminder that you must call `next()` at some point in the remote hook callback function.
 It doesn't necessarily have to come at the end of the function, but must be called at some point before the function completes.
 
+### Using async/await
+
+Remote hooks can also return a promise instead of using the next parameter
+
+```javascript
+_modelName_.afterRemoteError( _methodName_, async function( ctx) {
+    //...
+    return;
+});
+```
+
 #### Wildcards
 
 You can use the following wildcard characters in `_methodName_`:

--- a/pages/en/lb2/Remote-methods.md
+++ b/pages/en/lb2/Remote-methods.md
@@ -78,6 +78,25 @@ Notice the REST API request above uses the plural form \"people\" instead of \"p
 [plural form of model names for REST API routes](Exposing-models-over-REST.html#REST-paths).
 " %}
 
+### Using async/await
+
+Remote methods can also return a promise instead of using the callback parameter.
+
+{% include code-caption.html content="/common/models/person.js" %}
+```javascript
+module.exports = function(Person){
+
+    Person.greet = async function(msg) {
+        return 'Greetings... ' + msg;
+    }
+
+    Person.remoteMethod('greet', {
+          accepts: {arg: 'msg', type: 'string'},
+          returns: {arg: 'greeting', type: 'string'}
+    });
+};
+```
+
 ## Registering a remote method
 
 All LoopBack models have a [`remoteMethod()`](http://apidocs.strongloop.com/loopback/#model-remotemethod) static method that you use to register a remote method:

--- a/pages/en/lb3/Operation-hooks.md
+++ b/pages/en/lb3/Operation-hooks.md
@@ -178,6 +178,18 @@ and _`observer`_ is `function observer(context, callback)`. Child models inher
   </tbody>
 </table>
 
+### Using async/await
+
+Operation hooks can also return a promise instead of calling the next parameter.
+
+{% include code-caption.html content="/common/models/MyModel.js" %}
+```javascript
+MyModel.observe('before save', async function(ctx) {
+  //...
+  return;
+});
+```
+
 ### Operation hook context object
 
 The `context` object is specific to operation hooks and does not have any relation to the context object passed to remote hooks registered via

--- a/pages/en/lb3/Remote-hooks.md
+++ b/pages/en/lb3/Remote-hooks.md
@@ -45,6 +45,18 @@ modelName.beforeRemote( methodName, function( ctx, next) {
 });
 ```
 
+
+### Using async/await
+
+Remote hooks can also return a promise instead of using the next parameter
+
+```javascript
+modelName.beforeRemote( methodName, async function( ctx) {
+    //...
+    return;
+});
+```
+
 Where:
 
 - `modelName` is the name of the model that has the remote method.

--- a/pages/en/lb3/Remote-methods.md
+++ b/pages/en/lb3/Remote-methods.md
@@ -70,6 +70,25 @@ Greetings... John!
 [plural form of model names for REST API routes](Exposing-models-over-REST.html#REST-paths).
 " %}
 
+### Using async/await
+
+Remote methods can also return a promise instead of using the callback parameter.
+
+{% include code-caption.html content="/common/models/person.js" %}
+```javascript
+module.exports = function(Person){
+
+    Person.greet = async function(msg) {
+        return 'Greetings... ' + msg;
+    }
+
+    Person.remoteMethod('greet', {
+          accepts: {arg: 'msg', type: 'string'},
+          returns: {arg: 'greeting', type: 'string'}
+    });
+};
+```
+
 ## Registering a remote method
 
 There are two ways to register a remote method:


### PR DESCRIPTION
Added async/await examples to en/lb3 and en/lb2 Remote-Methods.md, Remote-hooks.md and Operation-hooks.md.  

https://github.com/strongloop/loopback/issues/3834