### PR TITLE
Add rel=noopener when open new page

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -65,10 +65,10 @@
                     <a class="nav-link" href="openapi-to-graphql.html">GraphQL</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank">Blog</a>
+                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">Blog</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank">Test Your APIs</a>
+                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank" rel="noopener noreferrer">Test Your APIs</a>
                 </li>
             </ul>
         </div>
@@ -144,7 +144,7 @@
                 </div>
         
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://groups.google.com/forum/#!forum/loopbackjs" target="_blank">
+                    <a class="card-2" href="https://groups.google.com/forum/#!forum/loopbackjs" target="_blank" rel="noopener noreferrer">
                     <div class="row">
                         <div class="col-sm-3">
                             <img class="icon" src="images/contribute/devchat-icon-1x.png" alt="Chat icon"/>
@@ -214,13 +214,13 @@
                         <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
                     </p>
                     <p class="regular">
-                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank">API Docs</a>
+                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
                     <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank">StrongLoop Blog</a>
+                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
                     </p> 
                     <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank">API Connect</a>
+                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
                     </p>
                 </div>
             </div>

--- a/getting-started-openapi-to-graphql.html
+++ b/getting-started-openapi-to-graphql.html
@@ -71,10 +71,10 @@ redirect_from: /getting-started-oasgraph
                     <a class="nav-link" href="openapi-to-graphql.html">GraphQL</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank">Blog</a>
+                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">Blog</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank">Test Your APIs</a>
+                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank" rel="noopener noreferrer">Test Your APIs</a>
                 </li>
             </ul>
 
@@ -100,7 +100,7 @@ redirect_from: /getting-started-oasgraph
           </div>
           <div class="col-md-6">
             <div class="col-md-6">
-              <a class="btn btn-secondary" style="padding-left:60px; padding-right:60px; top: 20%" role="button" href="https://nodejs.org/en/download/" target="_blank">Install Node.js</a>
+              <a class="btn btn-secondary" style="padding-left:60px; padding-right:60px; top: 20%" role="button" href="https://nodejs.org/en/download/" target="_blank" rel="noopener noreferrer">Install Node.js</a>
             </div>
           </div>
         </div>
@@ -217,13 +217,13 @@ redirect_from: /getting-started-oasgraph
                         <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
                     </p>
                     <p class="regular">
-                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank">API Docs</a>
+                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
                     <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank">StrongLoop Blog</a>
+                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
                     </p> 
                     <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank">API Connect</a>
+                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
                     </p>
                 </div>
             </div>

--- a/getting-started.html
+++ b/getting-started.html
@@ -64,10 +64,10 @@
                     <a class="nav-link" href="openapi-to-graphql.html">GraphQL</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank">Blog</a>
+                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">Blog</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank">Test Your APIs</a>
+                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank" rel="noopener noreferrer">Test Your APIs</a>
                 </li>
             </ul>
 
@@ -97,7 +97,7 @@
                         runtime. </p>
                 </div>
                 <div class="col-md-6">
-                    <a class="btn btn-secondary" style="padding-left:60px; padding-right:60px; top: 20%" role="button" href="https://nodejs.org/en/download/" target="_blank">Install Node.js</a>
+                    <a class="btn btn-secondary" style="padding-left:60px; padding-right:60px; top: 20%" role="button" href="https://nodejs.org/en/download/" target="_blank" rel="noopener noreferrer">Install Node.js</a>
                 </div>
             </div>
         </div>
@@ -256,7 +256,7 @@ Controller Hello was now created in src/controllers/
                     </p>
                 </div>
                 <div class="col-md-6">
-                    Visit <a class="link" href="http://127.0.0.1:3000/hello" target="_blank">http://127.0.0.1:3000/hello</a> to see <code>Hello world!</code>
+                    Visit <a class="link" href="http://127.0.0.1:3000/hello" target="_blank" rel="noopener noreferrer">http://127.0.0.1:3000/hello</a> to see <code>Hello world!</code>
                 </div>
             </div>
         </div>
