### PR TITLE
docs: remove CLA docs

### DIFF
--- a/_includes/content/cla.md
+++ b/_includes/content/cla.md
@@ -71,25 +71,3 @@ To amend the commit message to include the sign off, you can run:
 ```sh
 git commit --amend -s
 ```
-
-### Contributor License Agreement (CLA)
-
-_Note: Some repositories were not migrated from CLA to DCO yet,
-the information below applies only to those repositories that are still
-using CLA._
-
-Like many open source projects, you must agree to the contributor license agreement (CLA)
-before we can accept (merge) your changes. See the [loopback-connector CLA](https://cla.strongloop.com/agreements/strongloop/loopback-connector).
-
-In summary, by submitting your code or doc contributions, you are granting us a right to use
-that code/content under the terms of this agreement, including providing it to
-others. You are also certifying that you wrote it, and that you are
-allowed to license it to us. You are not giving up your copyright in
-your work. The license does not change your rights to use your own
-contributions for any other purpose.
-
-Contributor License Agreements are important because they define the
-chain of ownership of a piece of software. Some companies won't allow
-the use of free software without clear agreements around code ownership.
-That's why many open source projects collect similar agreements from
-contributors. The LoopBack CLA is based on the Apache CLA.


### PR DESCRIPTION
We've moved from CLA to DCO as contribution method a long time ago, so removing the CLA content from the docs.