### PR TITLE
Add rest-explorer to v4 readmes.

### DIFF
--- a/update-v4-readmes.sh
+++ b/update-v4-readmes.sh
@@ -15,6 +15,7 @@
 #
 (cat <<LIST_END
 strongloop loopback-next master packages/metadata/README.md
+strongloop loopback-next master packages/rest-explorer/README.md
 strongloop loopback-next master examples/todo/README.md
 strongloop loopback-next master examples/todo-list/README.md
 strongloop loopback-next master examples/soap-calculator/README.md


### PR DESCRIPTION
Update the script `update-v4-readmes.sh` to fetch README from `@loopback/rest-explorer`. See https://github.com/strongloop/loopback-next/pull/2014.

In the future, I would like to move this script into loopback-next, so that package READMEs are included in the tarball published to npmjs.

See also https://github.com/strongloop/loopback-next/issues/1960 and 
https://github.com/strongloop/loopback-next/issues/559.