### PR TITLE
Incorrect list of available operators for where filter

### DIFF
--- a/pages/en/lb3/Where-filter.md
+++ b/pages/en/lb3/Where-filter.md
@@ -185,7 +185,7 @@ This table describes the operators available in "where" filters. See [Examples]
 
 | Operator  | Description|
 | ------------- | ------------- |
-| = | Equivalence. See [examples](#equivalence) below.|
+| eq | Equivalence. See [examples](#equivalence) below.|
 | and | Logical AND operator. See [AND and OR operators](#and-and-or-operators) and [examples](#and--or) below.|
 | or | Logical OR operator. See [AND and OR operators](#and-and-or-operators) and [examples](#and--or) below.|
 | gt, gte | Numerical greater than (&gt;); greater than or equal (&gt;=). Valid only for numerical and date values. See [examples](#gt-and-lt) below. <br/><br/>  For Geopoint values, the units are in miles by default. See [Geopoint](http://apidocs.loopback.io/loopback-datasource-juggler/#geopoint) for more information.|
@@ -328,6 +328,7 @@ Equivalently, in Node:
 
 ```javascript
 Cars.find({ where: {carClass:'fullsize'} });
+Cars.find({ where: {carClass:{'eq':'fullsize'}} }); // full condition syntax
 ```
 
 ### gt and lt


### PR DESCRIPTION
Filter with "=" operator produces error (tested for mongodb)

Example:

```js
// query filter (incorrect)
{"where":{"categoryId":{"=":"21529"}}}
```

Request CURL: `curl -X GET --header 'Accept: application/json' 'http://localhost:3000/api/Products?filter=%7B%22where%22%3A%7B%22categoryId%22%3A%7B%22%3D%22%3A%2221529%22%7D%7D%7D'`

Request URI: `http://localhost:3000/api/Products?filter=%7B%22where%22%3A%7B%22categoryId%22%3A%7B%22%3D%22%3A%2221529%22%7D%7D%7D`

```js
// result
{
  "error": {
    "statusCode": 500,
    "name": "MongoError",
    "message": "unknown operator: $=",
    "ok": 0,
    "errmsg": "unknown operator: $=",
    "code": 2,
    "codeName": "BadValue",
    "stack": "MongoError: unknown operator: $=\n    at queryCallback (/home/ilya/webstorm-projects/loopback-api-server/node_modules/mongodb-core/lib/cursor.js:248:25)\n    at /home/ilya/webstorm-projects/loopback-api-server/node_modules/mongodb-core/lib/connection/pool.js:532:18\n    at _combinedTickCallback (internal/process/next_tick.js:132:7)\n    at process._tickDomainCallback (internal/process/next_tick.js:219:9)"
  }
}
```

Correct filter with for same condition:
```js
// query filter (correct, works fine)
{"where":{"categoryId":{"eq":"21529"}}}
// short syntax, also works fine
{"where":{"categoryId":"21529"}}
```

## enviroment
* loopback: 3.24.0
* loopback-datasource-juggler: 3.28.0

Mongodb connector settings:

```js
"mongodb": {
    "host": "${DEFAULT_MONGO_HOST}",
    "port": 27017,
    "url": false,
    "database": "${DEFAULT_MONGO_DATABASE}",
    "password": "${DEFAULT_MONGO_PASSWORD}",
    "name": "mongodb",
    "user": "${DEFAULT_MONGO_USER}",
    "connector": "mongodb",
    "allowExtendedOperators": true,
    "enableGeoIndexing": true
  }
```