### PR TITLE
fix search result attributes

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -83,7 +83,7 @@
         $('input[name="sidebar"]').val(queryObj.sidebar);
     }
 
-    var urlBase = "https://openwhisk.ng.bluemix.net/api/v1/web/slbld%40ca.ibm.com_loopback/default/search.json?";
+    var urlBase = "https://us-south.functions.cloud.ibm.com/api/v1/web/dhmlau%40ca.ibm.com_dev/default/search.json?";
     var url = urlBase + query;
 
     $.get(url).done(function(data) {
@@ -99,8 +99,11 @@
             t = escapeHTML(t);
           });
 
-          html += '<li><a class="title" href="' + escapeHTML(res.metadata.url) + '">' + escapeHTML(res.metadata.title) + '</a><br/>';
-          html += '<a class="link" href="' + escapeHTML(res.metadata.url) + '">' + window.location.protocol + '//' + window.location.host + escapeHTML(res.metadata.url) + '</a>';
+          var displayedTitle = escapeHTML(res.extracted_metadata.title);
+          displayedTitle = displayedTitle.slice(0, displayedTitle.indexOf('|')!=-1? displayedTitle.indexOf('|'): displayedTitle.length);
+          
+          html += '<li><a class="title" href="' + escapeHTML(res.metadata.source.url) + '">' + displayedTitle + '</a><br/>';
+          html += '<a class="link" href="' + escapeHTML(res.metadata.source.url) + '">' + escapeHTML(res.metadata.source.url) + '</a>';
           html += '<p>' + res.highlight.text.splice(0, 3).join('<br/>') + '</p></li>';
         });
         html += '</ul>';


### PR DESCRIPTION
The search in loopback.io no longer working. There could be a few reasons: 
- the watson discovery service deployed on IBM Cloud is stopped 
- the cloud function which calls the watson discovery service was deployed using Node.js 8 according to Taranveer, so it might just stop working.

Since I am having some problem with logging into IBM Cloud using the account we had it set up, I'm using my own account. It is not ideal, but we can at least get things going. 

Regarding the changes:
- the endpoint is the URL for the cloud function, which in turns calls the discovery service. It is changed to use mine instead of using the old account
- the json returned by the service has changed, so the attribute values used for displaying are changed. There's been some breaking changes in the service, and the one we had haven't been updated for more than 1.5 years. 

Sample search result:
<img width="790" alt="Screen Shot 2020-01-14 at 3 36 46 PM" src="https://user-images.githubusercontent.com/25489897/72380571-b4fa4c80-36e3-11ea-9b2f-4fba10dbe69b.png">

Next step: 
- IIRC, if we're on a LB4 page, the search results will be on LB4 contents. Similarly for LB3 page as the starting point.  However, I wasn't able to get it to work yet.
- there are some changes in the cloud function. I'll submit a PR to https://github.com/strongloop/loopback.io-search soon.