### PR TITLE
replace Watson search with Algolia DocSearch

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -52,18 +52,9 @@
                 {% if site.feedback_disable == null or site.feedback_disable == false %}
 			{% include feedback.html %}
     {% endif %}
+                
                 <li>
-                    <form id="search" name="search" class="input-group lb-search" action="/search" method="GET">
-                        <input type="text" class="form-control search-bar" placeholder="Search (powered by Watson)" name="q">
-                        {% if page.sidebar contains "lb" %}
-                          <input type="hidden" name="sidebar" value="{{page.sidebar}}">
-                        {% endif %}
-                        <div class="input-group-btn">
-                            <button type="submit" class="btn btn-default" aria-label="search">
-                              <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
-                            </button>
-                        </div>
-                      </form>
+                  <span id="algolia-docsearch"></span>
                 </li>
             </ul>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,10 @@
         });
     </script>
     {% endif %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"/>
 
+    
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 </head>
 <body>
 {% include topnav.html %}
@@ -41,6 +44,19 @@
 </div>
 <!-- /.container -->
     </div>
+    <script type="text/javascript">
+        docsearch({
+          appId: 'JHHAZ68MS2',
+          apiKey: 'd5ea594dd98a77b9e4b27fb69776fa9f',
+          indexName: 'loopback',
+          container: '#algolia-docsearch',
+          searchParameters: {
+            facetFilters: ['lang:en']
+          }
+        });
+      
+      </script>
+
 </body>
 
 </html>


### PR DESCRIPTION
The plan that we're using for Watson Discovery search is no longer available. 
Switching to use Algolia DocSearch. 

Note: When running in my local environment, the Algolia search box only shows up for the first time. Any subsequent pages are still showing the old Watson text box even the code is no longer there. I'd like to submit this PR to further test it. 