### PR TITLE
remove GA blog post link in index.md

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -20,7 +20,6 @@ Getting Started with Node for:
 This site contains documentation for:
 
 - **[LoopBack 4](en/lb4)** - Current release. <br/> 
-_LoopBack 4 GA (General Availability) has been released in October 2018, read more in the [announcement post](http://strongloop.com/strongblog/loopback-4-ga)_
 - **[LoopBack 3.x](en/lb3)** - Active LTS. _Details can be found in our [LTS plan](en/contrib/Long-term-support.html)._
 - **[LoopBack 2.x](en/lb2)** - Maintenance LTS. _Details can be found in our [LTS plan](en/contrib/Long-term-support.html)._
 - **[Contributing to LoopBack](en/contrib/)** - How to contribute to the LoopBack project.


### PR DESCRIPTION
Remove the GA blog post link in https://loopback.io/doc/index.html. 
We've removed that link in the docs header, and this one should be updated too. 