### PR TITLE
chore: exclude infrastructure files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,11 +39,16 @@ port: 4001
 exclude:
   - .idea/
   - .gitignore
+  - CODEOWNERS
+  - ISSUE_TEMPLATE.md
+  - package.json
   - node_modules
   - Jenkinsfile
   - update-readmes.sh
-  - vendor 
-  
+  - update-community-readmes.sh
+  - update-lb4-docs.js
+  - vendor
+
 # these are the files and directories that jekyll will exclude from the build
 
 feedback_email: reachsl@us.ibm.com


### PR DESCRIPTION
Exclude the following files from the public website:

 - CODEOWNERS
 - ISSUE_TEMPLATE.md
 - package.json
 - update-community-readmes.sh
 - update-lb4-docs.js

Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>

Loosely related: https://github.com/strongloop/loopback-next/issues/1310