### PR TITLE
Add DAO and relation promise support to documentation

### DIFF
--- a/pages/en/lb3/BelongsTo-relations.md
+++ b/pages/en/lb3/BelongsTo-relations.md
@@ -66,7 +66,7 @@ For example, here is the model JSON file for the order model in
   ...
 ```
 
-Alternatively, you can define a "belongsTo" relation in code, though in general this is not recommended:
+Alternatively, you can define a `belongsTo` relation in code, though in general this is not recommended:
 
 {% include code-caption.html content="common/models/order.js" %}
 ```javascript
@@ -83,11 +83,13 @@ If you don't specify them, then LoopBack derives the relation name and foreign k
 
 ## Methods added to the model
 
-Once you define the belongsTo relation, LoopBack automatically adds a method with the relation name to the declaring model class's prototype,
+Once you define the `belongsTo` relation, LoopBack automatically adds a method with the relation name to the declaring model class's prototype,
 for example: `Order.prototype.customer(...)`.
 
 Depending on the arguments, the method can be used to get or set the owning model instance.
 The results of method calls are cached internally and available via later synchronous calls to the method. 
+
+The relation can return a promise by calling the `get()` method on the relation property.
 
 <table>
   <tbody>
@@ -114,6 +116,12 @@ The results of method calls are cached internally and available via later synchr
         <pre>order.customer(customer);</pre>
       </td>
       <td>Set the customer for the order</td>
+    </tr>
+    <tr>
+      <td>
+        <pre>order.customer.get().then(function(customer) { ... });</pre>
+      </td>
+      <td>Use the `get()` method on the relation name to return a promise.</td>
     </tr>
   </tbody>
 </table>

--- a/pages/en/lb3/HasAndBelongsToMany-relations.md
+++ b/pages/en/lb3/HasAndBelongsToMany-relations.md
@@ -73,6 +73,8 @@ Assembly.Parts.link({id:assemblyId, fk: partId}, partInstance,  function(value, 
 Once you define a "hasAndBelongsToMany" relation, LoopBack adds methods with the relation name to the declaring model class's prototype automatically.
 For example: `assembly.parts.create(...)`.
 
+The relation can return a promise by calling the `find()` method on the relation property.
+
 <table>
   <tbody>
     <tr>
@@ -126,6 +128,12 @@ For example: `assembly.parts.create(...)`.
 function(err) {<br>  ...<br>});</pre>
       </td>
       <td>Delete a part by ID.</td>
+    </tr>
+    <tr>
+      <td>
+        <pre>assembly.parts.find().then(function(parts) { ... });</pre>
+      </td>
+      <td>Use the `find()` method on the relation name to return a promise.</td>
     </tr>
   </tbody>
 </table>

--- a/pages/en/lb3/HasMany-relations.md
+++ b/pages/en/lb3/HasMany-relations.md
@@ -60,6 +60,8 @@ If not specified, LoopBack derives the relation name and foreign key as follows:
 Once you define a "hasMany" relation, LoopBack adds a method with the relation name to the declaring model class's prototype automatically.
 For example: `Customer.prototype.orders(...)`.
 
+The relation can return a promise by calling the `find()` method on the relation property.
+
 <table>
   <tbody>
     <tr>
@@ -110,6 +112,12 @@ For example: `Customer.prototype.orders(...)`.
   function(err) {<br>  ...<br>});</pre>
       </td>
       <td>Delete an order by ID.</td>
+    </tr>
+    <tr>
+      <td>
+        <pre>customer.orders.find().then(function(orders) { ... });</pre>
+      </td>
+      <td>Use the `find()` method on the relation name to return a promise.</td>
     </tr>
   </tbody>
 </table>

--- a/pages/en/lb3/HasManyThrough-relations.md
+++ b/pages/en/lb3/HasManyThrough-relations.md
@@ -243,6 +243,8 @@ Follow.belongsTo(User, {as: 'followee'});
 
 Once you define a "hasManyThrough" relation, LoopBack adds methods with the relation name to the declaring model class's prototype automatically, for example: `physician.patients.create(...)`.
 
+The relation can return a promise by calling the `find()` method on the relation property.
+
 <table>
   <tbody>
     <tr>
@@ -295,6 +297,12 @@ Once you define a "hasManyThrough" relation, LoopBack adds methods with the rela
   function(err, patient) {<br>  ...<br>});</pre>
       </td>
       <td>Find an patient by ID.</td>
+    </tr>
+    <tr>
+      <td>
+        <pre>physician.patients.find().then(function(patients) { ... });</pre>
+      </td>
+      <td>Use the `find()` method on the relation name to return a promise.</td>
     </tr>
   </tbody>
 </table>

--- a/pages/en/lb3/HasOne-relations.md
+++ b/pages/en/lb3/HasOne-relations.md
@@ -97,6 +97,8 @@ If you don't specify them, then LoopBack derives the relation name and foreign k
 Once you define the hasOne relation, LoopBack automatically adds a method with the relation name to the declaring model class's prototype.
 For example: `supplier.prototype.account(...)`.
 
+The relation can return a promise by calling the get() method on the relation property.
+
 <table>
   <tbody>
     <tr>
@@ -140,6 +142,12 @@ For example: `supplier.prototype.account(...)`.
         <pre>supplier.account.update({balance: 100}, function(err, account) {<br>  ...<br>});</pre>
       </td>
       <td>Update the associated account.</td>
+    </tr>
+    <tr>
+      <td>
+        <pre>supplier.account.get().then(function(account) { ... });</pre>
+      </td>
+      <td>Use the `get()` method on the relation name to return a promise.</td>
     </tr>
   </tbody>
 </table>

--- a/pages/en/lb3/Using-promises.md
+++ b/pages/en/lb3/Using-promises.md
@@ -166,3 +166,23 @@ MyModel.myFunc = function(input, cb) {
  MyModel.remoteMethod('myFunc', ...);
 }
 ```
+
+### DAO and relation methods
+
+`BelongsTo` and `HasOne` relations return promises by calling the `get()` method on the relation property:
+
+```javascript
+MyModel.relation.get()
+  .then(function(result) {
+    // ...
+  });
+```
+
+`HasMany` relations return promises by calling the `find()` method on the relation property:
+
+```javascript
+MyModel.relations.find()
+  .then(function(results) {
+    // ...
+  });
+```


### PR DESCRIPTION
Pinging @bajtos and https://github.com/strongloop/loopback-datasource-juggler/issues/1127.

I'm still getting used to Loopback source, so bear with me. It looks like `HasManyThrough` extends `HasMany`, and itself isn't tested in `./test/relation.test.js`. So, I imagine it's safe to say `HasManyThrough` would use the same wording as `HasMany`. Can you confirm? 

Also, I know it's a separate issue, but why is there no mention of `HasManyThrough` in `relation.test.js`?