### PR TITLE
fix: remove `/blog` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ node_modules
 .jekyll-metadata
 vendor
 .bundle
-blog/


### PR DESCRIPTION
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>