### PR TITLE
chore: add md option for collapsible block

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,7 @@ kramdown:
  auto_ids: true
  hard_wrap: false
  syntax_highlighter: rouge
+ parse_block_html: true
 # filter used to process markdown. note that kramdown differs from github-flavored markdown in some subtle ways
 
 collections:


### PR DESCRIPTION
Allowing markdown content inside of the collapsible block to be parsed correctly. Relates to https://github.com/strongloop/loopback-connector-postgresql/pull/442