@@ -309,13 +309,13 @@ Controller Hello was now created in src/controllers/
                         <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
                     </p>
                     <p class="regular">
-                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank">API Docs</a>
+                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
                     <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank">StrongLoop Blog</a>
+                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
                     </p> 
                     <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank">API Connect</a>
+                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
                     </p>
                 </div>
             </div>

--- a/openapi-to-graphql.html
+++ b/openapi-to-graphql.html
@@ -70,10 +70,10 @@ redirect_from: /oasgraph
                     <a class="nav-link highlighted" href="openapi-to-graphql.html">GraphQL</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank">Blog</a>
+                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">Blog</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank">Test Your APIs</a>
+                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank" rel="noopener noreferrer">Test Your APIs</a>
                 </li>
             </ul>
         </div>
@@ -130,7 +130,7 @@ redirect_from: /oasgraph
             <img class="feature-image" src="images/openapi-to-graphql/authentication-2x.png" alt="Icon depicting authentication"/>
             <h4>Authentication</h4>
             <p>
-              OpenAPI-to-GraphQL provides <em>viewers</em> to support passing API keys or basic auth credentials. OAuth 2.0 integration can be handled by the hosting application (<a href="https://github.com/ibm/openapi-to-graphql/tree/master/packages/openapi-to-graphql#authentication" target="_blank">learn more...</a>).
+              OpenAPI-to-GraphQL provides <em>viewers</em> to support passing API keys or basic auth credentials. OAuth 2.0 integration can be handled by the hosting application (<a href="https://github.com/ibm/openapi-to-graphql/tree/master/packages/openapi-to-graphql#authentication" target="_blank" rel="noopener noreferrer">learn more...</a>).
             </p>
           </div>
         </div>
@@ -170,7 +170,7 @@ redirect_from: /oasgraph
 
             <div class="row text-center" style="justify-content: center">
               <div class="col-sm-12 col-md-6">
-                <a class="openapi-to-graphql-card" href="https://strongloop.com/strongblog/" target="_blank">
+                <a class="openapi-to-graphql-card" href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">
                   <div class="row">
                     <div class="col-sm-3">
                       <img class="help-image" src="images/openapi-to-graphql/blog-posts-2x.png" alt="Icon depicting blog"/>
@@ -184,7 +184,7 @@ redirect_from: /oasgraph
               </div>
 
               <div class="col-sm-12 col-md-6">
-                <a class="openapi-to-graphql-card" href="https://github.com/ibm/openapi-to-graphql" target="_blank">
+                <a class="openapi-to-graphql-card" href="https://github.com/ibm/openapi-to-graphql" target="_blank" rel="noopener noreferrer">
                   <div class="row">
                     <div class="col-sm-3">
                       <img class="help-image" src="images/openapi-to-graphql/git-repository-2x.png" alt="Icon depicting Git repository"/>
@@ -234,13 +234,13 @@ redirect_from: /oasgraph
                         <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
                     </p>
                     <p class="regular">
-                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank">API Docs</a>
+                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
                     <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank">StrongLoop Blog</a>
+                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
                     </p> 
                     <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank">API Connect</a>
+                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
                     </p>
                 </div>
             </div>

--- a/resources.html
+++ b/resources.html
@@ -65,10 +65,10 @@
                     <a class="nav-link" href="openapi-to-graphql.html">GraphQL</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank">Blog</a>
+                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">Blog</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank">Test Your APIs</a>
+                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank" rel="noopener noreferrer">Test Your APIs</a>
                 </li>
             </ul>
         </div>
@@ -111,7 +111,7 @@
                 </div>
     
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://github.com/strongloop/loopback-next/issues" target="_blank">
+                    <a class="card-2" href="https://github.com/strongloop/loopback-next/issues" target="_blank" rel="noopener noreferrer">
                     <div class="row">
                         <div class="col-sm-3">
                             <img class="icon" src="images/resources/issue-icon-1x.png" alt="Issues icon"/>
