### PR TITLE
add banner for APIWorld award

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,10 @@
 
         </div>
     </nav>
-    
+    <!--Header alert -->
+    <div class="header-alert">
+        <p class="centered-regular">LoopBack won API World's 2019 Best in API Middleware category, see <a href="https://strongloop.com/strongblog/loopback-2019-api-award-api-middleware/" target="_blank">our announcement post.</a></p>
+    </div>
     <!-- Header -->
     <div class="masthead">
         <div class="container-fluid"></div>


### PR DESCRIPTION
Add banner to promote the API World award: https://strongloop.com/strongblog/loopback-2019-api-award-api-middleware/

<img width="1056" alt="Screen Shot 2019-08-08 at 5 15 36 PM" src="https://user-images.githubusercontent.com/25489897/62738423-4ad8cf80-ba00-11e9-8f7c-2df5aba6f86d.png">
