### PR TITLE
update footer to include openjsf copyrights

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -142,64 +142,7 @@
 
     <!-- footer -->
     <footer>
-        <div class="container">
-            <div class="row text-center">
-                <div class="col-md-3">
-                    <img src="images/global/loopback-mark-frame-white.svg" width=40px/>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Product</p>
-                    <p class="regular">
-                        <a href="getting-started.html">Getting Started</a>
-                    </p>
-                    <p class="regular">
-                        <a href="doc/en/lb4/Tutorials.html">Tutorials</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase" >Documentation</p>
-                    <p class="regular">
-                        <a href="/doc">Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="resources.html">Resources</a>
-                    </p>
-                    <p class="regular">
-                        <a href="contribute.html">Contribute</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Support</p>
-                    <p class="regular">
-                        <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-                    </p> 
-                    <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-                    </p>
-                </div>
-            </div>
-            <hr class="hairline-footer">
-            <div class="row text-center">
-                <div class="col-md-6">
-                    <p class="regular"> @ Copyright 2020 StrongLoop, an IBM company</p>
-                </div>
-                <div class="col-md-6">
-                    <p style="float:right">
-                        <a class="twitter-share-button"
-                            href="https://twitter.com/intent/tweet?text=Creating APIs has never been easier using %23LoopBack 4 by %40StrongLoop. Check it out at loopback.io.&url= dloopback.io">
-                            Tweet</a>
-                        <a href="https://twitter.com/intent/tweet?screen_name=StrongLoop&ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="true">Tweet to @StrongLoop</a>
-                        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                    </p>
-                </div>
-            </div>
-        </div>
+        <div id="footer-template"></div>
     </footer>
 
     <script src="/dist/jquery/jquery-3.4.1.min.js" crossorigin="anonymous"></script>    
@@ -213,6 +156,7 @@
     <script>
         $(function(){
             $("#navbar-template").load("navbar-template.html"); 
+            $("#footer-template").load("footer-template.html");
         });
     </script>
 

--- a/footer-template.html
+++ b/footer-template.html
@@ -1,0 +1,65 @@
+<div class="container">
+    <div class="row text-center">
+        <div class="col-md-3">
+            <img src="images/global/loopback-mark-frame-white.svg" width=40px/>
+        </div>
+        <div class="col-md-3">
+            <p class="label text-uppercase">Product</p>
+            <p class="regular">
+                <a href="getting-started.html">Getting Started</a>
+            </p>
+            <p class="regular">
+                <a href="doc/en/lb4/Tutorials.html">Tutorials</a>
+            </p>
+        </div>
+        <div class="col-md-3">
+            <p class="label text-uppercase" >Documentation</p>
+            <p class="regular">
+                <a href="/doc">Docs</a>
+            </p>
+            <p class="regular">
+                <a href="resources.html">Resources</a>
+            </p>
+            <p class="regular">
+                <a href="contribute.html">Contribute</a>
+            </p>
+        </div>
+        <div class="col-md-3">
+            <p class="label text-uppercase">Support</p>
+            <p class="regular">
+                <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
+            </p>
+            <p class="regular">
+                <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
+            </p>
+            <p class="regular">
+                <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
+            </p> 
+            <p class="regular">
+                <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
+            </p>
+        </div>
+    </div>
+    <hr class="hairline-footer">
+    <div class="row text-center">
+        <div class="col-md-4"></div>
+        <div class="col-md-8">
+            <p style="float:right">
+                <a class="twitter-share-button"
+                    href="https://twitter.com/intent/tweet?text=Creating APIs has never been easier using %23LoopBack 4 by %40StrongLoop. Check it out at loopback.io.&url=loopback.io">
+                    Tweet</a>
+                <a href="https://twitter.com/intent/tweet?screen_name=StrongLoop&ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="true">Tweet to @StrongLoop</a>
+                <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            </p>
+        </div>
+    </div>
+    <div class="row text-center">
+        <div class="col-md-2">
+            <a href="https://openjsf.org"><img class="openjs-logo" src="https://nodered.org/images/openjs_foundation-logo.svg" /></a>
+        </div>
+        <div class="col-md-10">
+            <p class="regular">Copyright IBM Corp., <a href="https://openjsf.org">OpenJS Foundation</a> and LoopBack contributors. All rights reserved. The <a href="https://openjsf.org">OpenJS Foundation</a> has registered trademarks and uses trademarks.  For a list of trademarks of the <a href="https://openjsf.org">OpenJS Foundation</a>, please see our <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> and <a href="https://trademark-list.openjsf.org">Trademark List</a>.  Trademarks and logos not indicated on the <a href="https://trademark-list.openjsf.org">list of OpenJS Foundation trademarks</a> are trademarks&trade; or registered&reg; trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.</p>
+<p><a href="https://openjsf.org">The OpenJS Foundation</a> | <a href="https://terms-of-use.openjsf.org">Terms of Use</a> | <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> | <a href="https://bylaws.openjsf.org">Bylaws</a> | <a href="https://code-of-conduct.openjsf.org">Code of Conduct</a> | <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> | <a href="https://trademark-list.openjsf.org">Trademark List</a> | <a href="https://www.linuxfoundation.org/cookies">Cookie Policy</a></p>
+        </div>
+    </div>
+</div>

