### PR TITLE
Update Controlling-data-access.md

### DIFF
--- a/pages/en/lb3/Controlling-data-access.md
+++ b/pages/en/lb3/Controlling-data-access.md
@@ -399,7 +399,7 @@ Do this in your test environment as there may be quite a lot of output.
       <td>&nbsp;</td>
       <td>__findById__relationName</td>
       <td>GET</td>
-      <td>/model-name-plural/{id}/relationName</td>
+      <td>/model-name-plural/{id}/relationName/{fk}</td>
     </tr>
     <tr>
       <td>&nbsp;</td>


### PR DESCRIPTION
Change for Access Type : **READ**

**__findById__relationName** property is for targeting the endpoint with `/model-name-plural/{id}/relationName/{fk}`. 

The **{fk}** is missing in the documentation. 

It currently states the same endpoint as `/model-name-plural/{id}/relationName` which is actually taken care of by **__get__relationName property**.