### PR TITLE
fix: rename connector md file for update-lb4-docs script

### DIFF
--- a/pages/en/lb3/DB2-for-i-connector.md
+++ b/pages/en/lb3/DB2-for-i-connector.md
@@ -1,0 +1,11 @@
+---
+title: "IBM Db2 for i connector"
+lang: en
+layout: readme
+source: loopback-connector-ibmi
+keywords: LoopBack
+tags: [connectors, readme]
+sidebar: lb3_sidebar
+permalink: /doc/en/lb3/DB2-for-i-connector.html
+summary: The loopback-connector-ibmi connector enables LoopBack applications to connect to IBM® Db2® for i data sources.
+---

--- a/pages/en/lb3/DB2-for-z-OS-connector.md
+++ b/pages/en/lb3/DB2-for-z-OS-connector.md
@@ -1,0 +1,11 @@
+---
+title: "IBM Db2 for z/OS connector"
+lang: en
+layout: readme
+source: loopback-connector-db2z
+keywords: LoopBack
+tags: [connectors, readme]
+sidebar: lb3_sidebar
+permalink: /doc/en/lb3/DB2-for-z-OS-connector.html
+summary: The loopback-connector-db2z connector enables LoopBack applications to connect to IBM® Db2® for z/OS® data sources.
+---


### PR DESCRIPTION
A follow up PR on https://github.com/strongloop/loopback.io/pull/946. It looks like the `update-lb4-docs.js` script are sensitive how files are named, otherwise it won't get copied! 

I've tested it locally that it's working. 
![Screen Shot 2020-03-18 at 3 50 11 PM](https://user-images.githubusercontent.com/25489897/77001354-31055080-6930-11ea-9d68-6966727c2ef4.png)
