### PR TITLE
chore: remove pages from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ dist
 .jekyll-metadata
 vendor
 .bundle
-pages/en/lb4/
-pages/**/*/readmes/


### PR DESCRIPTION
Fixes the missing GDPR Deploy Page for LB4.