### PR TITLE
feat: add expand by default

### DIFF
--- a/_includes/sidebar_menu_list_items.liquid
+++ b/_includes/sidebar_menu_list_items.liquid
@@ -1,8 +1,8 @@
 {% assign pageurl = page.url | split: "/" %}
 {% for item in include.menuitems %}
-  {% comment %} Is this supposed to be ouput on the `web`site?{% endcomment %}
+  {% comment %} Is this supposed to be output on the `web`site?{% endcomment %}
   {% if item.output contains "web" %}
-  <li class="{% if item.children.size > 0 %} tree-parent {%else%} leaf-node {% endif %} {% if pageurl.last == item.url %}active{% endif %}">
+  <li class="{% if item.children.size > 0 %} {% if item.expand == 'true' %} tree-parent-expand {%else%} tree-parent {% endif %} {%else%} leaf-node {% endif %} {% if pageurl.last == item.url %}active{% endif %}">
     {% if item.children.size > 0 %} <a class="show-hide" href="#"></span> {% endif %}
     {% if item.url %}
       <a class="page-link" href="{{item.url}}">{{ item.title }}</a>

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -767,6 +767,10 @@ ul#mysidebar, #mysidebar ul{
   display:block;
 }
 
+.tree-parent-expand.expanded .nav-list{
+  display:block;
+}
+
 #mysidebar li.active a.show-hide,
 #mysidebar a.show-hide:hover,
 #mysidebar a.show-hide:active{

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -56,9 +56,14 @@ $(function() {
 function setupSidebarTreeNav(){
 
     //hide all non-active nav-lists:
-    $('.nav-list').not('#mysidebar').each(function(i, list){
-      if(!$(list).parent().is('.active')){
-        $(list).hide();
+    $('.nav-list').not('#mysidebar').each(function (i, list) {
+      if (!$(list).parent().is('.active')) {
+        //add expanded class for the items marked as expand be default
+        if ($(list).parent().is('.tree-parent-expand')) {
+          $(list).parent().addClass('expanded');
+        } else {
+          $(list).hide();
+        }
       }
     });
 
@@ -66,10 +71,13 @@ function setupSidebarTreeNav(){
     $("li.active").parentsUntil('#mysidebar', '.tree-parent')
       .addClass('expanded')
       .children('ul.nav-list').show();
-
+    $("li.active").parentsUntil('#mysidebar', '.tree-parent-expand')
+      .addClass('expanded')
+      .children('ul.nav-list').show();
 
     //add expanded class to active tree parents
     $('.tree-parent.active').addClass('expanded');
+    $('.tree-parent-expand.active').addClass('expanded');
 
     $('a.show-hide').click(toggleSectionChildren);
     $('a.section-name').click(toggleSectionChildren);


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

connect to https://github.com/strongloop/loopback-next/issues/6477

Add a configure field called `expand` to control expand or hide a sidebar item by default. 
Add a new class `tree-parent-expand` in the css file to decorate the item set with `{expand: true}`.
The customjs file expands children for item decorated by `tree-parent-expand`.

<img width="276" alt="Screen Shot 2020-10-07 at 3 08 31 PM" src="https://user-images.githubusercontent.com/12554153/95376378-028c9a00-08af-11eb-9187-e338bfa3ec67.png">
