### PR TITLE
add google_analytics id to config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,8 @@ github_editme_path: strongloop/loopback.io/blob/gh-pages/pages
 
 lb4_editme_path: strongloop/loopback-next/blob/master/docs/site
 
+google_analytics: UA-150726441-2
+
 disqus_shortname:
 # if you're using disqus for comments, add the shortname here. if not, leave this value blank.
 


### PR DESCRIPTION
The Google Analytics data is not showing up, it might be because the tracking id is missing in `_config.yml`. 

Reference PR: https://github.com/strongloop/loopback.io/pull/419/