### PR TITLE
fix: remove line break from "important" alerts

### DIFF
--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,7 +1,6 @@
 <div markdown="1" class="alert alert-warning" role="alert">
   <i class="fa fa-warning"></i>
-  {% if include.title %}
-  <b>{{include.title}}</b>
-  {% else %}
-  <b>Important:</b>{% endif %} {{include.content}}
+  {% if include.title %}<b>{{include.title}}</b>
+  {% else %}<b>Important:</b>{% endif %}
+  {{include.content}}
 </div>


### PR DESCRIPTION
Before (notice the line break after the exclamation-mark-icon):

<img width="887" alt="Screen Shot 2020-03-02 at 14 33 43" src="https://user-images.githubusercontent.com/1140553/75680920-d5ca3180-5c92-11ea-89cd-242ebcb75f7b.png">

After:

<img width="885" alt="Screen Shot 2020-03-02 at 14 34 03" src="https://user-images.githubusercontent.com/1140553/75680968-eaa6c500-5c92-11ea-82a1-718c7cd8893f.png">

The trick is to format templating directives `{%` and `%}` in such way that we do not emit an empty newline after `<i>` element. The original version was producing a new line, which was interpreted by the markdown parser as a paragraph delimiter.