### PR TITLE
Fix typo and make code more readable

### DIFF
--- a/pages/en/lb3/Registering-users.md
+++ b/pages/en/lb3/Registering-users.md
@@ -95,17 +95,17 @@ module.exports = function(user) {
   user.afterRemote('create', function(context, userInstance, next) {
     console.log('> user.afterRemote triggered');
 
-    var options = {
+    var verifyOptions = {
       type: 'email',
       to: userInstance.email,
       from: 'noreply@loopback.com',
       subject: 'Thanks for registering.',
       template: path.resolve(__dirname, '../../server/views/verify.ejs'),
       redirect: '/verified',
-      user: user
+      user: userInstance
     };
 
-    userInstance.verify(options, function(err, response, next) {
+    userInstance.verify(verifyOptions, function(err, response, next) {
       if (err) return next(err);
 
       console.log('> verification email sent:', response);


### PR DESCRIPTION
Typo in: user -> userInstance
If you read the source code of loopback it can be a little confusing with parameters `options` and `verifyOptions`