### PR TITLE
chore: enable renovate automerge

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -27,7 +27,16 @@
   
     "separateMajorMinor": true,
     "separateMinorPatch": false,
-  
+    "packageRules": [
+      {
+        "updateTypes": ["minor", "patch"],
+        "automerge": true
+      },
+      {
+        "depTypeList": ["devDependencies"],
+        "automerge": true
+      }
+    ],
     "travis": {
       "enabled": true,
       "supportPolicy": ["lts", "current"]


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>
Enable renovate automerge for patch/minor versions or devDependencies.
Using PR https://github.com/strongloop/loopback-next/pull/6472 as the reference.