### PR TITLE
Update LB4 contributing link and update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,8 @@ exclude:
   - node_modules
   - Jenkinsfile
   - update-readmes.sh
+  - vendor 
+  
 # these are the files and directories that jekyll will exclude from the build
 
 feedback_email: reachsl@us.ibm.com

--- a/_data/sidebars/contrib_sidebar.yml
+++ b/_data/sidebars/contrib_sidebar.yml
@@ -37,7 +37,7 @@ children:
       output: web, pdf
   
   - title: LoopBack 4
-    url: code-contrib-lb4.html
+    url: /doc/en/lb4/code-contrib-lb4.html
     output: web, pdf
     children:
 


### PR DESCRIPTION
There are 2 commits in this PR:
1. update the LB4 contributing link in sidebar.  This PR should be merged after we have published a new release in `loopback-next` and the link has been updated. 

2. update _config.yml. 
Currently when testing locally from `loopback-next` repo, there's an error.  According to the [troubleshooting docs in jekyll](https://jekyllrb.com/docs/troubleshooting/), adding `vendor` to `exclude` can fix this problem. 
```
Error: could not read file /Users/xxxx/loopback/loopback-next/sandbox/loopback.io/vendor/bundle/gems/jekyll-3.7.4/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/gems/jekyll-3.7.4/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/gems/jekyll-3.7.4/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.

```