### PR TITLE
docs(typeorm): add info for registering connection

### DIFF
--- a/pages/en/lb4/readmes/loopback-next/extensions/typeorm/README.md
+++ b/pages/en/lb4/readmes/loopback-next/extensions/typeorm/README.md
@@ -58,12 +58,25 @@ export const SqliteConnection: ConnectionOptions = {
   synchronize: true,
 };
 ```
-
 Make sure to install the underlying database driver. For example, if you are
 using SQlite, you'll need to install `sqlite3`.
 
 ```sh
 npm install sqlite3
+```
+
+
+Then, register `SqliteConnection` connection in `application.ts` file as shown below:
+
+```ts
+import {BootMixin} from '@loopback/boot';
+import {RestApplication} from '@loopback/rest';
+import {TypeOrmMixin} from '@loopback/typeorm';
+export class MyApplication extends BootMixin(TypeOrmMixin(RestApplication)) {
+    super(options);
+    this.connection(SqliteConnection);
+    ...
+}
 ```
 
 Refer to the


### PR DESCRIPTION
I tried using `@loopback/typeorm` locally and suddenly getting an error because connection was not coming Then I got an idea to register the connection somewhere in `application.ts` which was also missing in the doc. Hence the PR.

Signed-off-by: bhavyasf <37434313+bhavyasf@users.noreply.github.com>