--- a/getting-started.html
+++ b/getting-started.html
@@ -236,64 +236,7 @@ Controller Hello was now created in src/controllers/
 
     <!-- footer -->
     <footer>
-        <div class="container">
-            <div class="row text-center">
-                <div class="col-md-3">
-                    <img src="images/global/loopback-mark-frame-white.svg" width=40px/>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Product</p>
-                    <p class="regular">
-                        <a href="getting-started.html">Getting Started</a>
-                    </p>
-                    <p class="regular">
-                        <a href="doc/en/lb4/Tutorials.html">Tutorials</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase" >Documentation</p>
-                    <p class="regular">
-                        <a href="/doc">Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="resources.html">Resources</a>
-                    </p>
-                    <p class="regular">
-                        <a href="contribute.html">Contribute</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Support</p>
-                    <p class="regular">
-                        <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-                    </p>
-                </div>
-            </div>
-            <hr class="hairline-footer">
-            <div class="row text-center">
-                <div class="col-md-6">
-                    <p class="regular"> &copy; Copyright 2020 StrongLoop, an IBM company</p>
-                </div>
-                <div class="col-md-6">
-                    <p style="float:right">
-                        <a class="twitter-share-button"
-                            href="https://twitter.com/intent/tweet?text=Creating APIs has never been easier using %23LoopBack 4 by %40StrongLoop. Check it out at loopback.io.&url=loopback.io">
-                          Tweet</a>
-                        <a href="https://twitter.com/intent/tweet?screen_name=StrongLoop&ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="true">Tweet to @StrongLoop</a>
-                        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                    </p>
-                </div>
-            </div>
-        </div>
+        <div id="footer-template"></div>
     </footer>
 
     <script src="/dist/jquery/jquery-3.4.1.min.js" crossorigin="anonymous"></script>
@@ -307,6 +250,7 @@ Controller Hello was now created in src/controllers/
     <script>
         $(function(){
             $("#navbar-template").load("navbar-template.html");
+            $("#footer-template").load("footer-template.html");
         });
     </script>
 

--- a/index.html
+++ b/index.html
@@ -403,64 +403,7 @@
 
     <!-- footer -->
     <footer>
