### PR TITLE
Fixes inconsistent naming.

### DIFF
--- a/pages/en/lb4/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/pages/en/lb4/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -187,7 +187,7 @@ export class TodoController {
 }
 ```
 
-Modify `createTodo` method to look up the address provided in `remindAtAddress`
+Modify `create` method to look up the address provided in `remindAtAddress`
 property and convert it to GPS coordinates stored in `remindAtGeo`.
 
 {% include code-caption.html content="src/controllers/todo.controller.ts" %}
@@ -204,7 +204,7 @@ export class TodoController {
       },
     },
   })
-  async createTodo(
+  async create(
     @requestBody({
       content: {
         'application/json': {


### PR DESCRIPTION
After following all steps of the tutorial user ends up with `create` method name, not with the  `createTodo` one.
But there are no references of `createTodo` on previous pages/steps.
That's why it looks confusing.