### PR TITLE
feat: add sample CSAF 2.0 document

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "pages/en/sec/*.csaf.json"
+            ],
+            "url": "https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json"
+        }
+    ]
+}

--- a/pages/en/sec/Security-advisories.md
+++ b/pages/en/sec/Security-advisories.md
@@ -21,3 +21,27 @@ Some advisories may require action on your part, for example to upgrade certain 
 ## How to report a security issue
 
 If you think you have discovered a new security issue with any StrongLoop package, please do not report it on GitHub.  Instead, send an email to [reachsl@us.ibm.com](mailto:reachsl@us.ibm.com) with a full description and steps to reproduce.
+
+## Resources
+
+The security advisories are accessible as human-readable HTML files and <a href="https://docs.oasis-open.org/csaf/csaf/v2.0/cs01/csaf-v2.0-cs01.html">OASIS <abbr title="Common Security Advisory Framework Version">CSAF</abbr> 2.0</a> documents.
+
+### OASIS CSAF 2.0
+
+OASIS CSAF 2.0 is the latest specification to "standardize existing practice in structured machine-readable vulnerability-related advisories". LoopBack takes on the role of a CSAF Publisher, and provides the following resources:
+
+- Freely-accessible, valid, <abbr title="Traffic Light Protocol">TLP</abbr>:WHITE CSAF documents with valid filenames over <abbr title="Transport Layer Security">TLS</abbr> only (Requirement 1, 2, 3, 4)
+
+The following resources are NOT available yet but are planned:
+
+- HTTP Header-based redirection, if needed (Requirement 6)
+- `provider-metadata.json` with <a href="https://loopback.io/.well-known/csaf/provider-metadata.json">well-known</a> URL (Requirement 7, 9)
+- `https://csaf.data.security.loopback.io` web server (Requirement 10)
+- Valid <abbr title="Resource-Oriented Lightweight Information Exchange">ROLIE</abbr> feed document (TLP:WHITE) (Requirement 15)
+- Valid ROLIE service document (Requirement 16)
+- Valid ROLIE category document (Requirement 17)
+- CSAF document hash file (Requirement 18)
+- CSAF document detached OpenPGP signatures (Requirement 19)
+- Public PGP key (Requirement 20)
+
+Other CSAF 2.0 resources not mentioned above are NOT available with no plans for adoption.

--- a/pages/en/sec/Security-advisory-11-30-2020.md
+++ b/pages/en/sec/Security-advisory-11-30-2020.md
@@ -11,6 +11,7 @@ permalink: /doc/en/sec/Security-advisory-11-30-2020.html
 
 - **Security risk**: High (CVSS: 7.3), [CVE link](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-4988)
 - **Vulnerability**: `@loopback/rest` allows REST APIs to have `constructor` in the JSON payload, which is vulnerable to prototype pollution.
+- **CSAF 2.0**: https://loopback.io/doc/en/sec/lbsa-20201130.csaf.json
 
 ### Description
 

