### PR TITLE
Revert back to use Tealium as site analytics

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,9 +1,16 @@
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-125843766-2"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('set', 'anonymizeIp', true);
-  gtag('config', 'UA-125843766-2');
+<script type="text/javascript">
+  /* Define digital data object based on _appInfo object */
+  window.digitalData = {
+    page: {
+      category: {
+        primaryCategory: 'IBM_Cloud_GlobalMarketing',
+      },
+      pageInfo: {
+        ibm: {
+          siteID: 'Cloud',
+        }
+      },
+    }
+  };
 </script>
+<script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>


### PR DESCRIPTION
Revert back to use Tealium as site analytics
See related PR: https://github.com/strongloop/loopback.io/pull/738