### PR TITLE
Extend LB3 LTS

### DIFF
--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -21,11 +21,11 @@ The project maintains:
 
 Below is the LTS schedule on the LoopBack versions:
 
-Framework | Status | Published | EOL | Runtime | GA | EOL
--- | -- | -- | -- | -- | -- | --
-LoopBack 4 | Current | Oct 2018 | Apr 2021<br/>_(minimum)_| Node 10 | Oct 2018 | Apr 2021
-Loopback 3 | Active LTS | Dec 2016 | Dec 2019 |  Node 8 | Oct 2017 | Dec 2019
-Loopback 2 | Maintenance LTS | Jul 2014 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
+Framework | Status | Published | Active LTS Start | Maintenance LTS Start | EOL | Runtime | GA | EOL
+-- | -- | -- | -- | -- | -- | -- | -- | --
+LoopBack 4 | Current | Oct 2018 | -- | -- | Apr 2021 _(minimum)_| Node 10 | Oct 2018 | Apr 2021
+Loopback 3 | Active LTS | Dec 2016 | Oct 2018 | Dec 2019 | Dec 2020 |  Node 8 | Oct 2017 | Dec 2019
+Loopback 2 | Maintenance LTS | Jul 2014 | Dec 2016 | Oct 2018 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
 
 
 


### PR DESCRIPTION
We'll be extending the LTS period for LB3, so that it allows more time for our users to move to the new version which is a different programming model and language. It also allows us to improve the migration experience and migration guide.

From the LTS table, I've added the `Active LTS Start` and `Maintenance LTS Start` column, so that it's clearer on when the different LTS releases end. 