### PR TITLE
add loopback-connector-ibmi readme to lb4 docs

### DIFF
--- a/update-readmes.sh
+++ b/update-readmes.sh
@@ -14,6 +14,7 @@ strongloop loopback-connector-cloudant master
 strongloop loopback-connector-dashdb master
 strongloop loopback-connector-db2 master
 strongloop loopback-connector-db2iseries master
+strongloop loopback-connector-ibmi master
 strongloop loopback-connector-db2z master
 strongloop loopback-connector-grpc master
 strongloop loopback-connector-informix master


### PR DESCRIPTION
In preparation of the changes mentioned in https://github.com/strongloop/loopback-next/pull/4716#discussion_r383389474, this PR adds the [loopback-connector-ibmi](https://github.com/strongloop/loopback-connector-ibmi) to the list of READMEs to be copied to LB4. 