### PR TITLE
Update Markdown-style-guide.md

### DIFF
--- a/pages/en/contrib/Markdown-style-guide.md
+++ b/pages/en/contrib/Markdown-style-guide.md
@@ -121,15 +121,18 @@ Always precede a code block with an empty line.
 
 Examples:
 
-INCORRECT: Jekyll will render the following block as inline code:
+<pre><code>INCORRECT: Jekyll will render the following block as inline code:
 ```js
-console.log('on no! No empty line above me :(');
+console.log('Oh no! No empty line above me :(');
 console.log('Oh well.')
 ```
+</code></pre>
 
-CORRECT: Works on BOTH GitHub and Jekyll:
+
+<pre><code>CORRECT: Works on BOTH GitHub and Jekyll:
 
 ```js
 console.log('I\'m preceded by an empty line!');
 console.log('Hooray!');
 ```
+</code></pre>


### PR DESCRIPTION
Fix markdown formatting of nested markdown examples.

Before my change, the content was rendered as follows:

<img width="865" alt="screen shot 2018-11-29 at 14 31 17" src="https://user-images.githubusercontent.com/1140553/49225100-77553a00-f3e3-11e8-8458-eaf3a6927e5c.png">
