### PR TITLE
fix: add ibm i readme to lb3

### DIFF
--- a/pages/en/lb3/DB2-connector.md
+++ b/pages/en/lb3/DB2-connector.md
@@ -1,5 +1,5 @@
 ---
-title: "DB2 connector"
+title: "IBM Db2 connector"
 lang: en
 layout: readme
 source: loopback-connector-db2
@@ -7,5 +7,5 @@ keywords: LoopBack
 tags: [connectors, readme]
 sidebar: lb3_sidebar
 permalink: /doc/en/lb3/DB2-connector.html
-summary: The DB2 connector enables LoopBack applications to connect to DB2 data sources. 
+summary: The Db2 connector enables LoopBack applications to connect to Db2 data sources. 
 ---

--- a/pages/en/lb3/DB2-for-i.md
+++ b/pages/en/lb3/DB2-for-i.md
@@ -1,0 +1,11 @@
+---
+title: "IBM Db2 for i connector"
+lang: en
+layout: readme
+source: loopback-connector-ibmi
+keywords: LoopBack
+tags: [connectors, readme]
+sidebar: lb3_sidebar
+permalink: /doc/en/lb3/DB2-for-i-connector.html
+summary: The loopback-connector-ibmi connector enables LoopBack applications to connect to IBM® DB2® for i data sources.
+---

--- a/pages/en/lb3/DB2-for-z-OS.md
+++ b/pages/en/lb3/DB2-for-z-OS.md
@@ -1,11 +1,11 @@
 ---
-title: "DB2 for z/OS connector"
+title: "IBM Db2 for z/OS connector"
 lang: en
 layout: readme
 source: loopback-connector-db2z
 keywords: LoopBack
 tags: [connectors, readme]
 sidebar: lb3_sidebar
-permalink: /doc/en/lb3/DB2-for-z-OS.html
-summary: The loopback-connector-db2z connector enables LoopBack applications to connect to IBM® DB2® for z/OS® data sources.
+permalink: /doc/en/lb3/DB2-for-z-OS-connector.html
+summary: The loopback-connector-db2z connector enables LoopBack applications to connect to IBM® Db2® for z/OS® data sources.
 ---


### PR DESCRIPTION
In the [update-lb4-docs script](https://github.com/strongloop/loopback.io/blob/gh-pages/update-lb4-docs.js), it copies all the connector related md files from LB3 to LB4. Originally, `loopback-connector-ibmi` was added in the LB4 location only (https://github.com/strongloop/loopback.io/tree/gh-pages/pages/en/lb4) but got overwritten. So I'm adding this to the LB3 location as well. 