### PR TITLE
Fix the third example on Remothe-hooks.md

### DIFF
--- a/pages/en/lb3/Remote-hooks.md
+++ b/pages/en/lb3/Remote-hooks.md
@@ -181,10 +181,10 @@ Customer.afterRemote('**', function (ctx, user, next) {
   if(ctx.result) {
     if(Array.isArray(ctx.result)) {
       ctx.result.forEach(function (result) {
-        delete result.password;
+        result.unsetAttribute('password');
       });
     } else {
-      delete ctx.result.password;
+      ctx.result.unsetAttribute('password');
     }
   }
 


### PR DESCRIPTION
Update the example according to what is said on #1816

While I was working whit an afterRemote Hook I tried to delete a
property of the results following the example in
https://loopback.io/doc/en/lb3/Remote-hooks#common/models/customer.js
(the second one) but it didn't worked for me, so I google it, and
I saw this closed issue strongloop/loopback#1816 and discovered that
I needed to use result.unsetAttribute('property_name') to do it…
so since the example didn't worked out I was thinking on send a pull
request changing that example.

Since I deleted the my fork of the project I remade the pull request
from a new fork.

close #772