### PR TITLE
Update HasOne-relations.md

### DIFF
--- a/pages/en/lb3/HasOne-relations.md
+++ b/pages/en/lb3/HasOne-relations.md
@@ -48,7 +48,7 @@ For example, consider two models: supplier and account.
 }
 ```
 
-A supplier has one account, where the foreign  key is on the declaring model: account.supplierId -> supplier.id.
+A supplier has one account, where the foreign  key is on the target model: account.supplierId -> supplier.id.
 
 {% include code-caption.html content="common/models/account.json" %}
 ```javascript
@@ -84,7 +84,7 @@ Supplier.hasOne(Account, {foreignKey: 'supplierId', as: 'account'});
 ```
 
 If the target model doesn't have a foreign key property, LoopBack will add a property with the same name.
-The type of the property will be the same as the type of the target model's **id** property.
+The type of the property will be the same as the type of the declaring model's **id** property.
 Please note the foreign key property is defined on the target model (for example, Account).
 
 If you don't specify them, then LoopBack derives the relation name and foreign key as follows:


### PR DESCRIPTION
This documentation chooses to explain the HasOne relationship with the Account and Supplier models as examples. Since we are documenting the HasOne relationship, it is my understanding that the DECLARING model is the Supplier model and the TARGET model is the Account model. The foreign key therefore would be on the declaring model as account.supplierId. I corrected the documentation to reflect that. Also, the type of the foreign key property (defined on the target model) should be the same as the type of the id key property on the declaring model (and not the target model as the docs state). I believe that the use of declaring and target has been flipped mistakenly. Of course, I'm just learning this stuff so I could be very wrong. If so, please disregard this proposed file change :)