### PR TITLE
chore: update changelog manually

### DIFF
--- a/pages/en/lb4/changelogs/bodyparsers/rest-msgpack/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/bodyparsers/rest-msgpack/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.rest-msgpack.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.1](https://github.com/loopbackio/loopback-next/compare/@loopback/rest-msgpack@0.7.0...@loopback/rest-msgpack@0.7.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/rest-msgpack
+
+
+
+
+
 # [0.7.0](https://github.com/loopbackio/loopback-next/compare/@loopback/rest-msgpack@0.6.1...@loopback/rest-msgpack@0.7.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/access-control-migration/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/access-control-migration/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-access-control-migration.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-access-control-migration@4.1.0...@loopback/example-access-control-migration@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-access-control-migration
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-access-control-migration@4.0.1...@loopback/example-access-control-migration@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/binding-resolution/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/binding-resolution/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-binding-resolution.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-binding-resolution@0.6.0...@loopback/example-binding-resolution@0.6.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-binding-resolution
+
+
+
+
+
 # [0.6.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-binding-resolution@0.5.1...@loopback/example-binding-resolution@0.6.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/context/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/context/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-context.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-context@4.1.0...@loopback/example-context@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-context
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-context@4.0.1...@loopback/example-context@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/express-composition/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/express-composition/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-express-composition.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-express-composition@4.1.0...@loopback/example-express-composition@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-express-composition
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-express-composition@4.0.1...@loopback/example-express-composition@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/file-transfer/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/file-transfer/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-file-transfer.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-file-transfer@3.1.0...@loopback/example-file-transfer@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-file-transfer
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-file-transfer@3.0.1...@loopback/example-file-transfer@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/graphql/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/graphql/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-graphql.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-graphql@0.6.0...@loopback/example-graphql@0.6.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-graphql
+
+
+
+
+
 # [0.6.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-graphql@0.5.1...@loopback/example-graphql@0.6.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/greeter-extension/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/greeter-extension/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-greeter-extension.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-greeter-extension@4.1.0...@loopback/example-greeter-extension@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-greeter-extension
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-greeter-extension@4.0.1...@loopback/example-greeter-extension@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/greeting-app/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/greeting-app/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-greeting-app.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-greeting-app@4.1.0...@loopback/example-greeting-app@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-greeting-app
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-greeting-app@4.0.1...@loopback/example-greeting-app@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/hello-world/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/hello-world/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-hello-world.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-hello-world@4.1.0...@loopback/example-hello-world@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-hello-world
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-hello-world@4.0.1...@loopback/example-hello-world@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/lb3-application/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/lb3-application/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-lb3-application.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-lb3-application@4.1.0...@loopback/example-lb3-application@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-lb3-application
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-lb3-application@4.0.1...@loopback/example-lb3-application@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/log-extension/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/log-extension/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-log-extension.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-log-extension@4.1.0...@loopback/example-log-extension@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-log-extension
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-log-extension@4.0.1...@loopback/example-log-extension@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/metrics-prometheus/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/metrics-prometheus/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-metrics-prometheus.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-metrics-prometheus@0.9.0...@loopback/example-metrics-prometheus@0.9.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-metrics-prometheus
+
+
+
+
+
 # [0.9.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-metrics-prometheus@0.8.1...@loopback/example-metrics-prometheus@0.9.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/multi-tenancy/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/multi-tenancy/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-multi-tenancy.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.12.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-multi-tenancy@0.12.0...@loopback/example-multi-tenancy@0.12.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-multi-tenancy
+
+
+
+
+
 # [0.12.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-multi-tenancy@0.11.1...@loopback/example-multi-tenancy@0.12.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/passport-login/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/passport-login/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-passport-login.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-passport-login@3.1.0...@loopback/example-passport-login@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-passport-login
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-passport-login@3.0.1...@loopback/example-passport-login@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/rest-crud/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/rest-crud/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-rest-crud.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-rest-crud@3.1.0...@loopback/example-rest-crud@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-rest-crud
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-rest-crud@3.0.1...@loopback/example-rest-crud@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/rpc-server/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/rpc-server/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-rpc-server.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-rpc-server@4.1.0...@loopback/example-rpc-server@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-rpc-server
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-rpc-server@4.0.1...@loopback/example-rpc-server@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/soap-calculator/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/soap-calculator/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-soap-calculator.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-soap-calculator@4.1.0...@loopback/example-soap-calculator@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-soap-calculator
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-soap-calculator@4.0.1...@loopback/example-soap-calculator@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/socketio/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/socketio/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-socketio.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-socketio@0.5.0...@loopback/example-socketio@0.5.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-socketio
+
+
+
+
+
 # [0.5.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-socketio@0.4.1...@loopback/example-socketio@0.5.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/todo-jwt/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/todo-jwt/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-todo-jwt.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-todo-jwt@3.1.0...@loopback/example-todo-jwt@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-todo-jwt
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-todo-jwt@3.0.1...@loopback/example-todo-jwt@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/todo-list/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/todo-list/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-todo-list.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-todo-list@5.1.0...@loopback/example-todo-list@5.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-todo-list
+
+
+
+
+
 # [5.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-todo-list@5.0.1...@loopback/example-todo-list@5.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/todo/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/todo/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-todo.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-todo@5.1.0...@loopback/example-todo@5.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-todo
+
+
+
+
+
 # [5.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-todo@5.0.1...@loopback/example-todo@5.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/validation-app/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/validation-app/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-validation-app.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-validation-app@3.1.0...@loopback/example-validation-app@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-validation-app
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-validation-app@3.0.1...@loopback/example-validation-app@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/examples/webpack/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/examples/webpack/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.example-webpack.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.1](https://github.com/loopbackio/loopback-next/compare/@loopback/example-webpack@0.7.0...@loopback/example-webpack@0.7.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/example-webpack
+
+
+
+
+
 # [0.7.0](https://github.com/loopbackio/loopback-next/compare/@loopback/example-webpack@0.6.1...@loopback/example-webpack@0.7.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/apiconnect/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/apiconnect/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.apiconnect.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.9.1](https://github.com/loopbackio/loopback-next/compare/@loopback/apiconnect@0.9.0...@loopback/apiconnect@0.9.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/apiconnect
+
+
+
+
+
 # [0.9.0](https://github.com/loopbackio/loopback-next/compare/@loopback/apiconnect@0.8.1...@loopback/apiconnect@0.9.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/authentication-jwt/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/authentication-jwt/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.authentication-jwt.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.1](https://github.com/loopbackio/loopback-next/compare/@loopback/authentication-jwt@0.11.0...@loopback/authentication-jwt@0.11.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/authentication-jwt
+
+
+
+
+
 # [0.11.0](https://github.com/loopbackio/loopback-next/compare/@loopback/authentication-jwt@0.10.1...@loopback/authentication-jwt@0.11.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/authentication-passport/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/authentication-passport/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.authentication-passport.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/authentication-passport@4.1.0...@loopback/authentication-passport@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/authentication-passport
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/authentication-passport@4.0.1...@loopback/authentication-passport@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/context-explorer/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/context-explorer/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.context-explorer.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.1](https://github.com/loopbackio/loopback-next/compare/@loopback/context-explorer@0.7.0...@loopback/context-explorer@0.7.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/context-explorer
+
+
+
+
+
 # [0.7.0](https://github.com/loopbackio/loopback-next/compare/@loopback/context-explorer@0.6.1...@loopback/context-explorer@0.7.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/cron/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/cron/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.cron.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/loopbackio/loopback-next/compare/@loopback/cron@0.8.0...@loopback/cron@0.8.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/cron
+
+
+
+
+
 # [0.8.0](https://github.com/loopbackio/loopback-next/compare/@loopback/cron@0.7.1...@loopback/cron@0.8.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/graphql/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/graphql/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.graphql.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.1](https://github.com/loopbackio/loopback-next/compare/@loopback/graphql@0.7.0...@loopback/graphql@0.7.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/graphql
+
+
+
+
+
 # [0.7.0](https://github.com/loopbackio/loopback-next/compare/@loopback/graphql@0.6.1...@loopback/graphql@0.7.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/health/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/health/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.health.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.10.1](https://github.com/loopbackio/loopback-next/compare/@loopback/health@0.10.0...@loopback/health@0.10.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/health
+
+
+
+
+
 # [0.10.0](https://github.com/loopbackio/loopback-next/compare/@loopback/health@0.9.1...@loopback/health@0.10.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/logging/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/logging/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.logging.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/loopbackio/loopback-next/compare/@loopback/logging@0.8.0...@loopback/logging@0.8.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/logging
+
+
+
+
+
 # [0.8.0](https://github.com/loopbackio/loopback-next/compare/@loopback/logging@0.7.1...@loopback/logging@0.8.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/metrics/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/metrics/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.metrics.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.10.1](https://github.com/loopbackio/loopback-next/compare/@loopback/metrics@0.10.0...@loopback/metrics@0.10.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/metrics
+
+
+
+
+
 # [0.10.0](https://github.com/loopbackio/loopback-next/compare/@loopback/metrics@0.9.1...@loopback/metrics@0.10.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/pooling/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/pooling/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.pooling.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.1](https://github.com/loopbackio/loopback-next/compare/@loopback/pooling@0.7.0...@loopback/pooling@0.7.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/pooling
+
+
+
+
+
 # [0.7.0](https://github.com/loopbackio/loopback-next/compare/@loopback/pooling@0.6.1...@loopback/pooling@0.7.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/socketio/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/socketio/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.socketio.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.1](https://github.com/loopbackio/loopback-next/compare/@loopback/socketio@0.5.0...@loopback/socketio@0.5.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/socketio
+
+
+
+
+
 # [0.5.0](https://github.com/loopbackio/loopback-next/compare/@loopback/socketio@0.4.1...@loopback/socketio@0.5.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/extensions/typeorm/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/extensions/typeorm/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.typeorm.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.1](https://github.com/loopbackio/loopback-next/compare/@loopback/typeorm@0.6.0...@loopback/typeorm@0.6.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/typeorm
+
+
+
+
+
 # [0.6.0](https://github.com/loopbackio/loopback-next/compare/@loopback/typeorm@0.5.1...@loopback/typeorm@0.6.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/authentication/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/authentication/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.authentication.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/authentication@8.1.0...@loopback/authentication@8.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/authentication
+
+
+
+
+
 # [8.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/authentication@8.0.1...@loopback/authentication@8.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/authorization/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/authorization/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.authorization.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.1](https://github.com/loopbackio/loopback-next/compare/@loopback/authorization@0.11.0...@loopback/authorization@0.11.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/authorization
+
+
+
+
+
 # [0.11.0](https://github.com/loopbackio/loopback-next/compare/@loopback/authorization@0.10.1...@loopback/authorization@0.11.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/boot/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/boot/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.boot.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/boot@4.1.0...@loopback/boot@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/boot
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/boot@4.0.1...@loopback/boot@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/booter-lb3app/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/booter-lb3app/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.booter-lb3app.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/booter-lb3app@3.1.0...@loopback/booter-lb3app@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/booter-lb3app
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/booter-lb3app@3.0.1...@loopback/booter-lb3app@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/build/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/build/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.build.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.1.2](https://github.com/loopbackio/loopback-next/compare/@loopback/build@8.1.1...@loopback/build@8.1.2) (2022-03-29)
+
+**Note:** Version bump only for package @loopback/build
+
+
+
+
+
 ## [8.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/build@8.1.0...@loopback/build@8.1.1) (2022-02-28)
 
 **Note:** Version bump only for package @loopback/build

--- a/pages/en/lb4/changelogs/packages/cli/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/cli/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.cli.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/cli@3.1.0...@loopback/cli@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/cli
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/cli@3.0.1...@loopback/cli@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/context/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/context/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.context.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/context@4.1.0...@loopback/context@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/context
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/context@4.0.1...@loopback/context@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/core/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/core/CHANGELOG.md
@@ -13,6 +13,17 @@ permalink: /doc/en/lb4/changelog.core.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/core@3.1.0...@loopback/core@3.1.1) (2022-02-28)
+
+
+### Bug Fixes
+
+* honor service injection options ([65ec864](https://github.com/loopbackio/loopback-next/commit/65ec8643682b4aa444657ffa32b6c692e48e82f2))
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/core@3.0.1...@loopback/core@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/eslint-config/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/eslint-config/CHANGELOG.md
@@ -13,6 +13,18 @@ permalink: /doc/en/lb4/changelog.eslint-config.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [12.0.4](https://github.com/loopbackio/loopback-next/compare/@loopback/eslint-config@12.0.3...@loopback/eslint-config@12.0.4) (2022-03-29)
+
+
+### Bug Fixes
+
+* ignore HTTP code-like object members ([493e275](https://github.com/loopbackio/loopback-next/commit/493e2759ef7749b4d2ff7499318b7a6232e74d0d))
+* ignore MIME type-like object members ([f282dca](https://github.com/loopbackio/loopback-next/commit/f282dcab18addf63a2fad45fb7b1f0da97c27390))
+
+
+
+
+
 ## [12.0.3](https://github.com/loopbackio/loopback-next/compare/@loopback/eslint-config@12.0.2...@loopback/eslint-config@12.0.3) (2022-02-28)
 
 **Note:** Version bump only for package @loopback/eslint-config

--- a/pages/en/lb4/changelogs/packages/express/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/express/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.express.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/express@4.1.0...@loopback/express@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/express
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/express@4.0.1...@loopback/express@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/filter/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/filter/CHANGELOG.md
@@ -13,6 +13,22 @@ permalink: /doc/en/lb4/changelog.filter.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.2](https://github.com/loopbackio/loopback-next/compare/@loopback/filter@2.1.1...@loopback/filter@2.1.2) (2022-03-29)
+
+**Note:** Version bump only for package @loopback/filter
+
+
+
+
+
+## [2.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/filter@2.1.0...@loopback/filter@2.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/filter
+
+
+
+
+
 # [2.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/filter@2.0.1...@loopback/filter@2.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/http-caching-proxy/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/http-caching-proxy/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.http-caching-proxy.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/http-caching-proxy@3.1.0...@loopback/http-caching-proxy@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/http-caching-proxy
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/http-caching-proxy@3.0.1...@loopback/http-caching-proxy@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/http-server/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/http-server/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.http-server.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/http-server@3.1.0...@loopback/http-server@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/http-server
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/http-server@3.0.1...@loopback/http-server@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/metadata/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/metadata/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.metadata.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/metadata@4.1.0...@loopback/metadata@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/metadata
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/metadata@4.0.1...@loopback/metadata@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/model-api-builder/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/model-api-builder/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.model-api-builder.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/model-api-builder@3.1.0...@loopback/model-api-builder@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/model-api-builder
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/model-api-builder@3.0.1...@loopback/model-api-builder@3.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/monorepo/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/monorepo/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.monorepo.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.4](https://github.com/loopbackio/loopback-next/compare/@loopback/monorepo@0.4.3...@loopback/monorepo@0.4.4) (2022-03-29)
+
+**Note:** Version bump only for package @loopback/monorepo
+
+
+
+
+
 ## [0.4.3](https://github.com/loopbackio/loopback-next/compare/@loopback/monorepo@0.4.2...@loopback/monorepo@0.4.3) (2022-02-28)
 
 **Note:** Version bump only for package @loopback/monorepo

--- a/pages/en/lb4/changelogs/packages/openapi-spec-builder/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/openapi-spec-builder/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.openapi-spec-builder.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/openapi-spec-builder@4.1.0...@loopback/openapi-spec-builder@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/openapi-spec-builder
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/openapi-spec-builder@4.0.1...@loopback/openapi-spec-builder@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/openapi-v3/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/openapi-v3/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.openapi-v3.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/openapi-v3@7.1.0...@loopback/openapi-v3@7.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/openapi-v3
+
+
+
+
+
 # [7.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/openapi-v3@7.0.1...@loopback/openapi-v3@7.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/repository-json-schema/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/repository-json-schema/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.repository-json-schema.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/repository-json-schema@5.1.0...@loopback/repository-json-schema@5.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/repository-json-schema
+
+
+
+
+
 # [5.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/repository-json-schema@5.0.1...@loopback/repository-json-schema@5.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/repository-tests/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/repository-tests/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.repository-tests.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.20.1](https://github.com/loopbackio/loopback-next/compare/@loopback/repository-tests@0.20.0...@loopback/repository-tests@0.20.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/repository-tests
+
+
+
+
+
 # [0.20.0](https://github.com/loopbackio/loopback-next/compare/@loopback/repository-tests@0.19.1...@loopback/repository-tests@0.20.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/repository/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/repository/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.repository.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/repository@4.1.0...@loopback/repository@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/repository
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/repository@4.0.1...@loopback/repository@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/rest-crud/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/rest-crud/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.rest-crud.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.1](https://github.com/loopbackio/loopback-next/compare/@loopback/rest-crud@0.13.0...@loopback/rest-crud@0.13.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/rest-crud
+
+
+
+
+
 # [0.13.0](https://github.com/loopbackio/loopback-next/compare/@loopback/rest-crud@0.12.1...@loopback/rest-crud@0.13.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/rest-explorer/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/rest-explorer/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.rest-explorer.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/rest-explorer@4.1.0...@loopback/rest-explorer@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/rest-explorer
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/rest-explorer@4.0.1...@loopback/rest-explorer@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/rest/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/rest/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.rest.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/rest@11.1.0...@loopback/rest@11.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/rest
+
+
+
+
+
 # [11.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/rest@11.0.1...@loopback/rest@11.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/security/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/security/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.security.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.1](https://github.com/loopbackio/loopback-next/compare/@loopback/security@0.7.0...@loopback/security@0.7.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/security
+
+
+
+
+
 # [0.7.0](https://github.com/loopbackio/loopback-next/compare/@loopback/security@0.6.1...@loopback/security@0.7.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/service-proxy/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/service-proxy/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.service-proxy.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/service-proxy@4.1.0...@loopback/service-proxy@4.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/service-proxy
+
+
+
+
+
 # [4.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/service-proxy@4.0.1...@loopback/service-proxy@4.1.0) (2022-02-14)
 
 

--- a/pages/en/lb4/changelogs/packages/testlab/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/testlab/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.testlab.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.2](https://github.com/loopbackio/loopback-next/compare/@loopback/testlab@4.1.1...@loopback/testlab@4.1.2) (2022-03-29)
+
+**Note:** Version bump only for package @loopback/testlab
+
+
+
+
+
 ## [4.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/testlab@4.1.0...@loopback/testlab@4.1.1) (2022-02-28)
 
 **Note:** Version bump only for package @loopback/testlab

--- a/pages/en/lb4/changelogs/packages/tsdocs/CHANGELOG.md
+++ b/pages/en/lb4/changelogs/packages/tsdocs/CHANGELOG.md
@@ -13,6 +13,14 @@ permalink: /doc/en/lb4/changelog.tsdocs.html
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.1](https://github.com/loopbackio/loopback-next/compare/@loopback/tsdocs@3.1.0...@loopback/tsdocs@3.1.1) (2022-02-28)
+
+**Note:** Version bump only for package @loopback/tsdocs
+
+
+
+
+
 # [3.1.0](https://github.com/loopbackio/loopback-next/compare/@loopback/tsdocs@3.0.1...@loopback/tsdocs@3.1.0) (2022-02-14)
 
 


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

For some reason, the latest `@loopback/docs` is not being picked up during build, so the changelogs aren't up-to-date. As an interim solution, i updated it manually by running the following command:
```
npm install @loopback/docs
npm run copydocs
```