### PR TITLE
feat: support non-root baseurl

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -11,7 +11,7 @@ topnav_dropdowns:
     - title: View
       folderitems:
         - title: LoopBack Overview
-          url: /
+          url: /doc/
         - title: LoopBack 4
           url: /doc/en/lb4/
         - title: LoopBack 3.x

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
 {% if page.last_updated %}<p>Page last updated:</span> {{page.last_updated}}<br/>{% endif %} Site last generated: {{ site.time | date: "%b %-d, %Y"  }}
               </div>
               <div class="col-md-6 footer-right">
-                <p><img src="{{site.url}}/images/company_logo.png" alt="Company logo"/></p>
+                <p><img src="{{site.baseurl | prepend: site.url}}/images/company_logo.png" alt="Company logo"/></p>
               </div>
             </div>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,4 @@
-{% if jekyll.environment == "production" %}
-  {% assign base = site.url %}
-{% endif %}
+{% assign base = site.baseurl | prepend: site.url %}
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/_includes/sidebar_menu_list_items.liquid
+++ b/_includes/sidebar_menu_list_items.liquid
@@ -5,15 +5,20 @@
   <li class="{% if item.children.size > 0 %} {% if item.expand == 'true' %} tree-parent-expand {%else%} tree-parent {% endif %} {%else%} leaf-node {% endif %} {% if pageurl.last == item.url %}active{% endif %}">
     {% if item.children.size > 0 %} <a class="show-hide" href="#"></span> {% endif %}
     {% if item.url %}
-      <a class="page-link" href="{{item.url}}">{{ item.title }}</a>
+      {% assign itemUrl = item.url %}
+      {% assign itemUrlFirstChar = item.url | slice: 0 == '/' %}
+      {% if  itemUrlFirstChar == "/" "%}
+        {% assign itemUrl = itemUrl | prepend: site.baseurl %}
+      {% endif %}
+      <a class="page-link" href="{{itemUrl}}">{{ item.title }}</a>
     {% else %}
       <a class="section-name" href="#">{{ item.title }}</a>
     {% endif %}
-      {% if item.children.size > 0 %}
-      <ul class="nav-list">
-          {% include sidebar_menu_list_items.liquid menuitems=item.children %}
-      </ul>
-      {% endif %}
+    {% if item.children.size > 0 %}
+    <ul class="nav-list">
+        {% include sidebar_menu_list_items.liquid menuitems=item.children %}
+    </ul>
+    {% endif %}
   </li>
   {% endif %}{% comment %} /"if web" {% endcomment %}
 

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -40,9 +40,9 @@
                           {% if folderitem.external_url %}
                             <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
                           {% elsif page.url contains folderitem.url and folderitem.title != 'LoopBack Overview' %}
-                            <li class="dropdownActive"><a href="{{folderitem.url }}">{{folderitem.title}}</a></li>
+                            <li class="dropdownActive"><a href="{{folderitem.url | prepend: site.baseurl}}">{{folderitem.title}}</a></li>
                           {% else %}
-                            <li><a href="{{folderitem.url }}">{{folderitem.title}}</a></li>
+                            <li><a href="{{folderitem.url | prepend: site.baseurl}}">{{folderitem.title}}</a></li>
                           {% endif %}
                         {% endfor %}
                     </ul>

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
         <div id="footer-template"></div>
     </footer>
 
-    <script src="/dist/jquery/jquery-3.4.1.min.js" crossorigin="anonymous"></script>    
+    <script src="dist/jquery/jquery-3.4.1.min.js" crossorigin="anonymous"></script>    
     <script src="dist/popper/1.14.0/umd/popper.min.js"></script>
     <!-- Bootstrap core JavaScript -->
     <script src="dist/bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
> [!NOTE]
> This depends on (and branches from) https://github.com/loopbackio/loopback.io/pull/2049 for a newer version of Jekyll due to some [behaviour differences](https://mademistakes.com/mastering-jekyll/site-url-baseurl/#:~:text=4000%2E-,This,happens%2E) in resolving `site.url`.

This adds support for hosting on a nont-root sub-path (with `--baseurl` flag), such as when deploying on a GitHub fork.

<details>
<summary>Comparison</summary>

**Before:**
<img width="1316" height="665" alt="image" src="https://github.com/user-attachments/assets/91e8df75-53d2-4e81-bddb-890612ba5088" />

**After:**
<img width="1316" height="665" alt="image" src="https://github.com/user-attachments/assets/7ba08b92-26ad-4ac4-babc-31f7e67071de" />

</details>