### PR TITLE
add Db2 for i connector readme

### DIFF
--- a/pages/en/lb4/DB2-for-i-connector.md
+++ b/pages/en/lb4/DB2-for-i-connector.md
@@ -1,0 +1,11 @@
+---
+title: "DB2 for i connector"
+lang: en
+layout: readme
+source: loopback-connector-ibmi
+keywords: LoopBack
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/DB2-for-i-connector.html
+summary: The loopback-connector-ibmi connector enables LoopBack applications to connect to IBM® DB2® for i data sources.
+---

--- a/pages/en/lb4/DB2-for-z-OS-connector.md
+++ b/pages/en/lb4/DB2-for-z-OS-connector.md
@@ -6,6 +6,6 @@ source: loopback-connector-db2z
 keywords: LoopBack
 tags: [connectors, readme]
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/DB2-for-z-OS.html
+permalink: /doc/en/lb4/DB2-for-z-OS-connector.html
 summary: The loopback-connector-db2z connector enables LoopBack applications to connect to IBM® DB2® for z/OS® data sources.
 ---


### PR DESCRIPTION
The [loopback-connector-ibmi](https://github.com/strongloop/loopback-connector-ibmi) readme is being copied to https://github.com/strongloop/loopback.io/tree/gh-pages/pages/en/lb4/readmes. It needs a md file under the `en/lb4` folder.