### PR TITLE
update the banner for openjsf news

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     
     <!--Header alert -->
     <div class="header-alert">
-        <p class="centered-regular">LoopBack won API World's 2019 Best in API Middleware category, see <a href="https://strongloop.com/strongblog/loopback-2019-api-award-api-middleware/" target="_blank" rel="noopener noreferrer">our announcement post.</a></p>
+        <p class="centered-regular">LoopBack joins OpenJS Foundation as new incubating project, see <a href="https://openjsf.org/blog/2021/06/02/loopback-joins-openjs-foundation-as-new-incubating-project/" target="_blank" rel="noopener noreferrer">the announcement post.</a></p>
     </div>
     <!-- Header -->
     <div class="masthead">


### PR DESCRIPTION
Tested it locally
<img width="1078" alt="Screen Shot 2021-08-06 at 10 59 08 AM" src="https://user-images.githubusercontent.com/25489897/128536266-26a8066b-cad0-4d27-b6f4-1710a83c6705.png">

Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>