### PR TITLE
update LB2 reaches EOL

### DIFF
--- a/_includes/content/ja/v3notice.html
+++ b/_includes/content/ja/v3notice.html
@@ -1,2 +1,1 @@
-<div class="v3notice">This article is for LoopBack 2.x.  For the latest
-information or if you're using version 3, see the <a href="{{page.url | replace: 'lb2', 'lb3'}}">corresponding article for 3.x</a>.  </div>
+<div class="v3notice">This article is for LoopBack 2.x, which is no longer supported.  Please see the <a href="{{page.url | replace: 'lb2', 'lb3'}}">corresponding article for 3.x</a>.  </div>

--- a/_includes/content/v3notice.html
+++ b/_includes/content/v3notice.html
@@ -1,2 +1,1 @@
-<div class="v3notice">This article is for LoopBack 2.x.  For the latest
-information or if you're using version 3, see the <a href="{{page.url | replace: 'lb2', 'lb3'}}">corresponding article for 3.x</a>.  </div>
+<div class="v3notice">This article is for LoopBack 2.x, which is no longer supported.  Please see the <a href="{{page.url | replace: 'lb2', 'lb3'}}">corresponding article for 3.x</a>.  </div>

--- a/pages/en/contrib/LTS.md
+++ b/pages/en/contrib/LTS.md
@@ -24,8 +24,8 @@ Below is the LTS schedule on the LoopBack versions:
 Framework | Status | Published | Active LTS Start | Maintenance LTS Start | EOL | Runtime | GA | EOL
 -- | -- | -- | -- | -- | -- | -- | -- | --
 LoopBack 4 | Current | Oct 2018 | -- | -- | Apr 2021 _(minimum)_| Node 10 | Oct 2018 | Apr 2021
-Loopback 3 | Active LTS | Dec 2016 | Oct 2018 | Dec 2019 | Dec 2020 |  Node 8 | Oct 2017 | Dec 2019
-Loopback 2 | Maintenance LTS | Jul 2014 | Dec 2016 | Oct 2018 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
+LoopBack 3 | Active LTS | Dec 2016 | Oct 2018 | Dec 2019 | Dec 2020 |  Node 8 | Oct 2017 | Dec 2020
+LoopBack 2 | End-of-Life | Jul 2014 | Dec 2016 | Oct 2018 | Apr 2019 | Node 6 | Oct 2016 | Apr 2019
 
 
 

--- a/pages/en/lb2/index.md
+++ b/pages/en/lb2/index.md
@@ -8,7 +8,7 @@ keywords: LoopBack 2.x
 tags: [getting_started]
 sidebar: lb2_sidebar
 permalink: /doc/en/lb2/index.html
-summary: LoopBack 2.x is the maintenance long-term support (LTS) release.
+summary: LoopBack 2.x has reached end-of-life in April 2019. It is no longer supported.
 ---
 {% include important.html content="If you're new to LoopBack, use the current release,
 [LoopBack 4.0](/doc/en/lb4/index.html).


### PR DESCRIPTION
Related to https://github.com/strongloop/loopback/issues/4180

- Update the LB2 documentation that LB2 has reached end-of-life.
- Fixed the LB3 EOL date.  There's a recent announcement on extending LB3 LTS to Dec 2020.