### PR TITLE
feat: refactor user testimonial page

### DIFF
--- a/css/users.css
+++ b/css/users.css
@@ -1,0 +1,61 @@
+.r-masthead {
+    text-align: center;
+    color: var(--color-white);
+    background-image: linear-gradient(to bottom, #009cff, #3f5dff);
+    padding: 120px 0px 80px 0px;
+    z-index: 5;
+    position: relative;
+    overflow: hidden;
+}
+  
+.r-masthead .container-fluid {
+    position: absolute;
+    background-color: var(--color-blue);
+    background: url('../images/contribute/node-pattern-2x.png');
+
+    opacity: 0.8;
+    z-index: -1;
+    background-repeat: no-repeat;
+    background-attachment: scroll;
+    background-position: center center;
+    -webkit-background-size: cover;
+    -moz-background-size: cover;
+    -o-background-size: cover;
+    background-size: cover;
+    width: 100%;
+    padding: 350px;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+}
+
+.r-masthead .header-space {
+    height:80px;
+}
+
+section.odd-section {
+    background-color: var(--color-white-xd);
+    padding: 0px;
+}
+section.even-section {
+    background-color: var(--color-white-d);
+    padding: 0px;
+}
+
+a.card-2 {
+    width: 100%;
+    display: inline-block;
+    border-radius: 5px;
+    padding: 10px 30px;
+    border-top: 2px solid var(--color-blue-d);
+    box-shadow: 0px 6px 6px 0px rgba(0, 0, 0, 0.15);
+    text-align: left;
+    color: var(--color-gray-xd);
+    text-decoration: none;
+    margin-bottom: 32px;
+}
+
+a.card-2:hover h5 {
+    color: var(--color-blue-d);
+}

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h3 class="section-heading">Who's using LoopBack?</h3>
-                    <p style="height:64px"></p>
+                    <p style="height:24px"></p>
                 </div>
             </div>
             <div class="row text-center" style="justify-content: center">
@@ -339,125 +339,15 @@
                     Wanna see your logo here? <a href="https://github.com/strongloop/loopback-next/issues/3047">Find out more.</a>       
                 </p>
             </div>
+            <div class="row text-center" style="justify-content: center">
+                <p>
+                    <a class="btn btn-secondary" role="button" href="what-our-users-say.html">See what our users say</a>
+                </p>
+            </div>
+            
         </div>
     </section>
-    <hr class="hairline-footer">
-    <section id="users-testimonial">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-12 text-center">
-                    <h3 class="section-heading">What our users say</h3>
-                    <p style="height:64px"></p>
-                </div>
-            </div>
-            <div class="row text-center" style="justify-content: center">
-                
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "SourceFuse builds innovative applications for enterprises. After having used most Node.js frameworks,  we are excited to select LoopBack V4 as a our go-to framework for delivering secure and scalable systems to our clients. To that end, SourceFuse is investing heavily in training it's staff on the best practices LoopBack V4 offers and giving back to the open source community by contributing to the project and organizing meetups for the local Node.js community."
-                    <br>
-                    <br>
-                    <br>
-                    <b>- Kabir Singh Chandhoke, Chief Operating Officer, SourceFuse</b>
-                </div>
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                "At Humans of Code, we always wanted a reliable node based backend that helps us with very rapid prototyping and has a way forward to production release at scale. LoopBack stood high amongst all other frameworks over time. Almost 80% of our user stories get covered with the 20% of generated code. LB provided us with a great leverage on time so that we can focus on business logic, rather than boilerplate code. With LoopBack 4 released and added support for TypeScript, we are excited for the great things ahead."
-                <br>
-                <br>
-                <b>- Vivek Dwivedi, Founder, Humans of Code</b>
-                </div>
-            </div>
-            <br>
-            <br>
-            <div class="row text-center" style="justify-content: center">
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "The Fundrails platform is built with LoopBack and industry leading technologies to enable integration with different providers, blockchain and expose APIs for our partners to consume. Our ubiquitous API (and GraphQL endpoint) powers an end-to-end digital onboarding, transfer agency for funds and integrations to our customer's fund accounting solutions."
-                    <br>
-                    <br>
-                    <b>- Kowsheek Mahmood, CTO, Fundrails</b>
-
-                </div>
-                
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                "When we set out to build our ERP system for the aviation industry we carefully researched various options. Node.js and the LoopBack framework came out far ahead. Its powerful features and built-in functionality made it incredibly quick and easy. Plus, LoopBack’s ability to auto-generate the entire API layer makes it a winner."
-                <br>
-                <br>
-                <b>- Lee Johnson, FlightOffice CEO & Founder</b>
-                </div>
-            </div> 
-            <br>
-            <br>
-            <div class="row text-center" style="justify-content: center">
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "We are excited to be collaborating with StrongLoop on our Reseller API. Co-developing a solution with the industry leader in Node has allowed us to accelerate the delivery of solutions to our reseller partners and drive revenue growth for them. Our external API is an incredibly important aspect of our overall technical strategy."
-                    <br>
-                    <br>
-                    <br>
-                    <b>- Elissa Murphy, GoDaddy Chief Technology Officer</b>
-                </div>
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                "FoKo is using LoopBack to create a whole new backend for a photo-sharing application specifically for enterprises. Loopback has allowed us to move away from Parse and we are now using Loopback with MongoDB, Redis, and Amazon S3. We are moving quite fast with such an awesome product and have already made contributions back to the LoopBack project."
-                <br>
-                <br>
-                <b>- Benjamin Boudreau, FoKo Software Developer</b>
-                </div>
-            </div>  
-            <br>
-            <br>
-            <div class="row text-center" style="justify-content: right">
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "Our company has been using LoopBack for several years. We started using it from its beginnings and the truth is that we love this new version. We want to congratulate the Strongloop Team from PTG Team for making developer's life a bit easier."
-                    <br>
-                    <br>
-                    <br>
-                    <b>- Jesús Mora, CTO & Co-Founder, Pitagorines Group</b>
-                </div>
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "I applaud the effort and dedication taken to build such high-quality, robust and modern framework, which is a key piece in our architecture since years ago. 
-                    It accelerates our development efforts insanely, saving us a precious time designing and deploying our REST APIs at Fixr. One of our best choices! Thank you team!"
-                    <br>
-                    <br>
-                    <b>- Antonio Parraga, CTO & Co-Founder, Fixr</b>
-                </div>
-            </div>  
-            <br>
-            <br> 
-            <div class="row text-center" style="justify-content: right">
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "Thanks to LoopBack we are EASILY developing a highly functional API system but above all it has satisfied all our stress tests.
-                    I believe that in the future we will no longer manage our Backends with PHP.
-                    Thanks to the pre-compiled structure in clear code we are able to focus our development exclusively on our idea.
-                    The automatic update of models with database columns is something magical.
-                    You can choose to use it only as a server or offer an API Explorer for your project automatically linked with your routes.
-                    Our team was able to create a Backend for Angular with tables, queries, authentication and endpoints in just 10 minutes from the command line! The Frontend was still writing CSS.
-                    I think this framework is the future of high level applications and we are honored to develop with it!"
-                    <br>
-                    <br>
-                    <br>
-                    <b>- Aleksandr Ivanovitch, CTO, MwSpace</b>
-                </div>
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "At Whiteboard, we were looking to rapidly re-architect the way we communicate with our integration providers and LoopBack 4 emerged as the clear winner. Designing API endpoints and interfacing with third-party data sources couldn't be easier, allowing us to focus only on what matters. With the latest release being written entirely in Typescript, we have been able to leverage the power of paradigms like Dependency Injection to improve test quality and maintain a clean yet consistent coding standard across our repository. LoopBack gives rapid development a new meaning!"
-                    <br>
-                    <br>
-                    <b>- Kaushik Gnanaskandan, Director of Technology, Whiteboard Technology</b>
-                </div>
-            </div> 
-            <br>
-            <br>     
-            <div class="row text-center" style="justify-content: right">
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                    "We use LoopBack to solve our client needs with rapid development, so we can focus on biz rules to get an awesome solution."
-                    <br>
-                    <br>
-                    <br>
-                    <b>- Oliver Cera, CEO, Kumisoft</b>
-                </div>
-                <div class="col-md-6" style="text-align: left; padding-right:60px">
-                </div>
-            </div>  
-        </div>
-    </div>
-    </section>    
+    
     <!-- Action section -->
     <div class="action">
         <div class="container">

--- a/what-our-users-say.html
+++ b/what-our-users-say.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <!-- not working -->
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+
+    <title>LoopBack 4</title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="dist/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans" rel="stylesheet">
+    <link href="css/loopback.css" rel="stylesheet">
+    <link href="css/users.css" rel="stylesheet">
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150726441-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-150726441-2');
+    </script>
+
+</head>
+
+<body>
+    <!-- Navbar -->
+    <nav class="navbar navbar-expand-lg navbar-light fixed-top">
+        <a class="navbar-brand" href="index.html">
+            <img src="images/global/loopback-full-logo-blue.svg" width=150px>
+        </a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
+            aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav ml-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="getting-started.html">Getting Started</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/doc/en/lb4">Docs</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link highlighted" href="contribute.html">Contribute</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="resources.html">Resources</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="openapi-to-graphql.html">GraphQL</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">Blog</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="https://ibm.biz/apitest" target="_blank" rel="noopener noreferrer">Test Your APIs</a>
+                </li>
+            </ul>
+        </div>
+    </nav> 
+
+    <div class="r-masthead">
+        <div class="container-fluid"></div>
+        <div class="header-space"></div>
+        <h2>What our users say</h2>
+        <br>
+        <h5 style="font-weight: normal">Let's continue to build our community together.</h5>
+        <div class="header-space"></div>
+    </div>
+    <hr class="hairline">
+    <section class="odd-section">
+        <div class="container">
+            <p style="height:24px"></p>
+            <div class="row text-center" style="justify-content: center">
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "SourceFuse builds innovative applications for enterprises. After having used most Node.js frameworks,  we are excited to select LoopBack V4 as a our go-to framework for delivering secure and scalable systems to our clients. To that end, SourceFuse is investing heavily in training it's staff on the best practices LoopBack V4 offers and giving back to the open source community by contributing to the project and organizing meetups for the local Node.js community."
+                        <br>
+                        <br>
+                        <b>Kabir Singh Chandhoke, Chief Operating Officer, SourceFuse</b>
+                    </div>
+                    </a>
+                </div>
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "At Humans of Code, we always wanted a reliable node based backend that helps us with very rapid prototyping and has a way forward to production release at scale. LoopBack stood high amongst all other frameworks over time. Almost 80% of our user stories get covered with the 20% of generated code. LB provided us with a great leverage on time so that we can focus on business logic, rather than boilerplate code. With LoopBack 4 released and added support for TypeScript, we are excited for the great things ahead."
+                        <br>
+                        <br>
+                        <b>Vivek Dwivedi, Founder, Humans of Code</b>
+                    </div>
+                    </a>
+                </div>
+            </div>
+    
+            <div class="row text-center" style="justify-content: center">
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "The Fundrails platform is built with LoopBack and industry leading technologies to enable integration with different providers, blockchain and expose APIs for our partners to consume. Our ubiquitous API (and GraphQL endpoint) powers an end-to-end digital onboarding, transfer agency for funds and integrations to our customer's fund accounting solutions."
+                        <br>
+                        <br>
+                        <b>Kowsheek Mahmood, CTO, Fundrails</b>
+                    </div>
+                    </a>
+                </div>
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "When we set out to build our ERP system for the aviation industry we carefully researched various options. Node.js and the LoopBack framework came out far ahead. Its powerful features and built-in functionality made it incredibly quick and easy. Plus, LoopBack’s ability to auto-generate the entire API layer makes it a winner."
+                        <br>
+                        <br>
+                        <b>Lee Johnson, FlightOffice CEO & Founder</b>
+                    </div>
+                    </a>
+                </div>
+            </div>
+
+            <div class="row text-center" style="justify-content: center">
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "We are excited to be collaborating with StrongLoop on our Reseller API. Co-developing a solution with the industry leader in Node has allowed us to accelerate the delivery of solutions to our reseller partners and drive revenue growth for them. Our external API is an incredibly important aspect of our overall technical strategy."
+                        <br>
+                        <br>
+                        <b>Elissa Murphy, GoDaddy Chief Technology Officer</b>
+                    </div>
+                    </a>
+                </div>
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "FoKo is using LoopBack to create a whole new backend for a photo-sharing application specifically for enterprises. Loopback has allowed us to move away from Parse and we are now using Loopback with MongoDB, Redis, and Amazon S3. We are moving quite fast with such an awesome product and have already made contributions back to the LoopBack project."
+                        <br>
+                        <br>
+                        <b>Benjamin Boudreau, FoKo Software Developer</b>
+                    </div>
+                    </a>
+                </div>
+            </div>
+
+            <div class="row text-center" style="justify-content: center">
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "Our company has been using LoopBack for several years. We started using it from its beginnings and the truth is that we love this new version. We want to congratulate the Strongloop Team from PTG Team for making developer's life a bit easier."
+                        <br>
+                        <br>
+                        <b>Jesús Mora, CTO & Co-Founder, Pitagorines Group</b>
+                    </div>
+                    </a>
+                </div>
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "I applaud the effort and dedication taken to build such high-quality, robust and modern framework, which is a key piece in our architecture since years ago. 
+                    It accelerates our development efforts insanely, saving us a precious time designing and deploying our REST APIs at Fixr. One of our best choices! Thank you team!"
+                        <br>
+                        <br>
+                        <b>Antonio Parraga, CTO & Co-Founder, Fixr</b>
+                    </div>
+                    </a>
+                </div>
+            </div>
+
+            <div class="row text-center" style="justify-content: center">
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "Thanks to LoopBack we are EASILY developing a highly functional API system but above all it has satisfied all our stress tests.
+                    I believe that in the future we will no longer manage our Backends with PHP.
+                    Thanks to the pre-compiled structure in clear code we are able to focus our development exclusively on our idea.
+                    The automatic update of models with database columns is something magical.
+                    You can choose to use it only as a server or offer an API Explorer for your project automatically linked with your routes.
+                    Our team was able to create a Backend for Angular with tables, queries, authentication and endpoints in just 10 minutes from the command line! The Frontend was still writing CSS.
+                    I think this framework is the future of high level applications and we are honored to develop with it!"
+                        <br>
+                        <br>
+                        <b>Aleksandr Ivanovitch, CTO, MwSpace</b>
+                    </div>
+                    </a>
+                </div>
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "At Whiteboard, we were looking to rapidly re-architect the way we communicate with our integration providers and LoopBack 4 emerged as the clear winner. Designing API endpoints and interfacing with third-party data sources couldn't be easier, allowing us to focus only on what matters. With the latest release being written entirely in Typescript, we have been able to leverage the power of paradigms like Dependency Injection to improve test quality and maintain a clean yet consistent coding standard across our repository. LoopBack gives rapid development a new meaning!"
+                        <br>
+                        <br>
+                        <b>Kaushik Gnanaskandan, Director of Technology, Whiteboard Technology</b>
+                    </div>
+                    </a>
+                </div>
+            </div>
+
+            <div class="row text-center" style="justify-content: center">
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        "We use LoopBack to solve our client needs with rapid development, so we can focus on biz rules to get an awesome solution."
+                        <br>
+                        <br>
+                        <b>Oliver Cera, CEO, Kumisoft</b>
+                    </div>
+                    </a>
+                </div>
+                
+                <div class="col-sm-12 col-md-6">
+                    <a class="card-2">
+                    <div class="row" style="padding:10px">
+                        In Wizerg we develop platforms for small businesses, creative minds, startups and large multinational companies.
+                        It has been 4 years since we implemented Loopback in our set of tools and developments, it was a good decision,
+                        the development time was reduced by 40%, If I had to describe Loopback, it would be in 3 words, modular, powerful and robust.
+                        Thanks to the entire Loopback team, they are part of the dreams fulfilled by several startups.
+                        <br>
+                        <br>
+                        <b>Josué Caro, CEO, Wizerg</b>
+                    </div>
+                    </a>
+                </div>
+            </div>
+
+            </div>
+        </div>
+    </section>
+    
+    <hr class="hairline">
+
+    <!-- footer -->
+    <footer>
+        <div class="container">
+            <div class="row text-center">
+                <div class="col-md-3">
+                    <img src="images/global/loopback-mark-frame-white.svg" width=40px/>
+                </div>
+                <div class="col-md-3">
+                    <p class="label text-uppercase">Product</p>
+                    <p class="regular">
+                        <a href="getting-started.html">Getting Started</a>
+                    </p>
+                    <p class="regular">
+                        <a href="doc/en/lb4/Tutorials.html">Tutorials</a>
+                    </p>
+                </div>
+                <div class="col-md-3">
+                    <p class="label text-uppercase" >Documentation</p>
+                    <p class="regular">
+                        <a href="/doc">Docs</a>
+                    </p>
+                    <p class="regular">
+                        <a href="resources.html">Resources</a>
+                    </p>
+                    <p class="regular">
+                        <a href="contribute.html">Contribute</a>
+                    </p>
+                </div>
+                <div class="col-md-3">
+                    <p class="label text-uppercase">Support</p>
+                    <p class="regular">
+                        <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
+                    </p>
+                    <p class="regular">
+                        <a href="http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html" target="_blank" rel="noopener noreferrer">API Docs</a>
+                    </p>
+                    <p class="regular">
+                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
+                    </p> 
+                    <p class="regular">
+                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
+                    </p>
+                </div>
+            </div>
+            <hr class="hairline-footer">
+            <div class="row text-center">
+                <div class="col-md-6">
+                    <p class="regular"> @ Copyright 2020 StrongLoop, an IBM company</p>
+                </div>
+                <div class="col-md-6">
+                    <p style="float:right">
+                        <a class="twitter-share-button"
+                            href="https://twitter.com/intent/tweet?text=Creating APIs has never been easier using %23LoopBack 4 by %40StrongLoop. Check it out at loopback.io.&url= dloopback.io">
+                            Tweet</a>
+                        <a href="https://twitter.com/intent/tweet?screen_name=StrongLoop&ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="true">Tweet to @StrongLoop</a>
+                        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="dist/jquery/jquery-3.3.1.slim.min.js"></script>
+    <script src="dist/popper/1.14.0/umd/popper.min.js"></script>
+    <!-- Bootstrap core JavaScript -->
+    <script src="dist/bootstrap/js/bootstrap.min.js"></script>
+
+    <!-- GitHub button -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
There are increasing number of user testimonials, so I think it might be better to move to another page. 

In index.html, removing "what our users says" section but add a button: 
<img width="1132" alt="Screen Shot 2020-03-25 at 7 03 35 PM" src="https://user-images.githubusercontent.com/25489897/77593967-a1c9e100-6ecb-11ea-91d8-995b74bc0ffd.png">

"What our users say page:
<img width="1278" alt="Screen Shot 2020-03-25 at 7 06 59 PM" src="https://user-images.githubusercontent.com/25489897/77594047-d8076080-6ecb-11ea-98e1-3e39a348811e.png">

Since the length of the testimonials are not the same, so the "cards" are a bit uneven
<img width="1174" alt="Screen Shot 2020-03-25 at 7 07 34 PM" src="https://user-images.githubusercontent.com/25489897/77594083-f2413e80-6ecb-11ea-958e-093b9a455da0.png">

