### PR TITLE
fix: remove <head> tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 {% if jekyll.environment == "production" %}
   {% assign base = site.url %}
 {% endif %}
-<head>
+
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -31,7 +31,7 @@
     <script src="{{base}}/js/customscripts.js"></script>
 
     <link rel="shortcut icon" href="{{base}}/images/favicon.ico">
-<head>
+
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
 <!--[if lt IE 9]>


### PR DESCRIPTION
The head.html will be included into other html pages that already have
<head></head> tags.

See https://github.com/strongloop/loopback-next/pull/5648#issuecomment-638364232