### PR TITLE
add a new line before end div tag

### DIFF
--- a/_includes/callout.html
+++ b/_includes/callout.html
@@ -1,1 +1,3 @@
-<div markdown="span" class="bs-callout bs-callout-{{include.type}}">{{include.content}}</div>
+<div markdown="span" class="bs-callout bs-callout-{{include.type}}">
+  {{include.content}}
+</div>

--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,4 +1,7 @@
-<div markdown="1" class="alert alert-warning" role="alert"><i class="fa fa-warning"></i>
-{% if include.title %}<b>{{include.title}}</b>
-{% else %}<b>Important:</b>{% endif %}
-{{include.content}}</div>
+<div markdown="1" class="alert alert-warning" role="alert">
+  <i class="fa fa-warning"></i>
+  {% if include.title %}
+  <b>{{include.title}}</b>
+  {% else %}
+  <b>Important:</b>{% endif %} {{include.content}}
+</div>

--- a/_includes/note-span.html
+++ b/_includes/note-span.html
@@ -1,1 +1,4 @@
-<div markdown="span" class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i> <b>Note:</b> {{include.content}}</div>
+<div markdown="span" class="alert alert-info" role="alert">
+  <i class="fa fa-info-circle"></i>
+  <b>Note:</b> {{include.content}}
+</div>

--- a/_includes/note.html
+++ b/_includes/note.html
@@ -1,4 +1,5 @@
 <div markdown="1" class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i>
 {% if include.title %}<b>{{include.title}}</b>
 {% else %}<b>Note:</b>{% endif %}
-{{include.content}}</div>
+{{include.content}}
+</div>

--- a/_includes/styled-box.html
+++ b/_includes/styled-box.html
@@ -1,1 +1,3 @@
-<div class="highlight-box" markdown="1" style="{{include.style}}">{{include.content}}</div>
+<div class="highlight-box" markdown="1" style="{{include.style}}">
+  {{include.content}}
+</div>

--- a/_includes/tip.html
+++ b/_includes/tip.html
@@ -1,1 +1,4 @@
-<div markdown="1" class="alert alert-success" role="alert"><i class="fa fa-check-square-o"></i> <b>Tip:</b> {{include.content}}</div>
+<div markdown="1" class="alert alert-success" role="alert">
+  <i class="fa fa-check-square-o"></i>
+  <b>Tip:</b> {{include.content}}
+</div>

--- a/_includes/tooltab.html
+++ b/_includes/tooltab.html
@@ -1,14 +1,20 @@
 <ul id="profileTabs" class="nav nav-tabs">
-    <li class="active"><a href="#one" data-toggle="tab">StrongLoop tools (slc)</a></li>
-    <li><a href="#two" data-toggle="tab">API Connect tools (apic)</a></li>
+  <li class="active">
+    <a href="#one" data-toggle="tab">StrongLoop tools (slc)</a>
+  </li>
+  <li>
+    <a href="#two" data-toggle="tab">API Connect tools (apic)</a>
+  </li>
 </ul>
 <div class="tab-content">
   <div role="tabpanel" class="tab-pane active" id="one">
-  <div markdown="1">
-{{include.slc}}</div>
+    <div markdown="1">
+      {{include.slc}}
+    </div>
   </div>
   <div role="tabpanel" class="tab-pane" id="two">
     <div markdown="1">
-{{include.apic}}</div>
+      {{include.apic}}
+    </div>
   </div>
 </div>

--- a/_includes/warning.html
+++ b/_includes/warning.html
@@ -1,1 +1,4 @@
-<div markdown="1" class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>Warning:</b> {{include.content}}</div>
+<div markdown="1" class="alert alert-danger" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Warning:</b> {{include.content}}
+</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,7 +9,9 @@ toc: false
 <div class="post-content">
 
  {% if page.summary %}
-  <div class="summary">{{page.summary}}</div>
+  <div class="summary">
+    {{page.summary}}
+  </div>
  {% endif %}
 
   {% if page.layout != 'readme' and page.layout != 'navgroup' %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -21,7 +21,9 @@ layout: default
 <div class="post-content">
 
  {% if page.summary %}
-  <div class="summary">{{page.summary}}</div>
+  <div class="summary">
+    {{page.summary}}
+  </div>
  {% endif %}
 
 {% if page.layout == 'navgroup' %}

--- a/_layouts/page_print.html
+++ b/_layouts/page_print.html
@@ -9,7 +9,9 @@ comments: true
 <div class="post-content">
 
     {% if page.summary %}
-    <div class="summary">{{page.summary}}</div>
+    <div class="summary">
+        {{page.summary}}
+    </div>
     {% endif %}
     {{ content }}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,7 +22,9 @@ layout: default
     <div class="post-content" itemprop="articleBody">
 
         {% if page.summary %}
-        <div class="summary">{{page.summary}}</div>
+        <div class="summary">
+            {{page.summary}}
+        </div>
         {% endif %}
 
         {{ content }}

--- a/scripts-pdf/pdfconfigs/titlepage.html
+++ b/scripts-pdf/pdfconfigs/titlepage.html
@@ -4,9 +4,15 @@ search: exclude
 permalink: /titlepage/
 ---
 <div class="printTitleArea">
-    <div class="printTitle">{{site.print_title}}</div>
-    <div class="printSubtitle">{{site.print_subtitle}}</div>
-    <div class="lastGeneratedDate">Last generated: {{ site.time | date: '%B %d, %Y' }}</div>
+    <div class="printTitle">
+        {{site.print_title}}
+    </div>
+    <div class="printSubtitle">
+        {{site.print_subtitle}}
+    </div>
+    <div class="lastGeneratedDate">
+        Last generated: {{ site.time | date: '%B %d, %Y' }}
+    </div>
     <hr />
 
     <div class="printTitleImage">


### PR DESCRIPTION
Jekyll templating used to break when `note.html` or any other similar assets were used when not in this specific format:
```
{% include note.html content="
Binding configuration such as component binding,
provider binding, or binding scopes are not possible with the constructor-based
configuration approach.
" %}
```
The said note.html file (and other similar assets) had a `</div>` tag right after where stuff specified in `content` would go. If we were to introduce a line break here, the problem goes away for the oddest reason.

The PR introduces line breaks to all of the </div> tags that didn't have one before