### PR TITLE
chore: allow manual trigger for GH actions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches:
       - gh-pages
-
+  workflow_dispatch:
+    branches:
+      - gh-pages
+      
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - gh-pages
+  workflow_dispatch:
+    branches:
+      - gh-pages
 
 jobs:
   build:


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

according to https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow, there's a way to manually trigger the GH actions. 

adding @marioestradarosa as the reviewer, as we were looking into this towards the end of last year.