### PR TITLE
Update notice at the top of LB4 documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ exclude:
   - update-readmes.sh
 # these are the files and directories that jekyll will exclude from the build
 
-feedback_email: rmckinn@us.ibm.com
+feedback_email: reachsl@us.ibm.com
 # used as a contact email for the Feedback link in the top navigation bar
 
 feedback_disable: true

--- a/_includes/content/v4notice.html
+++ b/_includes/content/v4notice.html
@@ -1,2 +1,2 @@
-<div class="v3notice" style="text-align:center;">LoopBack 4 GA (General Availability) has been released in October 2018, read more in <a href="http://strongloop.com/strongblog/loopback-4-ga">the announcement post</a>
+<div class="v3notice" style="text-align:center;">LoopBack won API World's 2019 Best in API Middleware category, see <a href="https://strongloop.com/strongblog/loopback-2019-api-award-api-middleware/">the announcement post.</a>
 </div>


### PR DESCRIPTION
In this PR (separate commits):
- Update notice at the top of LB4 documentation
- Update the `feedback_email` to the one used in strongloop.com, i.e. reachsl@us.ibm.com.  