### PR TITLE
update lb3 docs link

### DIFF
--- a/_includes/overview/install.html
+++ b/_includes/overview/install.html
@@ -6,7 +6,7 @@
         <a class="v-button lb3">LoopBack 3<br>(Active LTS)</a>
         <ul class="v-descriptions">
           <li><a href="getting-started">Get started</a></li>
-          <li><a href="doc">Docs</a></li>
+          <li><a href="doc/en/lb3/">Docs</a></li>
         </ul>
       </div>
       <div class="v-block">


### PR DESCRIPTION
Since the `docs` link in the navigation bar already leads to https://loopback.io/doc/, the one under LoopBack 3 should lead to https://loopback.io/doc/en/lb3/. 