-        <div class="container">
-            <div class="row text-center">
-                <div class="col-md-3">
-                    <img src="images/global/loopback-mark-frame-white.svg" width=40px/>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Product</p>
-                    <p class="regular">
-                        <a href="getting-started.html">Getting Started</a>
-                    </p>
-                    <p class="regular">
-                        <a href="doc/en/lb4/Tutorials.html">Tutorials</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase" >Documentation</p>
-                    <p class="regular">
-                        <a href="/doc">Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="resources.html">Resources</a>
-                    </p>
-                    <p class="regular">
-                        <a href="contribute.html">Contribute</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Support</p>
-                    <p class="regular">
-                        <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-                    </p> 
-                    <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-                    </p>
-                </div>
-            </div>
-            <hr class="hairline-footer">
-            <div class="row text-center">
-                <div class="col-md-6">
-                    <p class="regular"> &copy; Copyright 2020 StrongLoop, an IBM company</p>
-                </div>
-                <div class="col-md-6">
-                    <p style="float:right">
-                        <a class="twitter-share-button"
-                            href="https://twitter.com/intent/tweet?text=Creating APIs has never been easier using %23LoopBack 4 by %40StrongLoop. Check it out at loopback.io.&url=loopback.io">
-                          Tweet</a>
-                        <a href="https://twitter.com/intent/tweet?screen_name=StrongLoop&ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="true">Tweet to @StrongLoop</a>
-                        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                    </p>
-                </div>
-            </div>
-        </div>
+        <div id="footer-template"></div>
     </footer>
 
     <script src="/dist/jquery/jquery-3.4.1.min.js" crossorigin="anonymous"></script>    
@@ -474,6 +417,7 @@
     <script>
         $(function(){
             $("#navbar-template").load("navbar-template.html"); 
+            $("#footer-template").load("footer-template.html");
         });
     </script>
 

--- a/resources.html
+++ b/resources.html
@@ -404,64 +404,7 @@
 
     <!-- footer -->
     <footer>
-        <div class="container">
-            <div class="row text-center">
-                <div class="col-md-3">
-                    <img src="images/global/loopback-mark-frame-white.svg" width=40px/>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Product</p>
-                    <p class="regular">
-                        <a href="getting-started.html">Getting Started</a>
-                    </p>
-                    <p class="regular">
-                        <a href="doc/en/lb4/Tutorials.html">Tutorials</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase" >Documentation</p>
-                    <p class="regular">
-                        <a href="/doc">Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="resources.html">Resources</a>
-                    </p>
-                    <p class="regular">
-                        <a href="contribute.html">Contribute</a>
-                    </p>
-                </div>
-                <div class="col-md-3">
-                    <p class="label text-uppercase">Support</p>
-                    <p class="regular">
-                        <a href="/doc/en/lb4">LoopBack 4 Documentation</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
-                    </p>
-                    <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-                    </p> 
-                    <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-                    </p>
-                </div>
-            </div>
-            <hr class="hairline-footer">
-            <div class="row text-center">
-                <div class="col-md-6">
-                    <p class="regular"> &copy; Copyright 2020 StrongLoop, an IBM company</p>
-                </div>
-                <div class="col-md-6">
-                    <p style="float:right">
-                        <a class="twitter-share-button"
-                            href="https://twitter.com/intent/tweet?text=Creating APIs has never been easier using %23LoopBack 4 by %40StrongLoop. Check it out at loopback.io.&url=loopback.io">
-                          Tweet</a>
-                        <a href="https://twitter.com/intent/tweet?screen_name=StrongLoop&ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="true">Tweet to @StrongLoop</a>
-                        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                    </p>
-                </div>
-            </div>
-        </div>
+        <div id="footer-template"></div>
     </footer>
 
     <!-- Scripts -->
@@ -476,6 +419,7 @@
     <script>
         $(function(){
             $("#navbar-template").load("navbar-template.html"); 
+            $("#footer-template").load("footer-template.html");
         });
     </script>
 


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

Fixes https://github.com/loopbackio/loopback-governance/issues/23

2 main changes in this PR:
- move the footer to be in a template
- update the footer to include openjsf copyright

See the output: 
![Screen Shot 2022-03-25 at 8 06 22 PM](https://user-images.githubusercontent.com/25489897/160216259-e5c85a15-0865-41e0-90fe-20da6ab4428e.png)

