### PR TITLE
fix edit this page link

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,7 +13,7 @@ layout: default
        <a target="_blank" href="https://github.com/{{edit_url}}" class="btn btn-default githubEditButton" role="button"><i class="fa fa-github fa-lg"></i> Edit this page</a>
    {% endif %}
    {% if site.lb4_editme_path and page.layout != 'readme' and page.sidebar == 'lb4_sidebar' %}
-     {% assign edit_url =  page.url | remove: "doc/en/lb4" | remove: ".html" | append: ".md" | prepend: site.lb4_editme_path %}
+     {% assign edit_url =  page.url | remove: "doc/en/lb4/" | remove: ".html" | append: ".md" | prepend: site.lb4_editme_path %}
        <a target="_blank" href="https://github.com/{{edit_url}}" class="btn btn-default githubEditButton" role="button"><i class="fa fa-github fa-lg"></i> Edit this page</a>
    {% endif %}
 </div>


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/3214.

This fixes the issue where currently when pressing the "Edit this page" button, the links go to https://github.com/strongloop/loopback-next/blob/master/docs/site//{page} instead of https://github.com/strongloop/loopback-next/blob/master/docs/site/{page}.