### PR TITLE
fix spaces for GA scripts

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,8 +1,9 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
+
   gtag('config', 'UA-150726441-2');
 </script>

--- a/contribute.html
+++ b/contribute.html
@@ -18,13 +18,15 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'UA-150726441-2');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-150726441-2');
     </script>
+
 </head>
 
 <body>

--- a/getting-started-openapi-to-graphql.html
+++ b/getting-started-openapi-to-graphql.html
@@ -24,11 +24,12 @@ redirect_from: /getting-started-oasgraph
     <link href="css/openapi-to-graphql.css" rel="stylesheet">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
+
       gtag('config', 'UA-150726441-2');
     </script>
 

--- a/getting-started.html
+++ b/getting-started.html
@@ -17,12 +17,13 @@
     <link href="css/getting-started.css" rel="stylesheet">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
     <script>
-       window.dataLayer = window.dataLayer || [];
-       function gtag(){dataLayer.push(arguments);}
-       gtag('js', new Date());
-       gtag('config', 'UA-150726441-2');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-150726441-2');
     </script>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -15,13 +15,15 @@
     <link href="css/loopback.css" rel="stylesheet">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
     <script>
-       window.dataLayer = window.dataLayer || [];
-       function gtag(){dataLayer.push(arguments);}
-       gtag('js', new Date());
-       gtag('config', 'UA-150726441-2');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-150726441-2');
     </script>
+
 </head>
 
 <body>

--- a/openapi-to-graphql.html
+++ b/openapi-to-graphql.html
@@ -23,12 +23,13 @@ redirect_from: /oasgraph
     <link href="css/openapi-to-graphql.css" rel="stylesheet">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
     <script>
-       window.dataLayer = window.dataLayer || [];
-       function gtag(){dataLayer.push(arguments);}
-       gtag('js', new Date());
-       gtag('config', 'UA-150726441-2');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-150726441-2');
     </script>
 </head>
 

--- a/resources.html
+++ b/resources.html
@@ -18,12 +18,13 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src=“https://www.googletagmanager.com/gtag/js?id=UA-150726441-2“></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
     <script>
-       window.dataLayer = window.dataLayer || [];
-       function gtag(){dataLayer.push(arguments);}
-       gtag('js', new Date());
-       gtag('config', 'UA-150726441-2');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-150726441-2');
     </script>
 </head>
 


### PR DESCRIPTION
Google Analytics still not working.  Read from https://support.google.com/analytics/answer/1009683?hl=en that they need precise formatting for it to work.  So I'm copying and pasting the code snippet without removing the extra line this time. It also realized the quotation marks are different. 