### PR TITLE
fix invalid character in translation

### DIFF
--- a/pages/ja/lb4/express-with-lb4-rest-tutorial.md
+++ b/pages/ja/lb4/express-with-lb4-rest-tutorial.md
@@ -69,7 +69,7 @@ $ lb4 app note
 
 ### Note モデルを追加する
 
-プロジェクトフォルダー内で`lb4 model`を実行し、`Note`モデルを構築します。`id`プロパティのデータ型は`number`、`title`プロパティは`string`、`content`プロパティは`string`で`Entity`を作成します。
+`lb4 model`を実行し、`Note`モデルを構築します。`id`プロパティのデータ型は`number`、`title`プロパティは`string`、`content`プロパティは`string`で`Entity`を作成します。
 
 
 ### データソースを追加する


### PR DESCRIPTION
Fixes #984.

There are invalid characters in the generated `_site/posts.json` and the error occurred in pages/ja/lb4/express-with-lb4-rest-tutorial.md. 

After I removed `プロジェクトフォルダー内で` (see the change), the error no longer happened. Without knowing the language, I'm not sure what's special about those.  From google translate, it says "in the project folder". 