### PR TITLE
Change site analytics to GA

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,16 +1,8 @@
-<script type="text/javascript">
-  /* Define digital data object based on _appInfo object */
-  window.digitalData = {
-    page: {
-      category: {
-        primaryCategory: 'IBM_Cloud_GlobalMarketing',
-      },
-      pageInfo: {
-        ibm: {
-          siteID: 'Cloud',
-        }
-      },
-    }
-  };
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-150726441-2');
 </script>
-<script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>

--- a/contribute.html
+++ b/contribute.html
@@ -17,23 +17,14 @@
     <link href="css/contribute.css" rel="stylesheet">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <!-- Site Analytics -->
-    <script type="text/javascript">
-        /* Define digital data object based on _appInfo object */
-        window.digitalData = {
-            page: {
-                category: {
-                    primaryCategory: 'IBM_Cloud_GlobalMarketing',
-                },
-                pageInfo: {
-                    ibm: {
-                        siteID: 'Cloud',
-                    }
-                },
-            }
-        };
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-150726441-2');
     </script>
-    <script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/getting-started-openapi-to-graphql.html
+++ b/getting-started-openapi-to-graphql.html
@@ -23,23 +23,15 @@ redirect_from: /getting-started-oasgraph
     <link href="css/getting-started.css" rel="stylesheet">
     <link href="css/openapi-to-graphql.css" rel="stylesheet">
 
-    <!-- Site Analytics -->
-    <script type="text/javascript">
-        /* Define digital data object based on _appInfo object */
-        window.digitalData = {
-            page: {
-                category: {
-                    primaryCategory: 'IBM_Cloud_GlobalMarketing',
-                },
-                pageInfo: {
-                    ibm: {
-                        siteID: 'Cloud',
-                    }
-                },
-            }
-        };
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-150726441-2');
     </script>
-    <script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>
+
 </head>
 
 <body>

--- a/getting-started.html
+++ b/getting-started.html
@@ -16,23 +16,14 @@
     <link href="css/loopback.css" rel="stylesheet">
     <link href="css/getting-started.css" rel="stylesheet">
 
-    <!-- Site Analytics -->
-    <script type="text/javascript">
-        /* Define digital data object based on _appInfo object */
-        window.digitalData = {
-            page: {
-                category: {
-                    primaryCategory: 'IBM_Cloud_GlobalMarketing',
-                },
-                pageInfo: {
-                    ibm: {
-                        siteID: 'Cloud',
-                    }
-                },
-            }
-        };
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script>
+       window.dataLayer = window.dataLayer || [];
+       function gtag(){dataLayer.push(arguments);}
+       gtag('js', new Date());
+       gtag('config', 'UA-150726441-2');
     </script>
-    <script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -14,23 +14,14 @@
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans" rel="stylesheet">
     <link href="css/loopback.css" rel="stylesheet">
 
-    <!-- Site Analytics -->
-    <script type="text/javascript">
-        /* Define digital data object based on _appInfo object */
-        window.digitalData = {
-            page: {
-                category: {
-                    primaryCategory: 'IBM_Cloud_GlobalMarketing',
-                },
-                pageInfo: {
-                    ibm: {
-                        siteID: 'Cloud',
-                    }
-                },
-            }
-        };
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script>
+       window.dataLayer = window.dataLayer || [];
+       function gtag(){dataLayer.push(arguments);}
+       gtag('js', new Date());
+       gtag('config', 'UA-150726441-2');
     </script>
-    <script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/openapi-to-graphql.html
+++ b/openapi-to-graphql.html
@@ -22,23 +22,14 @@ redirect_from: /oasgraph
     <link href="css/loopback.css" rel="stylesheet">
     <link href="css/openapi-to-graphql.css" rel="stylesheet">
 
-    <!-- Site Analytics -->
-    <script type="text/javascript">
-        /* Define digital data object based on _appInfo object */
-        window.digitalData = {
-            page: {
-                category: {
-                    primaryCategory: 'IBM_Cloud_GlobalMarketing',
-                },
-                pageInfo: {
-                    ibm: {
-                        siteID: 'Cloud',
-                    }
-                },
-            }
-        };
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script>
+       window.dataLayer = window.dataLayer || [];
+       function gtag(){dataLayer.push(arguments);}
+       gtag('js', new Date());
+       gtag('config', 'UA-150726441-2');
     </script>
-    <script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/resources.html
+++ b/resources.html
@@ -17,23 +17,14 @@
     <link href="css/resources.css" rel="stylesheet">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <!-- Site Analytics -->
-    <script type="text/javascript">
-        /* Define digital data object based on _appInfo object */
-        window.digitalData = {
-            page: {
-                category: {
-                    primaryCategory: 'IBM_Cloud_GlobalMarketing',
-                },
-                pageInfo: {
-                    ibm: {
-                        siteID: 'Cloud',
-                    }
-                },
-            }
-        };
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script>
+       window.dataLayer = window.dataLayer || [];
+       function gtag(){dataLayer.push(arguments);}
+       gtag('js', new Date());
+       gtag('config', 'UA-150726441-2');
     </script>
-    <script src="//1.www.s81c.com/common/stats/ida_stats.js" type="text/javascript"></script>
 </head>
 
 <body>


### PR DESCRIPTION
We have an approved tracking ID for Google Analytics for the site analytics, so can switch back to it now! 
Thanks @DaveYVR!

Reviewers: We have done something similar before, see this PR https://github.com/strongloop/v4.loopback.io/pull/36 as a reference. 