### PR TITLE
change search page colour scheme

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -84,7 +84,7 @@ body h1 {margin-top:40px;}
 
 .lb-search-container {
   padding: 0 10px;
-  background-color: #72ac4a;
+  background-color: var(--color-blue-d);
 }
 
 .lb-search {
@@ -94,7 +94,7 @@ body h1 {margin-top:40px;}
 }
 
 .lb-search input {
-    color: #72ac4a;
+    color: var(--color-blue-d);
 }
 
 .search-bar::placeholder {
@@ -108,11 +108,11 @@ body h1 {margin-top:40px;}
 .resultList a.title {
     font-size: 18px;
     font-weight: bold;
-    color: #72ac4a;
+    color: var(--color-blue-d);
 }
 
 .resultList a.link {
-    color: #72ac4a;
+    color: var(--color-blue-d);
     display: block;
     margin-top: -5px;
     margin-bottom: 5px;
@@ -127,7 +127,7 @@ body h1 {margin-top:40px;}
 }
 
 .resultList li {
-    border-bottom: 1px solid #72ac4a;
+    border-bottom: 1px solid var(--color-blue-d);
     margin-bottom: 5px;
 }
 
@@ -138,7 +138,7 @@ body h1 {margin-top:40px;}
 }
 
 .pagination a {
-    color: #72ac4a;
+    color: var(--color-blue-d);
 }
 
 /* End of Search CSS */

--- a/css/lavish-bootstrap.css
+++ b/css/lavish-bootstrap.css
@@ -4063,8 +4063,8 @@ textarea.input-group-sm > .input-group-btn > .btn {
 .pagination > .active > span:focus {
   z-index: 2;
   color: #ffffff;
-  background-color: #74ab50;
-  border-color: #74ab50;
+  background-color: var(--color-blue-d);
+  border-color: var(--color-blue-d);
   cursor: default;
 }
 .pagination > .disabled > span,


### PR DESCRIPTION
Updated the colour scheme from v3 green to v4 blue for the search page. 

~Note: does anyone know where this search animation from:~
<img width="627" alt="Screen Shot 2019-05-29 at 11 56 17 AM" src="https://user-images.githubusercontent.com/42985749/58571971-d536d300-8208-11e9-999c-d8f6db47853e.png">

It's https://github.com/strongloop/loopback.io/blob/gh-pages/images/LB_Preloader.gif, but recolouring it would take a while so I'll leave it as is for now.