### PR TITLE
update email address for reporting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ exclude:
 
 # these are the files and directories that jekyll will exclude from the build
 
-feedback_email: reachsl@us.ibm.com
+feedback_email: tsc@loopback.io
 # used as a contact email for the Feedback link in the top navigation bar
 
 feedback_disable: true

--- a/pages/en/contrib/Reporting-issues.md
+++ b/pages/en/contrib/Reporting-issues.md
@@ -65,7 +65,7 @@ We take security vulnerabilities in LoopBack very seriously for our users.
 
 In production, do not enable debug logs that may contain sensitive data; for example, the payload of `PersistedModel.create` should not be exposed in production. Logging this type of information is acceptable in development, but not in production.
 
-Do not report security vulnerabilities using GitHub issues. Please send an email to [`reachsl@us.ibm.com`](mailto:reachsl@us.ibm.com) with:
+Do not report security vulnerabilities using GitHub issues. Please send an email to [`security@loopback.io`](mailto:security@loopback.io) with:
 
 - Description of the vulnerability.
 - Steps to reproduce the issue.

--- a/pages/en/contrib/Security-advisories.md
+++ b/pages/en/contrib/Security-advisories.md
@@ -20,4 +20,4 @@ Some advisories may require action on your part, for example to upgrade certain 
 
 ## How to report a security issue
 
-If you think you have discovered a new security issue with any StrongLoop package, please do not report it on GitHub.  Instead, send an email to [reachsl@us.ibm.com](mailto:reachsl@us.ibm.com) with a full description and steps to reproduce.
+If you think you have discovered a new security issue with any StrongLoop package, please do not report it on GitHub.  Instead, send an email to [security@loopback.io](mailto:security@loopback.io) with a full description and steps to reproduce.

--- a/pages/en/sec/Security-advisories.md
+++ b/pages/en/sec/Security-advisories.md
@@ -20,4 +20,4 @@ Some advisories may require action on your part, for example to upgrade certain 
 
 ## How to report a security issue
 
-If you think you have discovered a new security issue with any StrongLoop package, please do not report it on GitHub.  Instead, send an email to [reachsl@us.ibm.com](mailto:reachsl@us.ibm.com) with a full description and steps to reproduce.
+If you think you have discovered a new security issue with any StrongLoop package, please do not report it on GitHub.  Instead, send an email to [security@loopback.io](mailto:security@loopback.io) with a full description and steps to reproduce.

--- a/pages/en/sec/index.md
+++ b/pages/en/sec/index.md
@@ -25,4 +25,4 @@ Advisories may require action on your part, for example to upgrade certain packa
 
 ## How to report a security issue
 
-If you think you have discovered a new security issue with any StrongLoop package, please do not report it on GitHub.  Instead, send an email to [reachsl@us.ibm.com](mailto:reachsl@us.ibm.com) with a full description and steps to reproduce.
+If you think you have discovered a new security issue with any StrongLoop package, please do not report it on GitHub.  Instead, send an email to [security@loopback.io](mailto:security@loopback.io) with a full description and steps to reproduce.


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

We got the 2 email aliases from OpenJS Foundation for reporting, instead of using an IBM email address. 🎉
Updating the corresponding docs in this repo to reflect this change.