### PR TITLE
LTS: rename LTS to Active LTS to avoid confusion

### DIFF
--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -65,7 +65,7 @@ In August 2018, there were two major Node.js versions covered by the LTS plan:
 6.x and 8.x; and two supported LoopBack versions: 2.x and 3.x.
 
 Framework | Status | Published | EOL | Runtime | GA | EOL
--- | -- | -- | -- | -- | --
+-- | -- | -- | -- | -- | -- | --
 Loopback 3 | Current | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
 Loopback 2 | Active LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
  |  |  | Apr 2018 | Node 4 | Oct 2015 | Apr 2018
@@ -74,7 +74,7 @@ Assuming LoopBack 4.0 is released in October 2018 to align with Node.js 10.x
 entering LTS:
 
 Framework | Status | Published | EOL | Runtime | GA | EOL
--- | -- | -- | -- | -- | --
+-- | -- | -- | -- | -- | -- | --
 LoopBack 4 | Current | Oct 2018 | Dec 2021 | Node 10 | Oct 2018 | Apr 2021
 Loopback 3 | Active LTS | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
 Loopback 2 | Maintenance LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019

--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -5,15 +5,15 @@ tags: [contributing, community]
 keywords: LoopBack, versioning, long-term support
 sidebar: home_sidebar
 permalink: /doc/en/contrib/Long-term-support.html
-summary: LoopBack maintains a current version, a long-term support (LTS) version, and a maintenance version.
+summary: LoopBack maintains a Current version, an Active long-term support (LTS) version, and one or more Maintenance LTS versions.
 ---
 
 ## Overview
 
