### PR TITLE
chore: enable stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - critical
+  - p1
+  - major
+  - good first issue
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been closed due to continued inactivity. Thank you for your understanding.
+  If you believe this to be in error, please contact one of the code owners,
+  listed in the `CODEOWNERS` file at the top-level of this repository.


### PR DESCRIPTION
Enable stalebot. The `stale.yml` is using https://github.com/strongloop/loopback-connector-postgresql/blob/master/.github/stale.yml as a reference.