@@ -127,7 +127,7 @@
 
             <div class="row text-center" style="justify-content: center">
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://gitter.im/strongloop/loopback" target="_blank">
+                    <a class="card-2" href="https://gitter.im/strongloop/loopback" target="_blank" rel="noopener noreferrer">
                     <div class="row">
                         <div class="col-sm-3">
                             <img class="icon" src="images/resources/devchat-icon-1x.png" alt="Chat room icon"/>
@@ -141,7 +141,7 @@
                 </div>
     
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md" target="_blank">
+                    <a class="card-2" href="https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">
                     <div class="row">
                         <div class="col-sm-3">
                             <img class="icon" src="images/resources/contribute-icon-1x.png" alt="Contribute icon"/>
@@ -171,7 +171,7 @@
 
             <div class="row text-center" style="justify-content: center">
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="/doc/en/lb4/Extending-LoopBack-4.html" target="_blank">
+                    <a class="card-2" href="/doc/en/lb4/Extending-LoopBack-4.html" target="_blank" rel="noopener noreferrer">
                         <div class="row">
                             <div class="col-sm-3">
                                 <img class="icon" src="images/resources/extension-icon-1x.png" alt="Extension Icon"/>
@@ -238,21 +238,21 @@
 
             <div class="row text-center" style="justify-content: center">
                 <div class="col-md-4">
-                    <a id="link1" class="card-3" target="_blank">
+                    <a id="link1" class="card-3" target="_blank" rel="noopener noreferrer">
                         <h5 id="post1" class="card-title"></h5>
                         <p id="date1" class="regular text-gray date"></p>
                     </a>
                 </div>
 
                 <div class="col-md-4">
-                    <a id="link2" class="card-3" target="_blank">
+                    <a id="link2" class="card-3" target="_blank" rel="noopener noreferrer">
                         <h5 id="post2" class="card-title"></h5>
                         <p id="date2" class="regular text-gray date"></p>
                     </a>
                 </div>
 
                 <div class="col-md-4">
-                    <a id="link3" class="card-3" target="_blank">
+                    <a id="link3" class="card-3" target="_blank" rel="noopener noreferrer">
                         <h5 id="post3" class="card-title"></h5>
                         <p id="date3" class="regular text-gray date"></p>
                     </a>
@@ -260,21 +260,21 @@
             </div>
             <div class="row text-center" style="justify-content: center">
                 <div class="col-md-4">
-                    <a id="link4" class="card-3" target="_blank">
+                    <a id="link4" class="card-3" target="_blank" rel="noopener noreferrer">
                         <h5 id="post4" class="card-title"></h5>
                         <p id="date4" class="regular text-gray date"></p>
                     </a>
                 </div>
 
                 <div class="col-md-4">
-                    <a id="link5" class="card-3" target="_blank">
+                    <a id="link5" class="card-3" target="_blank" rel="noopener noreferrer">
                         <h5 id="post5" class="card-title"></h5>
                         <p id="date5" class="regular text-gray date"></p>
                     </a>
                 </div>
 
                 <div class="col-md-4">
-                    <a id="link6" class="card-3" target="_blank">
+                    <a id="link6" class="card-3" target="_blank" rel="noopener noreferrer">
                         <h5 id="post6" class="card-title"></h5>
                         <p id="date6" class="regular text-gray date"></p>
                     </a>
@@ -285,7 +285,7 @@
             <div>
                 <div class="row text-center" style="justify-content: center">
                     <h6 style="margin-top: 18px; padding-right: 6px;">OLDER</h6>
-                    <a href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank">
+                    <a href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">
                         <img class="navigation" src="images/resources/forward_32.svg" alt="Forward button" height="23" width="23"
                             style="margin-top:18px;">
                     </a>
@@ -315,7 +315,7 @@
                                 <div class="col-sm-9">
                                     <h5 class="card-title no-link">REST APIs in Minutes with LoopBack 4</h5>
                                     <p class="regular text-gray" style="margin-bottom: 8px;">Janny Hou | Toronto Meetup 2019</p> 
