### PR TITLE
Specify the rule for eternal access tokens

### DIFF
--- a/pages/en/lb3/Model-definition-JSON-file.md
+++ b/pages/en/lb3/Model-definition-JSON-file.md
@@ -256,7 +256,7 @@ The `options` key specifies advanced options, for example data source-specific o
     <tr>
       <td><code>allowEternalTokens</code></td>
       <td>Boolean</td>
-      <td>Allow access tokens that never expire.</td>
+      <td>Allow access tokens created with <code>ttl = -1</code> never expire.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Currently, there's no documentation about the need of setting the access token with `ttl = -1` for it to be considered eternal, after setting `allowEternalTokens = true` on the User model.

Code reference on `access-token.js`: <https://github.com/strongloop/loopback/blob/master/common/models/access-token.js#L255> 

Maybe it could also help if the description says it should be set on the model the AccessToken model points to (which is usually an extension of the built-in User model).