### PR TITLE
fix: get latest LB4 docs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Install and Build 🔧
         run: |
           bundle install
-          npm ci
+          npm install
           npm ls @loopback/docs 2>/dev/null || true
           npm run build


### PR DESCRIPTION
The latest changes in loopback-next docs folder are not reflected in the docs site. 
Comparing the .travis.yml file and the GH actions in https://github.com/strongloop/loopback.io/pull/1128, it might be because we were calling `npm ci` instead of `npm i`. 

Note: I'm not sure how I can test it "locally".