### PR TITLE
fix: remove "StrongLoop Blog" and "API Connect" under footer

### DIFF
--- a/footer-template.html
+++ b/footer-template.html
@@ -32,12 +32,6 @@
             <p class="regular">
                 <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
             </p>
-            <p class="regular">
-                <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-            </p> 
-            <p class="regular">
-                <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-            </p>
         </div>
     </div>
     <hr class="hairline-footer">

--- a/getting-started-openapi-to-graphql.html
+++ b/getting-started-openapi-to-graphql.html
@@ -213,12 +213,6 @@ redirect_from: /getting-started-oasgraph
                     <p class="regular">
                         <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
-                    <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-                    </p> 
-                    <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-                    </p>
                 </div>
             </div>
             <hr class="hairline-footer">

--- a/openapi-to-graphql.html
+++ b/openapi-to-graphql.html
@@ -195,12 +195,6 @@ redirect_from: /oasgraph
                     <p class="regular">
                         <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
-                    <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-                    </p> 
-                    <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-                    </p>
                 </div>
             </div>
             <hr class="hairline-footer">

--- a/what-our-users-say.html
+++ b/what-our-users-say.html
@@ -379,12 +379,6 @@ LoopBack’s strong TypeScript support, OpenAPI integration, and modular archite
                     <p class="regular">
                         <a href="https://loopback.io/doc/en/lb4/apidocs.index.html" target="_blank" rel="noopener noreferrer">API Docs</a>
                     </p>
-                    <p class="regular">
-                        <a href="https://strongloop.com/strongblog/" target="_blank" rel="noopener noreferrer">StrongLoop Blog</a>
-                    </p> 
-                    <p class="regular">
-                        <a href="https://www.ibm.com/marketplace/api-management" target="_blank" rel="noopener noreferrer">API Connect</a>
-                    </p>
                 </div>
             </div>
             <hr class="hairline-footer">


### PR DESCRIPTION
This PR addresses issue https://github.com/loopbackio/loopback.io/issues/1990 by removing redundant links “StrongLoop Blog” and “API Connect” from the website footer.

**Technical Approach**

To ensure consistency and prevent broken or outdated references:

Removed the “StrongLoop Blog” link from the footer template.
Removed the “API Connect” link from the footer template.
Searched and removed occurrences of these links from child pages where applicable.
Confirmed no residual references remained in shared layout or partial files.

**Changes Included**

Deleted redundant footer link entries.
Cleaned up references across main and child layout files.
Verified layout spacing and alignment remain intact after link removal.
Confirmed that no styling regressions occurred.
Related Issue
Fixes https://github.com/loopbackio/loopback.io/issues/1990

**Screenshots**
Before (Footer with outdated links)
<img width="1078" height="213" alt="image" src="https://github.com/user-attachments/assets/8622bac7-8f84-4250-8c6a-79d86e333b31" />
After (Footer cleaned up)
<img width="3428" height="936" alt="image" src="https://github.com/user-attachments/assets/a4268752-4e6b-4e2b-a832-f47a9759fbf0" />

**Checklist**

- [x]  I have read the CONTRIBUTING.md document.
- [x]  All commits are signed off (DCO compliant).
- [x]  Changes have been tested locally and layout integrity is preserved.