### PR TITLE
Update resource page to include Slack workspace link

### DIFF
--- a/pages/ja/lb4/express-with-lb4-rest-tutorial.md
+++ b/pages/ja/lb4/express-with-lb4-rest-tutorial.md
@@ -14,7 +14,7 @@ summary: A simple Express application with LoopBack 4 REST API
 
 {% include note.html content="
 ホストとしてLoopBackを使用し、LoopBack4アプリケーションにExpressアプリケーションをマウントする場合は、[Express Routerのマウント](Routes.md#mounting-an-express-router)を参照してください 。
- %}
+" %}
 
 このチュートリアルでは、LoopBack 4アプリケーションの土台・['モデル'](Model.md)・['データソース'](DataSources.md)・['レポジトリ'](Repositories.md)・['コントローラー'](Controllers.md)の背景知識があることを前提としています。各機能のアプリ内での働きについては、[`Todo` チュートリアル](todo-tutorial.md)をご参照ください.
 

--- a/resources.html
+++ b/resources.html
@@ -86,14 +86,14 @@
 
             <div class="row text-center" style="justify-content: center">
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://gitter.im/strongloop/loopback" target="_blank" rel="noopener noreferrer">
+                    <a class="card-2" href="https://join.slack.com/t/loopbackio/shared_invite/zt-8lbow73r-SKAKz61Vdao~_rGf91pcsw" target="_blank" rel="noopener noreferrer">
                     <div class="row">
                         <div class="col-sm-3">
                             <img class="icon" src="images/resources/devchat-icon-1x.png" alt="Chat room icon"/>
                         </div>
                         <div class="col-sm-9">
-                            <h5 class="card-title">Participate in Gitter chat room</h5>
-                            <p class="regular text-gray">See the LoopBack Gitter channel for realtime discussions with fellow LoopBack developers.</p>
+                            <h5 class="card-title">Participate in our Slack community</h5>
+                            <p class="regular text-gray">Join the LoopBack Slack community for realtime discussions with fellow LoopBack developers.</p>
                         </div>
                     </div>
                     </a>


### PR DESCRIPTION
There are 2 commits in this PR:
1. fix the missing quote in the "note" for ja/lb4/express-with-lb4-rest-tutorial.md
2. update resource page to include Slack workspace link. 
![Screen Shot 2020-05-10 at 9 48 15 PM](https://user-images.githubusercontent.com/25489897/81517161-fbfdf480-9307-11ea-9bbf-f0c6154d59cb.png)
