### PR TITLE
docs: update lb3 prompt to lts

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -22,7 +22,7 @@ item: examples
 <span class="prompt">?</span> What's the name of your application? <span class="input">(office-supplies)</span>
 <span class="prompt">?</span> Enter name of the directory to contain the project: <span class="input">(office-supplies)</span>
 
-<span class="prompt">?</span> Which version of LoopBack would you like to use? 3.x (current)
+<span class="prompt">?</span> Which version of LoopBack would you like to use? 3.x (Active Long Term Support)
 <span class="prompt">?</span> What kind of application do you have in mind? <span class="input">empty-server (An empty LoopBack API,
   without any configured models or datasources)</span>
 ...

--- a/getting-started/index.html
+++ b/getting-started/index.html
@@ -36,7 +36,7 @@ item: getting-started
 <span class="prompt">?</span> What's the name of your application? <span class="input">hello-world</span>
 <span class="prompt">?</span> Enter name of the directory to contain the project: <span class="input">hello-world</span>
 
-<span class="prompt">?</span> Which version of LoopBack would you like to use? 3.x (current)
+<span class="prompt">?</span> Which version of LoopBack would you like to use? 3.x (Active Long Term Support)
 <span class="prompt">?</span> What kind of application do you have in mind? hello-world (A project containing a controller,
 including a single vanilla Message and a single remote method)
 ...

--- a/pages/en/lb3/readmes/loopback-example-connector-soap.md
+++ b/pages/en/lb3/readmes/loopback-example-connector-soap.md
@@ -86,7 +86,7 @@ The tool will create a directory with that name (`my-soap-demo`).
 1. `Enter name of the directory to contain the project:`
 <br/>Press Enter to accept the default (directory has the same name as the app).
 1. `Which version of LoopBack would you like to use?`
-<br/>Choose `3.x (current)`
+<br/>Choose `3.x (Active Long Term Support)`
 1. `What kind of application do you have in mind?`
 <br/>Choose `empty-server (An empty LoopBack API, without any configured models or datasources) `
 

--- a/pages/en/lb3/readmes/loopback-example-database.md
+++ b/pages/en/lb3/readmes/loopback-example-database.md
@@ -83,7 +83,7 @@ lb app loopback-example-database
 ? Enter name of the directory to contain the project: loopback-example-database
      info change the working directory to loopback-example-database
 
-? Which version of LoopBack would you like to use? 3.x (current)
+? Which version of LoopBack would you like to use? 3.x (Active Long Term Support)
 ? What kind of application do you have in mind? empty-server (An empty LoopBack API, without any c
 onfigured models or datasources)
 


### PR DESCRIPTION
Update docs to match CLI: `3.x (current)` --> `3.x (Active Long Term Support)`.