### PR TITLE
fix lb3 links

### DIFF
--- a/_includes/overview/install.html
+++ b/_includes/overview/install.html
@@ -10,9 +10,9 @@
         </ul>
       </div>
       <div class="v-block">
-        <a href="/lb3/" class="v-button">LoopBack 3<br>(LTS)</a>
+        <a href="/lb3" class="v-button">LoopBack 3<br>(LTS)</a>
         <ul class="v-descriptions">
-          <li><a href="getting-started">Get started</a></li>
+          <li><a href="/lb3/getting-started">Get started</a></li>
           <li><a href="https://loopback.io/doc/en/lb3/">Docs</a></li>
         </ul>
       </div>


### PR DESCRIPTION
The original links work when running the site locally, but not when it's on loopback.io.