--- a/pages/en/sec/lbsa-20201130.csaf.json
+++ b/pages/en/sec/lbsa-20201130.csaf.json
@@ -1,0 +1,200 @@
+{
+  "document": {
+    "acknowledgments": [
+      {
+        "names": [
+          "Olivier Beg",
+          "Samuel Erb"
+        ]
+      }
+    ],
+    "category": "security_advisory",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Disclosure is not limited.",
+      "tlp": {
+        "label": "WHITE"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "audience": "all",
+        "category": "description",
+        "text": "It's a similar issue as https://snyk.io/vuln/SNYK-JS-LODASH-73638, where the following description is quoted from.\n\n> Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n>\n> There are two main ways in which the pollution of prototypes occurs:\n>\n> - Unsafe Object recursive merge\n> - Property definition by path"
+      },
+      {
+        "audience": "all",
+        "category": "summary",
+        "text": "`@loopback/rest` allows REST APIs to have `constructor` in the JSON payload, which is vulnerable to prototype pollution."
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "The LoopBack Maintainers",
+      "namespace": "https://loopback.io"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "Security Advisory 11-30-2020 CSAF document",
+        "url": "https://loopback.io/doc/en/sec/lbsa-2020-11-30.csaf.json"
+      },
+      {
+        "category": "self",
+        "summary": "Security Advisory 11-30-2020 HTML document",
+        "url": "https://loopback.io/doc/en/sec/Security-advisory-11-30-2020.html"
+      },
+      {
+        "summary": "X-Force Vulnerability Report",
+        "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/192706"
+      }
+    ],
+    "title": "Security Advisory 11-30-2020",
+    "tracking": {
+      "current_release_date": "2022-01-17T00:00:00.000Z",
+      "id": "lbsa-20201130",
+      "initial_release_date": "2022-01-17T00:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2022-01-17T00:00:00.000Z",
+          "number": "1.0.0",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1.0.0"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "branches": [
+                  {
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "Version 8.0.0",
+                        "product": {
+                          "name": "@loopback/rest - Version8.0.0",
+                          "product_id": "1",
+                          "product_identification_helper": {
+                            "cpe": "cpe:2.3:a:loopback:loopback_rest:8.0.0",
+                            "purl": "pkg:npm/%40loopback/rest@8.0.0"
+                          }
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "Version 9.0.0",
+                        "product": {
+                          "name": "@loopback/rest - Version 9.0.0",
+                          "product_id": "2",
+                          "product_identification_helper": {
+                            "cpe": "cpe:2.3:a:loopback:loopback_rest:9.0.0",
+                            "purl": "pkg:npm/%40loopback/rest@9.0.0"
+                          }
+                        }
+                      }
+                    ],
+                    "category": "product_name",
+                    "name": "@loopback/rest"
+                  }
+                ],
+                "category": "product_family",
+                "name": "LoopBack 4"
+              }
+            ],
+            "category": "product_family",
+            "name": "LoopBack"
+          }
+        ],
+        "category": "vendor",
+        "name": "The LoopBack Maintainers"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2020-4988",
+      "cwe": {
+        "id": "CWE-1321",
+        "name": "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')"
+      },
+      "id": {
+        "system_name": "IBM X-Force ID",
+        "text": "192706"
+      },
+      "notes": [
+        {
+          "audience": "all",
+          "category": "description",
+          "text": "It's a similar issue as https://snyk.io/vuln/SNYK-JS-LODASH-73638, where the following description is quoted from.\n\n> Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n>\n> There are two main ways in which the pollution of prototypes occurs:\n>\n> - Unsafe Object recursive merge\n> - Property definition by path"
+        },
+        {
+          "audience": "all",
+          "category": "summary",
+          "text": "`@loopback/rest` allows REST APIs to have `constructor` in the JSON payload, which is vulnerable to prototype pollution."
+        }
+      ],
+      "product_status": {
+        "first_affected": [
+          "1"
+        ],
+        "fixed": [
+          "2"
+        ]
+      },
+      "references": [
+        {
+          "summary": "GitHub pull request",
+          "url": "https://github.com/loopbackio/loopback-next/pull/6676"
+        },
+        {
+          "summary": "X-Force Vulnerability Report",
+          "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/192706"
+        }
+      ],
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "date": "2020-05-11T08:22:42.000Z",
+          "details": "Upgrade to `@loopback/rest` 9.0.0 or later.",
+          "product_ids": [
+            "1"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "LOW",
+            "exploitCodeMaturity": "UNPROVEN",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "remediationLevel": "OFFICIAL_FIX",
+            "reportConfidence": "CONFIRMED",
+            "scope": "UNCHANGED",
+            "temporalScore": 6.4,
+            "temporalSeverity": "MEDIUM",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/RL:O/E:U/RC:C",
+            "version": "3.0"
+          },
+          "products": [
+            "1"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[OASIS CSAF (Common Security Advisory Framework Version) 2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/cs01/csaf-v2.0-cs01.html) is the latest specification to "standardize existing practice in structured machine-readable vulnerability-related advisories".

This PR is intended to demonstrate what a minimal, initial adoption of CSAF 2.0 for one of the security advisories may look like, and to get the other maintainers' feedback.

If this PR were to go forward, it would be a minimal implementation of the specification, where we adopt the CSAF Publisher role and thereby only need to provide the CSAF 2.0 documents.

Future iterative improvements may include:

- Generation of other documents from CSAF 2.0 document
    - Generation of security advisory HTML documents
    - Generation of [OASIS CVRF (Common Vulnerability Reporting Framework) 1.2](http://docs.oasis-open.org/csaf/csaf-cvrf/v1.2/cs01/csaf-cvrf-v1.2-cs01.html) - This is the predecessor to CSAF 2.0, which may benefit from a more mature ecosystem of tools.
- CI and Git-verify-hook validation of CSAF 2.0 document (Requirement 1) - Currently, this is done out-of-band using [Secvisogram](https://secvisogram.github.io/).
- Adoption of CSAF Provider or CSAF Trusted Provider role
    - HTTP Header-based redirection, if needed (Requirement 6)
    - `provider-metadata.json` with <a href="https://loopback.io/.well-known/csaf/provider-metadata.json">well-known</a> URL (Requirement 7, 9)
    - `https://csaf.data.security.loopback.io` web server (Requirement 10)
    - Valid <abbr title="Resource-Oriented Lightweight Information Exchange">ROLIE</abbr> feed document (TLP:WHITE) (Requirement 15)
    - Valid ROLIE service document (Requirement 16)
    - Valid ROLIE category document (Requirement 17)
    - CSAF document hash file (Requirement 18)
    - CSAF document detached OpenPGP signatures (Requirement 19)
    - Public PGP key (Requirement 20)

The final endpoint that we should reach towards (i.e. through a long-term sprint) is to adopt an existing, or implement our own CSAF CMS in accordance with the specification.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>