### PR TITLE
helmet includeSubdomains param deprecated

### DIFF
--- a/pages/en/lb3/middleware.json.md
+++ b/pages/en/lb3/middleware.json.md
@@ -37,7 +37,7 @@ Here is the default version created by the [Application generator](Application-g
     "helmet#hsts": {
       "params": {
         "maxAge": 0,
-        "includeSubdomains": true
+        "includeSubDomains": true
       }
     },
     "helmet#hidePoweredBy": {},


### PR DESCRIPTION
includeSubdomains param deprecated and replaced by includeSubDomains (capital D)