### PR TITLE
fix: remove the deployment build for Node 10 and 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "10"
-  - "12"
   - "14"
 
 os:


### PR DESCRIPTION
This repo does not publish a public npm package and there is no need to
run CI on multiple Node.js versions, which also cause duplicate deployments.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>