### PR TITLE
feat: no summary in LB4 docs

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,11 +23,13 @@ layout: default
 
 <div class="post-content">
 
- {% if page.summary %}
-  <div class="summary">
-    {{page.summary}}
-  </div>
- {% endif %}
+{% if page.sidebar != 'lb4_sidebar' %}
+  {% if page.summary %}
+   <div class="summary">
+     {{page.summary}}
+   </div>
+  {% endif %}
+{% endif %}
 
 {% if page.layout == 'navgroup' %}
   {% capture nav-include %}{% include navgroups/{{page.navgroup}}.md %}{% endcapture %}


### PR DESCRIPTION
Let's get rid of the summary boxes in LB4 docs. Most of the pages do not contain them, and those which do, create redundant text as shown in the screenshot.

> LoopBack 4 Todo Application Tutorial - Integrate with a geo-coding service

![image](https://user-images.githubusercontent.com/950112/79087329-8a5c7600-7d5c-11ea-8d13-ba261d24802d.png)
