### PR TITLE
Fix update-lb4-docs to handle missing files

### DIFF
--- a/update-lb4-docs.js
+++ b/update-lb4-docs.js
@@ -49,6 +49,7 @@ const fileToUpdate = path.resolve(destDocs, 'Testing-the-API.md');
 // bug in `jekyll-relative-links` plugin; probably safe to remove when
 // https://github.com/benbalter/jekyll-relative-links/issues/5
 // is resolved
+if (!fs.existsSync(fileToUpdate)) return;
 try {
   let contents = fs.readFileSync(fileToUpdate, 'utf-8');
   contents = contents.replace('include previous.md', 'include previous.html');


### PR DESCRIPTION
Fix the script to handle the situation when `Testing-the-API.md` is not present, e.g. because it was renamed (see https://github.com/strongloop/loopback-next/pull/1433).

Connect to strongloop/loopback-next#1094