### PR TITLE
Update update-v4-readme.sh to include todo-list README

### DIFF
--- a/update-v4-readmes.sh
+++ b/update-v4-readmes.sh
@@ -16,6 +16,7 @@
 (cat <<LIST_END
 strongloop loopback-next master packages/metadata/README.md
 strongloop loopback-next master examples/todo/README.md
+strongloop loopabck-next master examples/todo-list/README.md
 LIST_END
 ) | while read org repo branch file module; do
   if [ -z "$file" ]; then


### PR DESCRIPTION
Related to strongloop/loopback-next#1518

A new README file needs to be accounted for in `update-v4-readme.sh` in order for it to be pulled from loopback-next and have its corresponding page generated.