-                                    <a href="https://www.slideshare.net/DaveWhiteley1/2019-02-05-toronto-cloud-integration-meetup" target="_blank"
+                                    <a href="https://www.slideshare.net/DaveWhiteley1/2019-02-05-toronto-cloud-integration-meetup" target="_blank" rel="noopener noreferrer"
                                         onclick="window.open('https://www.slideshare.net/DaveWhiteley1/2019-02-05-toronto-cloud-integration-meetup')">
                                         <div class="row">
                                             <img class="icon slides-icon" src="images/resources/slideshare-brands.svg" alt="Slideshare icon"/>
@@ -325,7 +325,7 @@
                                 </div>
                             </div>
                         </div>
-                        <a class="card-2 pres" href="https://www.youtube.com/watch?v=W5u_YF96q6o&list=PL2I5I38o2kSCPCIxd8IjzYAMZnxcy3BYo&index=3&t=0s" target="_blank">
+                        <a class="card-2 pres" href="https://www.youtube.com/watch?v=W5u_YF96q6o&list=PL2I5I38o2kSCPCIxd8IjzYAMZnxcy3BYo&index=3&t=0s" target="_blank" rel="noopener noreferrer">
                             <div class="col-sm-12 row">
                                 <div class="col-sm-3">
                                     <img class="icon" src="images/resources/play_128.svg" alt="Play icon"/>
@@ -336,7 +336,7 @@
                                 </div>
                             </div>
                         </a>
-                        <a class="card-2 pres" href="https://jsi2018.sched.com/event/HYVB?iframe=no" target="_blank">
+                        <a class="card-2 pres" href="https://jsi2018.sched.com/event/HYVB?iframe=no" target="_blank" rel="noopener noreferrer">
                             <div class="col-sm-12 row">
                                 <div class="col-sm-3">
                                     <img class="icon" src="images/resources/slideshare-brands.svg" alt="Slideshare icon"/>
@@ -352,7 +352,7 @@
 
                 <div class="col-md-6">
                     <p style="height: 6px;"></p>
-                    <a class="card-2 pres" href="http://www.nodesummit.com/prior-video/node-summit-2018-async-functions-in-practice-miroslav-bajtos/" target="_blank">
+                    <a class="card-2 pres" href="http://www.nodesummit.com/prior-video/node-summit-2018-async-functions-in-practice-miroslav-bajtos/" target="_blank" rel="noopener noreferrer">
                         <div class="row">
                             <div class="col-sm-3">
                                 <img class="icon" src="images/resources/play_128.svg" alt="Play icon"/>
@@ -363,7 +363,7 @@
                             </div>
                         </div>
                     </a>
-                    <a class="card-2 pres" href="http://www.nodesummit.com/prior-video/node-summit-2018-the-art-of-extensibility-and-composability-taranveer-virk/" target="_blank">
+                    <a class="card-2 pres" href="http://www.nodesummit.com/prior-video/node-summit-2018-the-art-of-extensibility-and-composability-taranveer-virk/" target="_blank" rel="noopener noreferrer">
                         <div class="row">
                             <div class="col-sm-3">
                                 <img class="icon" src="images/resources/play_128.svg" alt="Play icon"/>
@@ -432,13 +432,13 @@
                         <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
                     </p>
                     <p class="regular">
-                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank">API Docs</a>
+                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
                     <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank">StrongLoop Blog</a>
+                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
                     </p> 
                     <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank">API Connect</a>
+                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Follow up task for comment from @hacksparrow in https://github.com/strongloop/loopback.io/pull/884#discussion_r325162615, adding the `rel="noopener noreferrer"` for other main pages of the site.

> ... target="_blank" rel="noopener noreferrer">
> Likewise, for all other links opening a new window. Why? Links to cross-origin destinations are unsafe.
https://developers.google.com/web/tools/lighthouse/audits/noopener