-In general, LoopBack version numbers adhere to [semantic versioning](http://semver.org/) conventions.
+LoopBack adheres to [semantic versioning](http://semver.org/) conventions and
+implements [Module LTS policy](https://github.com/CloudNativeJS/ModuleLTS).
 
-The LoopBack project implements [Module LTS
-policy](https://github.com/CloudNativeJS/ModuleLTS) and maintains:
+The project maintains:
 
 - A _Current_ version where most of the development occurs.
 - An _Active LTS_ (Long-Term Support) version that does not add new features but gets bug fixes.
@@ -44,12 +44,38 @@ Changes are limited to:
  Semver-minor changes are only permitted if required for bug fixes. Semver-major
  changes are only permitted if required for critical security and bug fixes.
 
+Support for new major Node.js versions may be added if the required changes
+have a low risk of breaking existing applications.
+
 ## Maintenance LTS
 
 When a new major version (for example, 4.0) is released, the oldest Active LTS
 version (for example, 2.x) enters Maintenance LTS mode, where it will stay for
-so long as the Node.js LTS versions available at release time are maintained by
-the Node.js project, but at least for six months.
+as long as the Node.js LTS versions available at release time are maintained by
+the Node.js project.
 
 Once a release moves into Maintenance LTS mode, only critical bugs, critical
 security fixes, and documentation updates will be permitted.
+
+Specifically, adding support for new major Node.js versions is not permitted.
+
+## Example
+
+In August 2018, there were two major Node.js versions covered by the LTS plan:
+6.x and 8.x; and two supported LoopBack versions: 2.x and 3.x.
+
+Framework | Status | Published | EOL | Runtime | GA | EOL
+-- | -- | -- | -- | -- | --
+Loopback 3 | Current | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
+Loopback 2 | Active LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
+ |  |  | Apr 2018 | Node 4 | Oct 2015 | Apr 2018
+
+Assuming LoopBack 4.0 is released in October 2018 to align with Node.js 10.x
+entering LTS:
+
+Framework | Status | Published | EOL | Runtime | GA | EOL
+-- | -- | -- | -- | -- | --
+LoopBack 4 | Current | Oct 2018 | Dec 2021 | Node 10 | Oct 2018 | Apr 2021
+Loopback 3 | Active LTS | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
+Loopback 2 | Maintenance LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
+ |  |  | Apr 2018 | Node 4 | Oct 2015 | Apr 2018

--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -66,16 +66,14 @@ In August 2018, there were two major Node.js versions covered by the LTS plan:
 
 Framework | Status | Published | EOL | Runtime | GA | EOL
 -- | -- | -- | -- | -- | -- | --
-Loopback 3 | Current | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
+Loopback 3 | Current | Dec 2016 | Dec 2019<br/>_(minimum)_ |  Node 8 | Oct 2017 | Dec 2019
 Loopback 2 | Active LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
- |  |  | Apr 2018 | Node 4 | Oct 2015 | Apr 2018
 
 Assuming LoopBack 4.0 is released in October 2018 to align with Node.js 10.x
 entering LTS:
 
 Framework | Status | Published | EOL | Runtime | GA | EOL
 -- | -- | -- | -- | -- | -- | --
-LoopBack 4 | Current | Oct 2018 | Dec 2021 | Node 10 | Oct 2018 | Apr 2021
+LoopBack 4 | Current | Oct 2018 | Dec 2021<br/>_(minimum)_| Node 10 | Oct 2018 | Apr 2021
 Loopback 3 | Active LTS | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
 Loopback 2 | Maintenance LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
- |  |  | Apr 2018 | Node 4 | Oct 2015 | Apr 2018

--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -16,14 +16,15 @@ The LoopBack project implements [Module LTS
 policy](https://github.com/CloudNativeJS/ModuleLTS) and maintains:
 
 - A _Current_ version where most of the development occurs.
-- A _Long-term support (LTS)_ version that does not add new features but gets bug fixes.
-- One or more _maintenance_ versions that receive only critical bug fixes.
+- An _Active LTS_ (Long-Term Support) version that does not add new features but gets bug fixes.
+- One or more _Maintenance LTS_ versions that receive only critical bug fixes.
 
 
-## LTS versions
+## Active LTS
 
-A major LoopBack version (for example, 3.x) enters LTS when the next major version is
-released (for example, 4.0) and stays in LTS mode for at least six months.
+A major LoopBack version (for example, 3.x) enters Active LTS when the next
+major version is released (for example, 4.0) and stays in Active LTS mode for
+at least six months.
 
 Once a release enters LTS, no new features may be added to that release.
 Changes are limited to:
@@ -31,8 +32,6 @@ Changes are limited to:
 1. Bug fixes;
 
 2. Security updates;
-
-3. Non-semver-major npm updates;
 
 4. Relevant documentation updates;
 
@@ -45,9 +44,12 @@ Changes are limited to:
  Semver-minor changes are only permitted if required for bug fixes. Semver-major
  changes are only permitted if required for critical security and bug fixes.
 
-## Maintenance versions
+## Maintenance LTS
 
-When a new major version (for example, 4.0) is released, the oldest LTS version (for example, 2.x) enters maintenance mode, where it will stay at least for another six months and so long as the Node.js LTS versions available at release time are maintained by the Node.js project.
+When a new major version (for example, 4.0) is released, the oldest Active LTS
+version (for example, 2.x) enters Maintenance LTS mode, where it will stay for
+so long as the Node.js LTS versions available at release time are maintained by
+the Node.js project, but at least for six months.
 
-Once a release moves into maintenance mode, only critical bugs, critical
+Once a release moves into Maintenance LTS mode, only critical bugs, critical
 security fixes, and documentation updates will be permitted.

--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -33,12 +33,12 @@ Changes are limited to:
 
 2. Security updates;
 
-4. Relevant documentation updates;
+3. Relevant documentation updates;
 
-5. Certain performance improvements where the risk of breaking existing
+4. Certain performance improvements where the risk of breaking existing
  applications is minimal;
 
-6. Changes that introduce large amount of code churn where the risk of breaking
+5. Changes that introduce large amount of code churn where the risk of breaking
  existing applications is low and where the change in question may significantly
  ease the ability to backport future changes due to the reduction in diff noise.
  Semver-minor changes are only permitted if required for bug fixes. Semver-major

--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -59,7 +59,7 @@ security fixes, and documentation updates will be permitted.
 
 Specifically, adding support for new major Node.js versions is not permitted.
 
-## Example
+## Examples
 
 In August 2018, there were two major Node.js versions covered by the LTS plan:
 6.x and 8.x; and two supported LoopBack versions: 2.x and 3.x.
@@ -74,6 +74,6 @@ entering LTS:
 
 Framework | Status | Published | EOL | Runtime | GA | EOL
 -- | -- | -- | -- | -- | -- | --
-LoopBack 4 | Current | Oct 2018 | Dec 2021<br/>_(minimum)_| Node 10 | Oct 2018 | Apr 2021
+LoopBack 4 | Current | Oct 2018 | Apr 2021<br/>_(minimum)_| Node 10 | Oct 2018 | Apr 2021
 Loopback 3 | Active LTS | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
 Loopback 2 | Maintenance LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019


### PR DESCRIPTION
Rename "LTS" and "Maintenace" modes to "Active LTS" and "Maintenance LTS".

This is to avoid confusion, because "Module LTS" uses LTS for what we call Maintenance mode.

Also drop the minimum of 6 months in Maintenance mode and use Module LTS rules to control EOL of our maintenance.

See also https://github.com/strongloop/loopback.io/pull/715