### PR TITLE
update renovate setting

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,6 +2,7 @@
     "extends": [
       ":gitSignOff",
       "group:recommended",
+      ":pinAllExceptPeerDependencies",
       "helpers:disableTypesNodeMajor"
     ],
   


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

The PRs created by Renovate bot did not include the changes for package-lock. Comparing the `.renovaterc.json` with example-shopping repo, it seems like `    ":pinAllExceptPeerDependencies",` is missing (see https://github.com/strongloop/loopback4-example-shopping/blob/master/.renovaterc.json). 

Test to see if this PR could fix.