### PR TITLE
Tweak RenovateBot for shorter commit messages

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,27 +4,26 @@
       "group:recommended",
       "helpers:disableTypesNodeMajor"
     ],
-  
+
     "automerge": false,
     "branchPrefix": "renovate/",
     "ignoreUnstable": true,
     "rangeStrategy": "bump",
     "statusCheckVerify": true,
     "updateNotScheduled": true,
-  
+
     "lockFileMaintenance": {
       "enabled": true,
       "schedule": "before 5am on monday"
     },
-  
+
     "prConcurrentLimit": 5,
     "prCreation": "immediate",
     "prHourlyLimit": 2,
-  
-    "semanticCommits": true,
-    "semanticCommitType": "chore",
-    "semanticCommitScope": null,
-  
+
+    "semanticCommits": false,
+    "commitMessageTopic": "{{depName}}",
+
     "separateMajorMinor": true,
     "separateMinorPatch": false,
     "packageRules": [
@@ -41,7 +40,7 @@
       "enabled": true,
       "supportPolicy": ["lts", "current"]
     },
-  
+
     "masterIssue": true,
     "masterIssueApproval": false,
     "masterIssueAutoclose": true


### PR DESCRIPTION
1. Disable semantic commits, we are using a different convention in this repo.

2. Remove "dependency" from the commit messages to keep them shorter.

Before, RenovateBot was creating commit messages like this one:

    chore: update swagger-ui-dist to ^3.37.0

With my change in place, I expect to see commit messages like this:

    Update swagger-ui-dist to ^3.37.0