### PR TITLE
add full text of DCO

### DIFF
--- a/_includes/content/cla.md
+++ b/_includes/content/cla.md
@@ -9,7 +9,47 @@ As an alternative to CLA, a Developer Ceritifcate of Origin (DCO) is a more ligh
 
 > Instead a signed legal contract, a DCO is an affirmation that the source code being submitted originated from the developer, or that the developer has permission to submit the code.
 
-The full text of DCO can be found: https://developercertificate.org/.
+The full text of DCO:
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+It can also be found: [https://developercertificate.org/](https://developercertificate.org/).
 
 #### Signing off commits using DCO
 For GitHub repositories using DCO, you need to sign off each commit. To sign off, you can use the `-s` flag or adding `Signed-off-By: Name<Email>` in the commit message. For example, 


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

Suggested by @bajtos, adding full text of DCO from https://developercertificate.org/.