### PR TITLE
Clarify relations change

### DIFF
--- a/pages/en/lb3/Authentication-authorization-and-permissions.md
+++ b/pages/en/lb3/Authentication-authorization-and-permissions.md
@@ -99,7 +99,7 @@ and uses the built-in `AccessToken` model.  In this case, you need to change the
     "relations": {
       "user": {
         "type": "belongsTo",
-        "model": "user",
+        "model": "CustomUserModel",
         "foreignKey": "userId"
       }
     }

--- a/pages/en/lb3/Authentication-authorization-and-permissions.md
+++ b/pages/en/lb3/Authentication-authorization-and-permissions.md
@@ -99,7 +99,7 @@ and uses the built-in `AccessToken` model.  In this case, you need to change the
     "relations": {
       "user": {
         "type": "belongsTo",
-        "model": "CustomUserModel",
+        "model": "CustomUser",
         "foreignKey": "userId"
       }
     }


### PR DESCRIPTION
Since the doc is trying to explain how to deal with a custom user model, I think it would make sense to not use `user` with lowercase `u` to identify the custom user model