### PR TITLE
feat: support sidebar groups with no page link

### DIFF
--- a/_includes/sidebar_menu_list_items.liquid
+++ b/_includes/sidebar_menu_list_items.liquid
@@ -4,7 +4,11 @@
   {% if item.output contains "web" %}
   <li class="{% if item.children.size > 0 %} tree-parent {%else%} leaf-node {% endif %} {% if pageurl.last == item.url %}active{% endif %}">
     {% if item.children.size > 0 %} <a class="show-hide" href="#"></span> {% endif %}
-    <a class="page-link" href="{{item.url}}">{{ item.title }}</a>
+    {% if item.url %}
+      <a class="page-link" href="{{item.url}}">{{ item.title }}</a>
+    {% else %}
+      <a class="section-name" href="#">{{ item.title }}</a>
+    {% endif %}
       {% if item.children.size > 0 %}
       <ul class="nav-list">
           {% include sidebar_menu_list_items.liquid menuitems=item.children %}

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -737,17 +737,19 @@ ul#mysidebar, #mysidebar ul{
     display: block;
 }
 
+#mysidebar .section-name,
 #mysidebar .page-link {
   padding: 3px 5px;
   margin-left: 1em;
 }
 
+#mysidebar > li > .section-name,
 #mysidebar > li > .page-link {
   text-transform: uppercase;
   font-size: 11px;
   font-weight: 500;
 }
-  
+
 #mysidebar .leaf-node>.page-link::before{
   content: "▪";
   float:left;
@@ -773,6 +775,8 @@ ul#mysidebar, #mysidebar ul{
   text-decoration: none;
 }
 
+#mysidebar li.active>a.section-name,
+#mysidebar a.section-name:hover,
 #mysidebar li.active>a.page-link,
 #mysidebar a.page-link:hover{
   background: #e3eeff;

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -71,7 +71,10 @@ function setupSidebarTreeNav(){
     //add expanded class to active tree parents
     $('.tree-parent.active').addClass('expanded');
 
-    $('a.show-hide').click(function (e) {
+    $('a.show-hide').click(toggleSectionChildren);
+    $('a.section-name').click(toggleSectionChildren);
+
+    function toggleSectionChildren(e) {
       console.log('clicked', this);
       $(this)
         .blur()
@@ -79,5 +82,5 @@ function setupSidebarTreeNav(){
         .children('ul.nav-list').toggle(200);
       return false;
       // $(this).parent().children('ul.nav-list').toggle(200);
-    });
+    }
 }


### PR DESCRIPTION
Allow side bar entries with children to have no page associated with them.

This will allow us to get rid of dummy placeholder-like pages like https://loopback.io/doc/en/lb4/Access-databases.html

Demo:

![lb4-sidebar-demo](https://user-images.githubusercontent.com/1140553/85010211-e8904580-b15f-11ea-9f5b-3c6bb3afdb6f.gif)
