### PR TITLE
open new tab for logo links

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,33 +208,33 @@
                 
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://godaddy.com/">
+                    <a href="https://godaddy.com/" target="_blank">
                         <img src="images/users/godaddy.png" width="90%"/>
                     </a>
                 </div>
                
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://www.symantec.com/">
+                    <a href="https://www.symantec.com/" target="_blank">
                         <img src="images/users/symantec.png" width="80%"/>
                     </a>
                 </div>
                 
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://www.ibm.com">
+                    <a href="https://www.ibm.com" target="_blank">
                         <img src="images/users/ibm-logo.png" width="70%"/>
                     </a>
                 </div>
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://www.energy.gov/">
+                    <a href="https://www.energy.gov/" target="_blank">
                         <img src="images/users/department-of-energy.jpeg" width="50%"/>
                     </a>
                 </div>
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://www.sourcefuse.com/">
+                    <a href="https://www.sourcefuse.com/" target="_blank">
                         <img src="images/users/SourceFuse_logo.png" width="95%"/>
                     </a>
                 </div>
@@ -243,25 +243,25 @@
             <div class="row text-center" style="justify-content: center">
                 <div class="col-md-3">
                     <span class="helper"></span>
-                    <a href="https://www.publicissapient.com/">
+                    <a href="https://www.publicissapient.com/" target="_blank">
                         <img src="images/users/sapient.png" width="50%"/>
                     </a>
                 </div>
                 <div class="col-md-3">
                     <span class="helper"></span>
-                    <a href="https://humansofcode.com/">
+                    <a href="https://humansofcode.com/" target="_blank">
                         <img src="images/users/hoc_logo_dark.png" width="90%"/>
                     </a>
                 </div>
                 <div class="col-md-3">
                     <span class="helper"></span>
-                    <a href="http://www.eycgrupo.com/">
+                    <a href="http://www.eycgrupo.com/" target="_blank">
                         <img src="images/users/eyc-logo.png" width="40%"/>
                     </a>
                 </div>
                 <div class="col-md-3">
                     <span class="helper"></span>
-                    <a href="https://www.fundrails.com/">
+                    <a href="https://www.fundrails.com/" target="_blank">
                         <img src="images/users/Fundrails-Logo.png" width="60%"/>
                     </a>
                 </div>
@@ -270,31 +270,31 @@
             <div class="row text-center" style="justify-content: center">
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://www.intellum.com/">
+                    <a href="https://www.intellum.com/" target="_blank">
                         <img src="images/users/intellum.jpg" width="80%"/>
                     </a>
                 </div>
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://flightoffice.com/">
+                    <a href="https://flightoffice.com/" target="_blank">
                         <img src="images/users/flight-office.png" width="80%"/>
                     </a>
                 </div>
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://tesera.com/">
+                    <a href="https://tesera.com/" target="_blank">
                         <img src="images/users/tesera.jpeg" width="80%"/>
                     </a>
                 </div>
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://www.viveat.com/en/"> 
+                    <a href="https://www.viveat.com/en/" target="_blank"> 
                         <img src="images/users/viveat.png" width="70%"/>
                     </a>
                 </div>
                 <div class="col-md-2">
                     <span class="helper"></span>
-                    <a href="https://www.shoppinpal.com/">
+                    <a href="https://www.shoppinpal.com/" target="_blank">
                         <img src="images/users/shoppin-pal.jpg" width="80%"/>
                     </a>
                 </div>


### PR DESCRIPTION
For company logos, it should open a new tab instead of reusing the same window.