### PR TITLE
chore: move repo to loopbackio repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To preview the website locally:
 2.  Clone this repo (you might use the SSH URL instead of HTTPS).:
 
 ```
-git clone https://github.com/strongloop/loopback.io.git
+git clone https://github.com/loopbackio/loopback.io.git
 ```
 
 3.  `cd` to the repository directory and run the following command:
@@ -83,11 +83,11 @@ for LoopBack 4 content. The changes are then picked up as part of Travis CI's
 builds along with README update scripts and deployed to GitHub Pages once
 successful. The `upgrade-swagger-ui.js` script is also run as part of the
 builds. If you'd like to make documentation changes for LoopBack 4, please do so
-on its own [repository](https://github.com/strongloop/loopback-next/).
+on its own [repository](https://github.com/loopbackio/loopback-next/).
 
 ### Linting Readmes
 
-There is an additional `npm script` that "lints" the readmes for markdown formatting problems. It is currently "experimental", see [this issue](https://github.com/strongloop/loopback.io/issues/49#issuecomment-253672668) for more info.
+There is an additional `npm script` that "lints" the readmes for markdown formatting problems. It is currently "experimental", see [this issue](https://github.com/loopbackio/loopback.io/issues/49#issuecomment-253672668) for more info.
 
 You can run this script thus:
 
@@ -129,7 +129,7 @@ reviews. Credentials for accessing the Cloud Function can be obtained from Diana
 #### Your own version
 
 You can deploy the code on your own IBM Cloud account and upload the URL for
-Discovery in [search.html](https://github.com/strongloop/loopback.io/blob/gh-pages/_layouts/search.html).
+Discovery in [search.html](https://github.com/loopbackio/loopback.io/blob/gh-pages/_layouts/search.html).
 
 
 ## Contributing 

--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
                         <p class="main-btn-text">LoopBack 4</p>
                         <p class="main-btn-text2">(Active)</p>
                     </h5></a>
-                    <a class="github-button" href="https://github.com/strongloop/loopback-next" data-icon="octicon-star" data-show-count="true"
-                        aria-label="Star strongloop/loopback-next on GitHub">Star</a>
+                    <a class="github-button" href="https://github.com/loopbackio/loopback-next" data-icon="octicon-star" data-show-count="true"
+                        aria-label="Star loopbackio/loopback-next on GitHub">Star</a>
                 </div>
                 <div class="btn btn-main" role="button">
                     <a class="main-btn-link" href="/lb3"><h5>
@@ -149,7 +149,7 @@
                     <h5 class="card-title">Stay in the Loop</h5>
                     <p class="regular text-gray">Check out our LoopBack 4 blog posts that feature the latest news and updates.</p>
                 </a>
-                <a class="col-lg-4 card" href="https://github.com/strongloop/loopback-next" target="_blank" rel="noopener noreferrer">
+                <a class="col-lg-4 card" href="https://github.com/loopbackio/loopback-next" target="_blank" rel="noopener noreferrer">
                     <h5 class="card-title">Contribute to the development</h5>
                     <p class="regular text-gray">Shape the future of LoopBack 4 to be more meaningful for our API creation experience.</p>
                 </a>
@@ -362,7 +362,7 @@
             </div>
             <div class="row text-center" style="justify-content: center">
                 <p style="padding-top:64px">
-                    Wanna see your logo here? <a href="https://github.com/strongloop/loopback-next/issues/3047">Find out more.</a>       
+                    Wanna see your logo here? <a href="https://github.com/loopbackio/loopback-next/issues/3047">Find out more.</a>       
                 </p>
             </div>
             <div class="row text-center" style="justify-content: center">

--- a/navbar-template.html
+++ b/navbar-template.html
@@ -25,7 +25,7 @@
                 <a class="nav-link" href="https://strongloop.com/strongblog/tag_LoopBack.html" target="_blank" rel="noopener noreferrer">Blog</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="https://github.com/strongloop/loopback-next" target="_blank" rel="noopener noreferrer">
+                <a class="nav-link" href="https://github.com/loopbackio/loopback-next" target="_blank" rel="noopener noreferrer">
                     <i class="fa fa-github fa-lg"></i>
                 </a>
             </li>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Strongloop/loopback.io.git"
+    "url": "git+https://github.com/loopbackio/loopback.io.git"
   },
   "devDependencies": {
     "@loopback/docs": "latest",

--- a/resources.html
+++ b/resources.html
@@ -70,7 +70,7 @@
                 </div>
     
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://github.com/strongloop/loopback-next/issues" target="_blank" rel="noopener noreferrer">
+                    <a class="card-2" href="https://github.com/loopbackio/loopback-next/issues" target="_blank" rel="noopener noreferrer">
                     <div class="row">
                         <div class="col-sm-3">
                             <img class="icon" src="images/resources/issue-icon-1x.png" alt="Issues icon"/>
@@ -100,7 +100,7 @@
                 </div>
     
                 <div class="col-sm-12 col-md-6">
-                    <a class="card-2" href="https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">
+                    <a class="card-2" href="https://github.com/loopbackio/loopback-next/blob/master/docs/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">
                     <div class="row">
                         <div class="col-sm-3">
                             <img class="icon" src="images/resources/contribute-icon-1x.png" alt="Contribute icon"/>

--- a/update-readmes.sh
+++ b/update-readmes.sh
@@ -8,31 +8,31 @@
 #   from the given github repo. If that branch is NOT master, then the
 #   branch name will be appended to the local readme file name.
 (cat <<LIST_END
-strongloop loopback-connector-mysql master
-strongloop loopback-connector-cassandra master
-strongloop loopback-connector-cloudant master
-strongloop loopback-connector-couchdb2 master
-strongloop loopback-connector-dashdb master
-strongloop loopback-connector-db2 master
+loopbackio loopback-connector-mysql master
+loopbackio loopback-connector-cassandra master
+loopbackio loopback-connector-cloudant master
+loopbackio loopback-connector-couchdb2 master
+loopbackio loopback-connector-dashdb master
+loopbackio loopback-connector-db2 master
 strongloop loopback-connector-db2iseries master
-strongloop loopback-connector-ibmi master
+loopbackio loopback-connector-ibmi master
 strongloop loopback-connector-db2z master
-strongloop loopback-connector-grpc master
+loopbackio loopback-connector-grpc master
 strongloop loopback-connector-informix master
 strongloop loopback-connector-jsonrpc master
-strongloop loopback-connector-kv-redis master
-strongloop loopback-connector-mongodb master
+loopbackio loopback-connector-kv-redis master
+loopbackio loopback-connector-mongodb master
 strongloop loopback-connector-mqlight master
-strongloop loopback-connector-mssql master
+loopbackio loopback-connector-mssql master
 strongloop loopback-connector-zosconnectee master
-strongloop loopback-connector-openapi master
-strongloop loopback-connector-oracle master
+loopbackio loopback-connector-openapi master
+loopbackio loopback-connector-oracle master
 strongloop loopback-oracle-installer master
-strongloop loopback-connector-postgresql master
+loopbackio loopback-connector-postgresql master
 strongloop loopback-connector-remote master
-strongloop loopback-connector-rest master
-strongloop loopback-connector-soap master
-strongloop strong-soap master
+loopbackio loopback-connector-rest master
+loopbackio loopback-connector-soap master
+loopbackio strong-soap master
 strongloop-community loopback-android-getting-started master
 strongloop loopback-example-angular master
 strongloop loopback-example-app-logic master
@@ -51,7 +51,7 @@ strongloop loopback-example-relations master
 strongloop loopback-example-storage master
 strongloop loopback-example-user-management master
 strongloop-community loopback-ios-getting-started master
-strongloop strong-error-handler master
+loopbackio strong-error-handler master
 strongloop strong-remoting master
 strongloop angular-live-set
 strongloop loopback-component-storage master

--- a/what-our-users-say.html
+++ b/what-our-users-say.html
@@ -48,7 +48,7 @@
             <p style="height:24px"></p>
             <div class="row text-center" style="justify-content: center">
                 Wanna tell us about your LoopBack usage? 
-                Click &nbsp;<a href="https://github.com/strongloop/loopback-next/issues/3047" target="_blank" rel="noopener noreferrer"> here</a>.
+                Click &nbsp;<a href="https://github.com/loopbackio/loopback-next/issues/3047" target="_blank" rel="noopener noreferrer"> here</a>.
             </div>
             <p style="height:24px"></p>
             <div class="row text-center" style="justify-content: center">


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

as part of https://github.com/loopbackio/loopback-next/issues/7595.

What I've changed in this PR: 
- I've updated the `update-readmes.sh` with the updated org location
- links in the web pages in loopback.io
- update links in package.json and README.md

What I haven't changed:
- I didn't update the readme*.html, because they are copied over from the repositories themselves in the next Travis. 
- there are copyright footer and logo that need to be changed. Will update when I have the info.