### PR TITLE
fix: update page layout to use page.path for editing md files

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,7 +13,7 @@ layout: default
        <a target="_blank" href="https://github.com/{{edit_url}}" class="btn btn-default githubEditButton" role="button"><i class="fa fa-github fa-lg"></i> Edit this page</a>
    {% endif %}
    {% if site.lb4_editme_path and page.layout != 'readme' and page.sidebar == 'lb4_sidebar' %}
-     {% assign edit_url =  page.url | remove: "doc/en/lb4" | remove: ".html" | append: ".md" | prepend: site.lb4_editme_path %}
+     {% assign edit_url =  page.path | remove: "pages/en/lb4" | prepend: site.lb4_editme_path %}
        <a target="_blank" href="https://github.com/{{edit_url}}" class="btn btn-default githubEditButton" role="button"><i class="fa fa-github fa-lg"></i> Edit this page</a>
    {% endif %}
 </div>


### PR DESCRIPTION
Part 1 of the fix to https://github.com/strongloop/loopback-next/issues/3214.

In layout page.html, check if the `lb4_editme_path` in the front matter exists. If exists, use this value instead of the default edit path for the LB4 docs site. 

Part 2 is to update the front matter of the docs md files accordingly. 