### PR TITLE
docs: specify that declarative test demo is for LB 3.x

### DIFF
--- a/pages/en/community/Declarative-test-demo.md
+++ b/pages/en/community/Declarative-test-demo.md
@@ -4,7 +4,7 @@ keywords: automation, e2e, example, loopback, mocha, test
 tags: [community_project]
 sidebar: community_sidebar
 permalink: /doc/en/community/Declarative-test-demo.html
-summary: Example application that demonstrates using lb-declarative-e2e-test to write tests in an object definition style.
+summary: Example LoopBack 3.x application that demonstrates using lb-declarative-e2e-test to write tests in an object definition style.
 ---
 
 ## Links
@@ -16,6 +16,8 @@ Library used:
 [https://www.npmjs.com/package/lb-declarative-e2e-test](https://www.npmjs.com/package/lb-declarative-e2e-test)
 
 ## Overview
+
+This community-contributed component/example is for LoopBack 3.x
 
 This project showcase the different features of [`lb-declarative-e2e-test`](https://www.npmjs.com/package/lb-declarative-e2e-test):
 - Test hooks: `before`, `beforeEach`, `after`, `afterEach`
@@ -75,3 +77,4 @@ npm run test-watch
 ## Requirements
 
 - Node >= 8
+- LoopBack 3.x


### PR DESCRIPTION
Specify that the declarative test demo is for LoopBack 3.x

Related to : https://github.com/strongloop/loopback-next/issues/2940

This is about this link: https://loopback.io/doc/en/community/Declarative-test-demo.html 

I spoke with @bajtos about this community example, since it mentioned `Authenticated Requests`.
I am working on updating documents related to authentication.
I wasn't sure if this project was still in use, and so I asked @bajtos .

Miroslav looked into it, and It turns out it is only for LoopBack 3.x .

He suggested:

```
Miroslav Bajtos  [1 hour ago]
It would be great to update
https://github.com/strongloop/loopback.io/blob/gh-pages/pages/en/community/Declarative-test-demo.md 
to make it clear that this community-contributed component/example is for LB 3.x
```

