### PR TITLE
chore: add achrinza as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,5 @@
 # Each line is a file pattern followed by one or more owners,
 # the last matching pattern has the most precedence.
 
-# Core team members from IBM
-* @dhmlau
+# Current maintainers
+* @dhmlau @achrinza 


### PR DESCRIPTION
Welcome @achrinza to extend his contributions as the maintainer of this repo as well! 🎉 
He's currently one of the maintainers for [LoopBack 4 - loopback-next repo](https://github.com/strongloop/loopback-next).

cc @bajtos @achrinza 