### PR TITLE
fix: upgrade DocSearch to v4 and add version boosting

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
   <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
+  {% if page.url contains '/lb4/' %}
+  <meta name="docsearch:version" content="lb4" />
+  {% elsif page.url contains '/lb3/' %}
+  <meta name="docsearch:version" content="lb3" />
+  {% elsif page.url contains '/lb2/' %}
+  <meta name="docsearch:version" content="lb2" />
+  {% endif %}
   <title>{{ page.title }} | {{ site.site_title }}</title>
   <link rel="stylesheet" href="{{base}}/css/syntax.css">
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,10 +21,11 @@
         });
     </script>
     {% endif %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"/>
+    <link rel="preconnect" href="https://JHHAZ68MS2.algolia.net" crossorigin />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@4"/>
 
     
-    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@4"></script>
 </head>
 <body>
 {% include topnav.html %}
@@ -45,13 +46,22 @@
 <!-- /.container -->
     </div>
     <script type="text/javascript">
+        const path = window.location.pathname;
+        let currentVersion = 'lb4';
+
+        if (path.includes('/lb3/')) {
+            currentVersion = 'lb3';
+        } else if (path.includes('/lb2/')) {
+            currentVersion = 'lb2';
+        }
         docsearch({
           appId: 'JHHAZ68MS2',
           apiKey: 'd5ea594dd98a77b9e4b27fb69776fa9f',
           indexName: 'loopback',
           container: '#algolia-docsearch',
           searchParameters: {
-            facetFilters: ['lang:en']
+            facetFilters: ['language:en'],
+            optionalFilters: [`version:${currentVersion}`]
           }
         });
       


### PR DESCRIPTION
Closes #1487

## Target Issue
Currently, the search engine indexes and displays results from older versions of the API (v3, v2) side-by-side with the current version (v4).

## The Solution
This PR resolves the issue by upgrading to DocSearch v4 and implementing contextual search behavior using Algolia's `optionalFilters`.

By parsing the current URL path, the site now dynamically boosts the ranking of the documentation version the user is currently viewing.

- When on `/lb4/` (or the root index), LoopBack 4 results are boosted.

- When on `/lb3/`, LoopBack 3 results are boosted.

- When on `/lb2/`, LoopBack 2 results are boosted.

This ensures the most relevant results appear first while still allowing users to search across the entire domain.

## Changes Made
- **DocSearch Upgrade:** Bumped `@docsearch/js` and `@docsearch/css` from `v3` to `v4`.

- **Meta Tag Injection (`_includes/head.html`):** Added Liquid templating to dynamically inject the `<meta name="docsearch:version" content="..." />` tag based on the page's directory path.

### Code snippet
```
{% if page.url contains '/lb4/' %}
  <meta name="docsearch:version" content="lb4" />
{% elsif page.url contains '/lb3/' %}
  <meta name="docsearch:version" content="lb3" />
{% elsif page.url contains '/lb2/' %}
  <meta name="docsearch:version" content="lb2" />
{% endif %}
```
- Contextual Search Boosting (`docsearch` initialization): Added logic to parse `window.location.pathname` to identify the user's current version, and passed that value into Algolia's `searchParameters`.

```JavaScript
const path = window.location.pathname;
let currentVersion = 'lb4'; // Default version

if (path.includes('/lb3/')) {
    currentVersion = 'lb3';
} else if (path.includes('/lb2/')) {
    currentVersion = 'lb2';
}

// Inside the docsearch({}) config
searchParameters: {
    optionalFilters: [`version:${currentVersion}`]
}
```
## Post-Merge Requirement
Action Required: Once this is merged and deployed, a manual re-crawl must be triggered in the Algolia Crawler Dashboard to index the new <meta> tags before the frontend optionalFilters will take effect.