### PR TITLE
fix: remove gray text in navbar links

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -931,12 +931,6 @@ span.soft {
     background-color: whitesmoke;
 }
 
-@media (max-width: 767px) {
-    .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
-        color: #444;
-    }
-}
-
 @media (max-width: 990px) {
     #mysidebar {
         position: relative;


### PR DESCRIPTION
Remove gray text in navbar links for mobile devices
![nav](https://user-images.githubusercontent.com/34798085/118026578-235c2700-b38b-11eb-9c19-f94d026ec11a.png)
