### PR TITLE
fix: update top menu to include LB4 apidocs

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,15 +1,13 @@
-## Topnav single links
-## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
-topnav:
-- title: Topnav
-  items:
-    - title: API Docs
-      external_url: http://apidocs.loopback.io
-
 #Topnav dropdowns
 topnav_dropdowns:
 - title: Topnav dropdowns
   folders:
+    - title: API Docs
+      folderitems:
+        - title: LoopBack 4
+          external_url: https://loopback.io/doc/en/lb4/apidocs.index.html
+        - title: LoopBack 3.x
+          external_url: http://apidocs.loopback.io
     - title: View
       folderitems:
         - title: LoopBack Overview


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/7010. 

The API docs link in the top menu is pointing to the LB3 API docs, though it has references to the LB4 api docs. I've updated the menu to include both LB3 and LB4 apidocs link. 
 
It looks like:
<img width="375" alt="Screen Shot 2021-01-11 at 9 34 45 PM" src="https://user-images.githubusercontent.com/25489897/104262250-3f8b9e00-5455-11eb-9b8a-a92859f69939.png">

cc @NorthDecoder