### PR TITLE
docs: fix oracle install tips

### DIFF
--- a/pages/en/lb3/Installing-the-Oracle-connector.md
+++ b/pages/en/lb3/Installing-the-Oracle-connector.md
@@ -11,7 +11,7 @@ permalink: /doc/en/lb3/Installing-the-Oracle-connector.html
 summary: The loopback-oracle-installer module takes care of binary dependencies and simplifies the process of installing the Oracle connector.
 ---
 {% include tip.html content="
-Use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
+For LB3 users, use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
 to easily install and troubleshoot installing `loopback-oracle-installer`
 and the Oracle data source connector.  
 " %}

--- a/pages/en/lb3/Oracle-connector.md
+++ b/pages/en/lb3/Oracle-connector.md
@@ -11,7 +11,7 @@ permalink: /doc/en/lb3/Oracle-connector.html
 summary: The Oracle connector enables LoopBack applications to connect to Oracle data sources.
 ---
 {% include tip.html content="
-Use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
+For LB3 users, use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
 to easily install and troubleshoot installing `loopback-oracle-installer`
 and the Oracle data source connector.  
 " %}


### PR DESCRIPTION
<img width="1186" alt="截圖 2020-08-13 下午4 34 16" src="https://user-images.githubusercontent.com/50331796/90184264-d6f3a480-dd82-11ea-8777-fff8298fa3ba.png">
The tip of using command `lb oracle` in the Oracle connector page is only supported by LB3.