### PR TITLE
Update ACL End-point

### DIFF
--- a/pages/en/lb2/Controlling-data-access.md
+++ b/pages/en/lb2/Controlling-data-access.md
@@ -384,7 +384,7 @@ Do this in your test environment as there may be quite a lot of output.
       <td>&nbsp;</td>
       <td>replaceById</td>
       <td>POST</td>
-      <td>/model-name-plural/{id}</td>
+      <td>/model-name-plural/{id}/replace</td>
     </tr>
     <tr>
       <td>&nbsp;</td>

--- a/pages/en/lb3/Controlling-data-access.md
+++ b/pages/en/lb3/Controlling-data-access.md
@@ -471,7 +471,7 @@ Do this in your test environment as there may be quite a lot of output.
       <td>&nbsp;</td>
       <td>replaceById</td>
       <td>POST</td>
-      <td>/model-name-plural/{id}</td>
+      <td>/model-name-plural/{id}/replace</td>
     </tr>
     <tr>
       <td>&nbsp;</td>


### PR DESCRIPTION
ACL docs have wrong end-point for **replaceById**

It is mentioned as `/model-name-plural/{id}`.

But it should be `/model-name-plural/{id}/replace`.

Source code :
https://github.com/strongloop/loopback/blob/master/lib/persisted-model.js#L785