### PR TITLE
fix: apidocs table links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@loopback/docs": "latest",
         "chalk": "^5.6.2",
         "fs-extra": "^11.3.6",
+        "glob": "^13.0.6",
         "markdownlint-cli": "^0.49.0",
         "retry": "^0.13.1",
         "swagger-ui-dist": "^5.32.8",
@@ -301,6 +302,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -473,6 +492,16 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/markdown-it": {
@@ -1146,6 +1175,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1171,6 +1210,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@loopback/docs": "latest",
     "chalk": "^5.6.2",
     "fs-extra": "^11.3.6",
+    "glob": "^13.0.6",
     "markdownlint-cli": "^0.49.0",
     "retry": "^0.13.1",
     "swagger-ui-dist": "^5.32.8",

--- a/update-lb4-docs.js
+++ b/update-lb4-docs.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const yaml = require('js-yaml');
 const assert = require('assert');
+const {glob} = require('glob');
 
 const srcDocs = path.resolve(__dirname,'node_modules/@loopback/docs/site');
 const destDocs = path.resolve(__dirname, 'pages/en/lb4');
@@ -82,6 +83,22 @@ function copyFile(input) {
 
 // Most of the connector doc files are in the lb3 dir, copy them for lb4
 copyFile(connectorsReference);
+
+const fixApidocs = async () => {
+    const apidocsFiles = await glob(path.resolve(destDocs, 'apidocs/**/*.md'));
+    for (apidocsFile of apidocsFiles) {
+        try {
+            let contents = fs.readFileSync(apidocsFile, 'utf-8');
+            contents = contents.replaceAll('<td>', '<td markdown="1">');
+            fs.writeFileSync(apidocsFile, contents, 'utf-8');
+        } catch (err) {
+            console.error('failed to update apidocs index %s', err.stack);
+            process.exit(1);
+        }
+    }
+}
+
+fixApidocs();
 
 const fileToUpdate = path.resolve(destDocs, 'Testing-the-API.md');
 


### PR DESCRIPTION
The [previous PR](https://github.com/loopbackio/loopback.io/pull/2028) to fix this was overwritten by the LB4 vendoring script, `update-lb4-docs.js#copyDocs`.

This PR instead performs the mutations as a step after `copyDocs()`.

<details>
<summary>Comparisons</summary>

**Before:**
<img width="1316" height="665" alt="image" src="https://github.com/user-attachments/assets/754a0831-0eeb-4060-a491-4383c9baf932" />

**After:**
<img width="1316" height="665" alt="image" src="https://github.com/user-attachments/assets/83cd71d9-9e9c-4f13-9145-83dc5727fdc9" />
<img width="1316" height="665" alt="image" src="https://github.com/user-attachments/assets/de8d2d97-56a5-4e3b-815a-cd488cefda88" />

</details>