### PR TITLE
fix: side panel and search modal overlapping issue

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,7 +60,7 @@
           indexName: 'loopback',
           container: '#algolia-docsearch',
           searchParameters: {
-            facetFilters: ['language:en'],
+            facetFilters: ['lang:en'],
             optionalFilters: [`version:${currentVersion}`]
           }
         });

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -312,6 +312,11 @@ ul#results-container a: hover {
 }
 /* end search */
 
+/* Docsearch container z-index overwrite */
+.DocSearch-Container {
+    z-index: 1000 !important;
+}
+
 .filter-options {
     margin-bottom: 20px;
 }


### PR DESCRIPTION
Fixes #1487

The z-index of side panel overlapping on search modal -
Added the screenshot for reference.
<img width="2492" height="2016" alt="image" src="https://github.com/user-attachments/assets/8274f1df-120e-43a2-8659-96ab94f8f2c3" />

Updated screenshot after fixing z-index issue.
<img width="1245" height="1087" alt="image" src="https://github.com/user-attachments/assets/71d51f7e-38a0-419a-ada1-f39262a84a10" />


Also, I have reverted the config changes for DocSearch facetFilters from 'language' to 'lang'.